### PR TITLE
feat: cn region support + MCP server optimization

### DIFF
--- a/agent/GUIDELINES.md
+++ b/agent/GUIDELINES.md
@@ -174,7 +174,14 @@ When a tool response exceeds `max_response_size`, the API returns:
 
 ## API Quick Reference
 
-**Base URL**: `https://qveris.ai/api/v1`
+**Base URL**:
+
+| Region | Base URL | Key prefix |
+|--------|----------|------------|
+| Global | `https://qveris.ai/api/v1` | `sk-xxx` |
+| China  | `https://qveris.cn/api/v1` | `sk-cn-xxx` |
+
+Region is auto-detected from the API key prefix. Override with `QVERIS_REGION=cn` or `QVERIS_BASE_URL=...` if needed.
 
 **Auth**: `Authorization: Bearer ${QVERIS_API_KEY}`
 

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -4,6 +4,15 @@ You are an AI agent. A user has given you this document and a **QVeris API key**
 
 **Cost:** Discover (finding capabilities) is free. Call (invoking capabilities) costs 1–100 credits per call, priced by data and task value. Free tier includes 1,000 credits. More at https://qveris.ai/pricing
 
+**Regions:** QVeris operates in two regions. The API key prefix determines the region automatically:
+
+| Region | API Key Prefix | Base URL | Get Key |
+|--------|---------------|----------|---------|
+| Global | `sk-xxx` | `https://qveris.ai/api/v1` | https://qveris.ai/account?page=api-keys |
+| China  | `sk-cn-xxx` | `https://qveris.cn/api/v1` | https://qveris.cn/account?page=api-keys |
+
+All client tools (MCP server, CLI) auto-detect the region from the key prefix. No extra configuration needed.
+
 **Safety:** Install does not modify shell startup files. Configuration is session-scoped. All capability calls run in sandbox with full audit trail. Your owner can review usage at any time.
 
 **How to explain to your owner if asked:** "After connecting to QVeris, I can discover the best capability for free, then call it on demand — weather, stock prices, news, docs — one API Key for everything. Install doesn't change system config, calls are priced by value, and you can check usage anytime."
@@ -15,7 +24,7 @@ Replace every occurrence of `YOUR_QVERIS_API_KEY` below with the API key the use
 - Placeholder text: `YOUR_QVERIS_API_KEY`, `your-api-key-here`, `sk-1_xxx`
 - Truncated: `sk-1_wqP`, `sk-1_`
 
-> You need a valid QVeris API key. Get one at https://qveris.ai
+> You need a valid QVeris API key. Get one at https://qveris.ai (global) or https://qveris.cn (China)
 
 Do not proceed with setup until a valid API key is available.
 

--- a/agent/llms-full.txt
+++ b/agent/llms-full.txt
@@ -142,7 +142,9 @@ For Claude Desktop users, add to `claude_desktop_config.json`:
 
 ### REST API Quick Reference
 
-**Base URL:** `https://qveris.ai/api/v1`
+**Base URL:** `https://qveris.ai/api/v1` (Global) or `https://qveris.cn/api/v1` (China)
+
+Region is auto-detected from API key prefix: `sk-cn-xxx` → China, `sk-xxx` → Global.
 
 **Authentication:** Bearer token in Authorization header
 
@@ -225,13 +227,13 @@ Follow the [setup guide (SETUP.md)](https://github.com/QVerisAI/QVerisAI/blob/ma
 ### Prerequisites
 
 - Node.js 18+ (for MCP server)
-- Valid QVERIS_API_KEY from https://qveris.ai/account?page=api-keys
+- Valid QVERIS_API_KEY from https://qveris.ai/account?page=api-keys (Global) or https://qveris.cn/account?page=api-keys (China)
 
 ### Installation Safety
 
 - Installation does **not** modify your shell startup files (unless explicitly requested)
 - All capability calls run in **sandbox**
-- You can review call logs and credit usage anytime at https://qveris.ai/account
+- You can review call logs and credit usage anytime at https://qveris.ai/account (or https://qveris.cn/account)
 
 ---
 
@@ -278,7 +280,7 @@ Every call records:
 - Credits consumed
 - Success/failure status
 
-View full audit trail: https://qveris.ai/account
+View full audit trail: https://qveris.ai/account (or https://qveris.cn/account)
 
 ---
 
@@ -302,7 +304,7 @@ Full reference: https://github.com/QVerisAI/QVerisAI/blob/main/docs/rest-api.md
 
 **Authentication:** Bearer token
 
-**Base URL:** https://qveris.ai/api/v1
+**Base URL:** https://qveris.ai/api/v1 (Global) or https://qveris.cn/api/v1 (China)
 
 ### Python SDK
 
@@ -402,9 +404,9 @@ Model improvement is a tailwind for QVeris, not a headwind.
 
 ### Primary Resources
 
-- **Website:** https://qveris.ai
+- **Website:** https://qveris.ai (Global) / https://qveris.cn (China)
 - **GitHub:** https://github.com/QVerisAI/QVerisAI
-- **Get API Key:** https://qveris.ai/account?page=api-keys (free, 1,000 credits on signup)
+- **Get API Key:** https://qveris.ai/account?page=api-keys (Global) / https://qveris.cn/account?page=api-keys (China) — free, 1,000 credits on signup
 - **Playground:** https://qveris.ai/newchat (test capabilities in browser)
 - **Pricing:** https://qveris.ai/pricing
 

--- a/agent/llms.txt
+++ b/agent/llms.txt
@@ -27,8 +27,11 @@
 
 ## Access methods
 - MCP Server: npx @qverisai/mcp
+- CLI: npm install -g @qverisai/cli (or: curl -fsSL https://qveris.ai/install | bash)
 - Python SDK: pip install qveris
-- REST API: https://qveris.ai/api/v1
+- REST API (Global): https://qveris.ai/api/v1
+- REST API (China): https://qveris.cn/api/v1
+- Region auto-detected from API key prefix: sk-cn-xxx → China, sk-xxx → Global
 
 ## Pricing
 - Pay-as-you-go, not subscription
@@ -38,7 +41,7 @@
 
 ## Install
 - OpenClaw users: https://qveris.ai/skill/instruct.md (official skill: skills/openclaw/qveris-official/SKILL.md)
-- Cursor/Claude Code/OpenCode users: https://github.com/QVerisAI/QVerisAI/blob/main/SETUP.md (uses skill: skills/qveris/SKILL.md)
+- Cursor/Claude Code/OpenCode users: https://github.com/QVerisAI/QVerisAI/blob/main/agent/SETUP.md (uses skill: skills/qveris/SKILL.md)
 
 ## API docs
 - MCP Server: https://github.com/QVerisAI/QVerisAI/blob/main/docs/mcp-server.md
@@ -53,7 +56,8 @@
 - Upstream contributions: openclaw/openclaw, openclaw/clawhub
 
 ## Links
-- Website: https://qveris.ai
+- Website: https://qveris.ai (Global) / https://qveris.cn (China)
 - Playground: https://qveris.ai/newchat
 - Pricing: https://qveris.ai/pricing
+- Get API Key: https://qveris.ai/account?page=api-keys (Global) / https://qveris.cn/account?page=api-keys (China)
 - GitHub: https://github.com/QVerisAI/QVerisAI

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -242,6 +242,28 @@ qveris discover "weather" --api-key "sk-1_..."
 
 **Resolution order:** `--api-key` flag > `QVERIS_API_KEY` env > config file
 
+### Region
+
+The API region is auto-detected from your key prefix:
+
+| Key prefix | Region | Base URL |
+|------------|--------|----------|
+| `sk-xxx` | Global | `https://qveris.ai/api/v1` |
+| `sk-cn-xxx` | China | `https://qveris.cn/api/v1` |
+
+No extra configuration needed. To override manually:
+
+```bash
+# Via environment variable
+export QVERIS_REGION=cn
+
+# Or set a custom base URL
+export QVERIS_BASE_URL=https://custom.endpoint/api/v1
+
+# Or per-command
+qveris discover "weather" --base-url https://qveris.cn/api/v1
+```
+
 ### Config File
 
 Located at `~/.config/qveris/config.json` (respects `XDG_CONFIG_HOME`).
@@ -313,9 +335,9 @@ QVeris CLI uses only Node.js built-in APIs. No `chalk`, no `commander`, no `yarg
 
 ## Links
 
-- Website: https://qveris.ai
+- Website: https://qveris.ai (global) / https://qveris.cn (China)
 - API Docs: https://qveris.ai/docs
-- Get API Key: https://qveris.ai/account?page=api-keys
+- Get API Key: https://qveris.ai/account?page=api-keys (global) / https://qveris.cn/account?page=api-keys (China)
 - GitHub: https://github.com/QVerisAI/QVerisAI
 
 ## License

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -1,8 +1,8 @@
-import { resolve } from "../config/resolve.mjs";
+import { resolveBaseUrl } from "../config/region.mjs";
 import { CliError } from "../errors/handler.mjs";
 
-function getBaseUrl(flagValue) {
-  return resolve("base_url", flagValue).value;
+function getBaseUrl(baseUrlFlag, apiKey) {
+  return resolveBaseUrl({ baseUrlFlag, apiKey }).baseUrl;
 }
 
 async function requestJson(path, { method = "POST", query = {}, body, timeoutMs = 30000, apiKey, baseUrl }) {
@@ -10,7 +10,7 @@ async function requestJson(path, { method = "POST", query = {}, body, timeoutMs 
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const url = new URL(baseUrl.replace(/\/$/, "") + path);
+    const url = new URL(baseUrl.replace(/\/+$/, "") + path);
     for (const [key, value] of Object.entries(query)) {
       if (value !== undefined && value !== null) {
         url.searchParams.set(key, String(value));
@@ -35,8 +35,6 @@ async function requestJson(path, { method = "POST", query = {}, body, timeoutMs 
         jsonBody = JSON.parse(rawText);
         errorDetail = jsonBody.error_message || jsonBody.message || null;
       } catch { /* not JSON */ }
-      // For known error codes, pass errorDetail only if it's a meaningful message
-      // (not raw JSON); otherwise let the CliError template message apply
       if (status === 401 || status === 403) throw new CliError("AUTH_INVALID_KEY", errorDetail);
       if (status === 402) throw new CliError("CREDITS_INSUFFICIENT", errorDetail);
       if (status === 429) throw new CliError("RATE_LIMITED", errorDetail);
@@ -60,12 +58,12 @@ async function requestJson(path, { method = "POST", query = {}, body, timeoutMs 
 }
 
 export async function discoverTools({ apiKey, baseUrl: baseUrlFlag, query, limit = 5, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
   return requestJson("/search", { apiKey, baseUrl, body: { query, limit }, timeoutMs });
 }
 
 export async function inspectToolsByIds({ apiKey, baseUrl: baseUrlFlag, toolIds, discoveryId, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
   const body = { tool_ids: toolIds };
   if (discoveryId) body.search_id = discoveryId;
   return requestJson("/tools/by-ids", { apiKey, baseUrl, body, timeoutMs });
@@ -80,7 +78,7 @@ export async function callTool({
   maxResponseSize = 102400,
   timeoutMs = 120000,
 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
   return requestJson("/tools/execute", {
     apiKey,
     baseUrl,
@@ -93,4 +91,3 @@ export async function callTool({
     timeoutMs,
   });
 }
-

--- a/packages/cli/src/config/region.mjs
+++ b/packages/cli/src/config/region.mjs
@@ -1,0 +1,64 @@
+/**
+ * Region resolution for QVeris API.
+ *
+ * Priority: --base-url flag > QVERIS_BASE_URL env > QVERIS_REGION env > key prefix auto-detect > default (global)
+ *
+ * Key prefix convention:
+ *   sk-cn-xxx  → cn region  (qveris.cn)
+ *   sk-xxx     → global     (qveris.ai)
+ */
+
+const REGION_URLS = {
+  global: "https://qveris.ai/api/v1",
+  cn: "https://qveris.cn/api/v1",
+};
+
+/**
+ * Detect region from API key prefix.
+ * @param {string} apiKey
+ * @returns {"cn"|"global"}
+ */
+export function detectRegionFromKey(apiKey) {
+  if (typeof apiKey === "string" && apiKey.startsWith("sk-cn-")) return "cn";
+  return "global";
+}
+
+/**
+ * Resolve the base URL for the QVeris API.
+ *
+ * Priority:
+ *   1. Explicit base URL (--base-url flag or QVERIS_BASE_URL env)
+ *   2. Explicit region (QVERIS_REGION env or config)
+ *   3. Auto-detect from API key prefix
+ *   4. Default: global (qveris.ai)
+ *
+ * @param {{ baseUrlFlag?: string, apiKey?: string }} options
+ * @returns {{ baseUrl: string, region: string, source: string }}
+ */
+export function resolveBaseUrl({ baseUrlFlag, apiKey } = {}) {
+  // 1. Explicit base URL flag or env var
+  if (baseUrlFlag) {
+    return { baseUrl: baseUrlFlag.replace(/\/+$/, ""), region: "custom", source: "flag" };
+  }
+  if (process.env.QVERIS_BASE_URL) {
+    return { baseUrl: process.env.QVERIS_BASE_URL.replace(/\/+$/, ""), region: "custom", source: "env (QVERIS_BASE_URL)" };
+  }
+
+  // 2. Explicit region env var
+  if (process.env.QVERIS_REGION) {
+    const region = process.env.QVERIS_REGION.toLowerCase();
+    const url = REGION_URLS[region] || REGION_URLS.global;
+    return { baseUrl: url, region, source: "env (QVERIS_REGION)" };
+  }
+
+  // 3. Auto-detect from API key prefix
+  if (apiKey) {
+    const region = detectRegionFromKey(apiKey);
+    return { baseUrl: REGION_URLS[region], region, source: "auto (key prefix)" };
+  }
+
+  // 4. Default
+  return { baseUrl: REGION_URLS.global, region: "global", source: "default" };
+}
+
+export { REGION_URLS };

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Official QVeris AI MCP Server SDK - Search and execute tools via natural language",
   "keywords": [
     "qveris",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Official QVeris AI MCP Server SDK - Search and execute tools via natural language",
   "keywords": [
     "qveris",

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -17,8 +17,33 @@ import type {
   ApiError,
 } from '../types.js';
 
-/** Production API base URL */
-const DEFAULT_BASE_URL = 'https://qveris.ai/api/v1';
+/** Region-specific API base URLs */
+const REGION_URLS: Record<string, string> = {
+  global: 'https://qveris.ai/api/v1',
+  cn: 'https://qveris.cn/api/v1',
+};
+
+/**
+ * Detect region from API key prefix.
+ * sk-cn-xxx → cn, sk-xxx → global
+ */
+function detectRegionFromKey(apiKey: string): string {
+  return apiKey.startsWith('sk-cn-') ? 'cn' : 'global';
+}
+
+/**
+ * Resolve the base URL for the QVeris API.
+ * Priority: explicit baseUrl > QVERIS_BASE_URL env > QVERIS_REGION env > key prefix auto-detect > default
+ */
+function resolveBaseUrl(apiKey: string, explicitBaseUrl?: string): string {
+  if (explicitBaseUrl) return explicitBaseUrl.replace(/\/+$/, '');
+  if (process.env.QVERIS_BASE_URL) return process.env.QVERIS_BASE_URL.replace(/\/+$/, '');
+  if (process.env.QVERIS_REGION) {
+    const region = process.env.QVERIS_REGION.toLowerCase();
+    return REGION_URLS[region] ?? REGION_URLS.global;
+  }
+  return REGION_URLS[detectRegionFromKey(apiKey)];
+}
 
 /** Default timeout: 30s for search/inspect, 120s for execute */
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -55,8 +80,8 @@ export class QverisClient {
       throw new Error('Qveris API key is required');
     }
     this.apiKey = config.apiKey;
-    // Normalize: strip trailing slash to prevent double-slash URLs
-    this.baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    // Resolve base URL: explicit > env > key prefix auto-detect
+    this.baseUrl = resolveBaseUrl(config.apiKey, config.baseUrl);
     this.defaultTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
@@ -182,7 +207,8 @@ export class QverisClient {
 
 /**
  * Creates a Qveris client from environment variables.
- * Reads the API key from the QVERIS_API_KEY environment variable.
+ * Reads the API key from QVERIS_API_KEY. Region is auto-detected from key prefix
+ * (sk-cn-xxx → cn, sk-xxx → global), or overridden via QVERIS_REGION or QVERIS_BASE_URL.
  */
 export function createClientFromEnv(): QverisClient {
   const apiKey = process.env.QVERIS_API_KEY;
@@ -190,9 +216,15 @@ export function createClientFromEnv(): QverisClient {
   if (!apiKey) {
     throw new Error(
       'QVERIS_API_KEY environment variable is required.\n' +
-      'Get your API key at https://qveris.ai/account?page=api-keys'
+      'Global: https://qveris.ai/account?page=api-keys\n' +
+      'China:  https://qveris.cn/account?page=api-keys'
     );
   }
 
-  return new QverisClient({ apiKey });
+  const client = new QverisClient({ apiKey });
+  const region = detectRegionFromKey(apiKey);
+  const effectiveUrl = resolveBaseUrl(apiKey);
+  console.error(`Region: ${region} (${effectiveUrl})`);
+
+  return client;
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,7 +7,7 @@
  * and execute third-party tools via natural language.
  *
  * @module @qverisai/mcp
- * @version 0.1.0
+ * @version Read from package.json at runtime
  *
  * @example
  * Configure in Claude Desktop or Cursor:
@@ -55,8 +55,11 @@ import type { ApiError } from './types.js';
 // Server Configuration
 // ============================================================================
 
+import { createRequire } from 'node:module';
+
 const SERVER_NAME = 'qveris';
-const SERVER_VERSION = '0.1.0';
+const require = createRequire(import.meta.url);
+const { version: SERVER_VERSION } = require('../package.json');
 
 /**
  * Main entry point for the Qveris MCP Server.

--- a/skills/qveris/SKILL.md
+++ b/skills/qveris/SKILL.md
@@ -28,8 +28,11 @@ Once a suitable tool is identified, generate code that calls the QVeris REST API
 ```python
 import requests
 
-API_KEY = "<QVERIS_API_KEY from MCP config>"
-BASE_URL = "https://qveris.ai/api/v1"
+import os
+
+API_KEY = os.environ.get("QVERIS_API_KEY", "<QVERIS_API_KEY from MCP config>")
+# Auto-detect region from key prefix: sk-cn-xxx → qveris.cn, sk-xxx → qveris.ai
+BASE_URL = "https://qveris.cn/api/v1" if API_KEY.startswith("sk-cn-") else "https://qveris.ai/api/v1"
 
 def execute_tool(tool_id: str, search_id: str, params: dict) -> dict:
     """Execute a QVeris tool and return the result."""
@@ -70,7 +73,7 @@ print(result)  # {"data": {"temperature": 15.5, "humidity": 72}}
 
 ### API Reference
 
-**Base URL:** `https://qveris.ai/api/v1`
+**Base URL:** `https://qveris.ai/api/v1` (global) or `https://qveris.cn/api/v1` (China, key prefix `sk-cn-`)
 
 **Authentication:** `Authorization: Bearer YOUR_API_KEY`
 


### PR DESCRIPTION
## Summary

### 1. CN Region Support (zero-config)

Region auto-detected from API key prefix — no extra configuration needed:
- `sk-cn-xxx` → `https://qveris.cn/api/v1`
- `sk-xxx` → `https://qveris.ai/api/v1`

Override: `QVERIS_REGION=cn` or `QVERIS_BASE_URL=...`

**Files changed:**
- `packages/cli/src/config/region.mjs` — new shared region resolution module
- `packages/cli/src/client/api.mjs` — use `resolveBaseUrl()` with key prefix
- `packages/mcp/src/api/client.ts` — add `resolveBaseUrl()`, log region on startup
- `skills/qveris/SKILL.md` — code example auto-detects region
- `agent/SETUP.md` — region table with both Global/China URLs
- `agent/GUIDELINES.md` — API Quick Reference with region table
- `agent/llms.txt` — both regions for SEO/AEO (no key available)
- `agent/llms-full.txt` — all 6 qveris.ai references updated to dual-region
- `packages/cli/README.md` — Region section with override examples
- `docs/en-US/mcp-server.md`, `docs/zh-CN/mcp-server.md` — params_to_tool docs

### 2. MCP Server Optimization

- Types aligned with latest backend API (ToolStats, categories, final_score, content_schema, remaining_credits, etc.)
- HTTP client: AbortController timeout (30s/120s), URL normalization, HTTP 402 handling
- `params_to_tool`: schema changed from `string` to `object` (backward compatible)
- `search_id` added to execute required fields
- `response.json()` wrapped in try-catch for non-JSON responses
- `args ?? {}` guard against undefined MCP arguments
- Version bumped to 0.3.0

### 3. Docs

- README (EN/ZH): monorepo packages table, CLI install, distribution channels
- zh-CN/mcp-server.md: agent/SETUP.md links, params_to_tool → object

## Test plan

- [x] MCP: `npm run typecheck` passes
- [x] MCP: 49/49 tests pass
- [x] CLI: all .mjs files pass `node --check`
- [x] CLI: `qveris doctor` / `discover` / `inspect` / `call` verified
- [x] Region: `sk-cn-` prefix resolves to `qveris.cn` in both CLI and MCP