### PR TITLE
feat(cli): welcome and login banners with brand gradient

### DIFF
--- a/packages/cli/src/commands/interactive.mjs
+++ b/packages/cli/src/commands/interactive.mjs
@@ -5,7 +5,9 @@ import { resolveParams } from "../utils/params.mjs";
 import { formatDiscoverResult, formatInspectResult, formatCallResult } from "../output/formatter.mjs";
 import { generateSnippet } from "../output/codegen.mjs";
 import { writeSession } from "../session/session.mjs";
+import { VERSION } from "../config/defaults.mjs";
 import { bold, dim, cyan } from "../output/colors.mjs";
+import { printWelcomeBanner } from "../output/banner.mjs";
 import { handleError } from "../errors/handler.mjs";
 import { createSpinner } from "../output/spinner.mjs";
 
@@ -22,7 +24,11 @@ export async function runInteractive(flags) {
     lastCallContext: null,
   };
 
-  console.log(`\n  ${bold("QVeris Interactive Mode")}`);
+  if (!flags.json) {
+    printWelcomeBanner({ version: VERSION, noColor: flags.noColor, compact: true });
+  }
+
+  console.log(`  ${bold("QVeris Interactive Mode")}`);
   console.log(`  ${dim("Type 'help' for commands, 'exit' to quit.")}\n`);
 
   const rl = createInterface({

--- a/packages/cli/src/commands/login.mjs
+++ b/packages/cli/src/commands/login.mjs
@@ -4,7 +4,9 @@ import { platform } from "node:os";
 import { resolve } from "../config/resolve.mjs";
 import { setConfigValue, deleteConfigValue } from "../config/store.mjs";
 import { discoverTools } from "../client/api.mjs";
+import { VERSION } from "../config/defaults.mjs";
 import { bold, green, red, dim, cyan } from "../output/colors.mjs";
+import { printLoginBanner } from "../output/banner.mjs";
 
 const ACCOUNT_URL = "https://qveris.ai/account?page=api-keys";
 
@@ -91,7 +93,11 @@ export async function runLogin(flags) {
     return;
   }
 
-  console.log(`\n  Get your API key at: ${cyan(ACCOUNT_URL)}\n`);
+  if (!flags.json) {
+    printLoginBanner({ version: VERSION, noColor: flags.noColor });
+  }
+
+  console.log(`  Get your API key at: ${cyan(ACCOUNT_URL)}\n`);
 
   if (!flags.noBrowser) {
     openBrowser(ACCOUNT_URL);

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -2,6 +2,7 @@ import { normalizeLegacyArgs } from "./compat/aliases.mjs";
 import { handleError } from "./errors/handler.mjs";
 import { VERSION } from "./config/defaults.mjs";
 import { bold, dim, cyan } from "./output/colors.mjs";
+import { printWelcomeBanner } from "./output/banner.mjs";
 
 export async function main(argv) {
   const rawArgs = argv.slice(2);
@@ -12,6 +13,10 @@ export async function main(argv) {
   }
 
   const flags = extractGlobalFlags(args);
+  if (flags.noColor) {
+    process.env.NO_COLOR = "1";
+  }
+
   const positional = flags._positional;
   const command = positional[0];
   const rest = positional.slice(1);
@@ -22,7 +27,7 @@ export async function main(argv) {
   }
 
   if (!command || flags.help) {
-    printUsage();
+    printUsage(flags);
     return;
   }
 
@@ -202,9 +207,13 @@ function extractGlobalFlags(args) {
   return flags;
 }
 
-function printUsage() {
+function printUsage(flags = {}) {
+  if (!flags.json) {
+    printWelcomeBanner({ version: VERSION, noColor: flags.noColor, compact: false });
+  }
+
   console.log(`
-  ${bold("QVeris CLI")} ${dim(`v${VERSION}`)} -- discover, inspect, and call 10,000+ capabilities
+  ${bold("QVeris CLI")} — ${dim("discover, inspect, and call 10,000+ capabilities")}
 
   ${bold("Usage:")}
     qveris <command> [args] [flags]

--- a/packages/cli/src/output/banner.mjs
+++ b/packages/cli/src/output/banner.mjs
@@ -169,7 +169,7 @@ export function printWelcomeBanner(opts) {
   console.log(nl + centered.join("\n"));
 
   const tag = "✦ Discover · Inspect · Call · 10,000+ capabilities · 智能编排 ✦";
-  const meta = `${dim("v" + version)} ${dim("·")} ${dim(shortenPath(processCwd()))}`;
+  const meta = dim(`v${version} · ${shortenPath(processCwd())}`);
   const tagLine = centerLine(dim(cyan(tag)), termCols);
   const metaLine = centerLine(meta, termCols);
 

--- a/packages/cli/src/output/banner.mjs
+++ b/packages/cli/src/output/banner.mjs
@@ -1,0 +1,216 @@
+/**
+ * Welcome / login banners: gradient on solid block letters (brand cyan → indigo).
+ * Figlet font "Banner3" (filled #), mapped to █ for stronger contrast.
+ */
+
+import { homedir } from "node:os";
+import { cwd as processCwd } from "node:process";
+import { dim, cyan, bold, isColorEnabled } from "./colors.mjs";
+
+/** @type {readonly [number, number, number][]} brand stops: highlight → mid → shadow */
+const BRAND_STOPS = [
+  [0, 242, 255], // #00F2FF
+  [0, 153, 255], // #0099FF
+  [26, 0, 255], // #1A00FF
+];
+
+const RESET = "\x1b[0m";
+
+/** Figlet -f Banner3 QVERIS (53 cols × 7 rows). # → █ at render. */
+const ASCII_QVERIS_HASH = [
+  " #######  ##     ## ######## ########  ####  ######  ",
+  "##     ## ##     ## ##       ##     ##  ##  ##    ## ",
+  "##     ## ##     ## ##       ##     ##  ##  ##       ",
+  "##     ## ##     ## ######   ########   ##   ######  ",
+  "##  ## ##  ##   ##  ##       ##   ##    ##        ## ",
+  "##    ##    ## ##   ##       ##    ##   ##  ##    ## ",
+  " ##### ##    ###    ######## ##     ## ####  ######  ",
+].join("\n");
+
+function solidBlockLines() {
+  return ASCII_QVERIS_HASH.split("\n").map((line) => line.replace(/#/g, "█"));
+}
+
+function colorDepth() {
+  try {
+    return typeof process.stdout.getColorDepth === "function"
+      ? process.stdout.getColorDepth()
+      : 8;
+  } catch {
+    return 8;
+  }
+}
+
+function lerp(a, b, t) {
+  return Math.round(a + (b - a) * t);
+}
+
+/** RGB along multi-stop gradient, t in [0,1]. */
+function rgbAt(t) {
+  const n = BRAND_STOPS.length - 1;
+  const x = Math.min(1, Math.max(0, t)) * n;
+  const i = Math.min(Math.floor(x), n - 1);
+  const f = x - i;
+  const [r1, g1, b1] = BRAND_STOPS[i];
+  const [r2, g2, b2] = BRAND_STOPS[i + 1];
+  return [lerp(r1, r2, f), lerp(g1, g2, f), lerp(b1, b2, f)];
+}
+
+function truecolorFg(r, g, b) {
+  return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+/**
+ * Map column index to gradient color (horizontal sweep across the banner).
+ * Spaces stay uncolored (reset) for cleaner edges.
+ */
+function paintLineTruecolor(line, maxCols) {
+  if (!line.length) return "";
+  const denom = Math.max(1, maxCols - 1);
+  let out = "";
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === " ") {
+      out += ch;
+      continue;
+    }
+    const t = i / denom;
+    const [r, g, b] = rgbAt(t);
+    out += truecolorFg(r, g, b) + ch + RESET;
+  }
+  return out;
+}
+
+function paintLineFallback(line, maxCols) {
+  let out = "";
+  const denom = Math.max(1, maxCols - 1);
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === " ") {
+      out += ch;
+      continue;
+    }
+    const t = i / denom;
+    const band = Math.min(2, Math.floor(t * 3));
+    if (band === 0) out += cyan(ch);
+    else if (band === 1) out += bold(cyan(ch));
+    else out += dim(cyan(ch));
+  }
+  return out;
+}
+
+export function bannerColorAllowed(noColorFlag) {
+  if (noColorFlag) return false;
+  return isColorEnabled();
+}
+
+function shortenPath(p) {
+  const home = homedir();
+  if (p === home) return "~";
+  if (p.startsWith(home + "/")) return "~" + p.slice(home.length);
+  return p;
+}
+
+/** Strip SGR ANSI sequences (truecolor / 16-color). */
+function stripAnsi(s) {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const RE_HAN = /\p{Script=Han}/u;
+const RE_HANGUL = /\p{Script=Hangul}/u;
+
+/** Terminal display width: CJK/Hangul/fullwidth = 2 cols (matches typical monospace). */
+function displayWidth(str) {
+  let w = 0;
+  for (const ch of str) {
+    const cp = ch.codePointAt(0);
+    if (RE_HAN.test(ch) || RE_HANGUL.test(ch)) w += 2;
+    else if (cp >= 0xff01 && cp <= 0xff60) w += 2; // fullwidth forms
+    else w += 1;
+  }
+  return w;
+}
+
+function centerBlock(lines, termCols) {
+  const widths = lines.map((l) => displayWidth(stripAnsi(l)));
+  const maxW = Math.max(...widths, 1);
+  const pad = termCols >= maxW + 4 ? Math.max(0, Math.floor((termCols - maxW) / 2)) : 2;
+  const prefix = " ".repeat(pad);
+  return lines.map((l) => prefix + l);
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.version
+ * @param {boolean} [opts.noColor]
+ * @param {boolean} [opts.compact] — fewer blank lines (e.g. interactive)
+ */
+export function printWelcomeBanner(opts) {
+  const { version, noColor = false, compact = false } = opts;
+  if (!bannerColorAllowed(noColor)) {
+    printPlainBanner({ version, compact });
+    return;
+  }
+
+  const rawLines = solidBlockLines();
+  const maxW = Math.max(...rawLines.map((l) => l.length));
+  const termCols = process.stdout.columns || 80;
+  const useTc = colorDepth() >= 24;
+
+  const painted = rawLines.map((line) => {
+    const padded = line.padEnd(maxW);
+    return useTc ? paintLineTruecolor(padded, maxW) : paintLineFallback(padded, maxW);
+  });
+  const centered = centerBlock(painted, termCols);
+
+  const nl = compact ? "\n" : "\n\n";
+  console.log(nl + centered.join("\n"));
+
+  const tag = "✦ Discover · Inspect · Call · 10,000+ capabilities · 智能编排 ✦";
+  const meta = `${dim("v" + version)} ${dim("·")} ${dim(shortenPath(processCwd()))}`;
+  const tagLine = centerLine(dim(cyan(tag)), termCols);
+  const metaLine = centerLine(meta, termCols);
+
+  console.log("\n" + tagLine + "\n" + metaLine + (compact ? "\n" : "\n\n"));
+}
+
+function centerLine(text, termCols) {
+  const len = displayWidth(stripAnsi(text));
+  const pad = termCols >= len + 4 ? Math.max(0, Math.floor((termCols - len) / 2)) : 2;
+  return " ".repeat(pad) + text;
+}
+
+function printPlainBanner({ version, compact }) {
+  const rawLines = solidBlockLines();
+  const termCols = process.stdout.columns || 80;
+  const centered = centerBlock(rawLines, termCols);
+  const nl = compact ? "\n" : "\n\n";
+  console.log(nl + centered.join("\n"));
+  const tag = "✦ Discover · Inspect · Call · 10,000+ capabilities · 智能编排 ✦";
+  const meta = `v${version} · ${shortenPath(processCwd())}`;
+  const tagLine = centerLine(dim(tag), termCols);
+  const metaLine = centerLine(dim(meta), termCols);
+  console.log("\n" + tagLine + "\n" + metaLine + (compact ? "\n" : "\n\n"));
+}
+
+/**
+ * Login screen: banner + framed hint (cyan border).
+ */
+export function printLoginBanner(opts) {
+  const { version, noColor = false } = opts;
+  printWelcomeBanner({ version, noColor, compact: true });
+
+  if (!bannerColorAllowed(noColor)) {
+    console.log(dim("  ─ Secure login · paste your API key below"));
+    return;
+  }
+
+  const termCols = process.stdout.columns || 80;
+  const inner = " Secure login · API key ";
+  const maxInner = Math.min(inner.length + 4, termCols - 4);
+  const bar = "─".repeat(Math.max(8, maxInner));
+  const top = centerLine(cyan("╭" + bar + "╮"), termCols);
+  const mid = centerLine(cyan("│") + dim(inner) + cyan("│"), termCols);
+  const bot = centerLine(cyan("╰" + bar + "╯"), termCols);
+  console.log(top + "\n" + mid + "\n" + bot + "\n");
+}

--- a/packages/cli/src/output/banner.mjs
+++ b/packages/cli/src/output/banner.mjs
@@ -76,7 +76,9 @@ function paintLineTruecolor(line, maxCols) {
     }
     const t = i / denom;
     const [r, g, b] = rgbAt(t);
-    out += truecolorFg(r, g, b) + ch + RESET;
+    out += truecolorFg(r, g, b) + ch;
+  }
+  return out + RESET;
   }
   return out;
 }

--- a/packages/cli/src/output/banner.mjs
+++ b/packages/cli/src/output/banner.mjs
@@ -5,7 +5,7 @@
 
 import { homedir } from "node:os";
 import { cwd as processCwd } from "node:process";
-import { dim, cyan, bold, isColorEnabled } from "./colors.mjs";
+import { dim, cyan, isColorEnabled } from "./colors.mjs";
 
 /** @type {readonly [number, number, number][]} brand stops: highlight → mid → shadow */
 const BRAND_STOPS = [
@@ -62,41 +62,64 @@ function truecolorFg(r, g, b) {
 
 /**
  * Map column index to gradient color (horizontal sweep across the banner).
- * Spaces stay uncolored (reset) for cleaner edges.
+ * Spaces stay uncolored. Consecutive non-space chars with identical RGB share one SGR span.
  */
 function paintLineTruecolor(line, maxCols) {
   if (!line.length) return "";
   const denom = Math.max(1, maxCols - 1);
   let out = "";
-  for (let i = 0; i < line.length; i++) {
+  let i = 0;
+  while (i < line.length) {
     const ch = line[i];
     if (ch === " ") {
       out += ch;
+      i++;
       continue;
     }
-    const t = i / denom;
-    const [r, g, b] = rgbAt(t);
-    out += truecolorFg(r, g, b) + ch;
-  }
-  return out + RESET;
+    const t0 = i / denom;
+    const [r0, g0, b0] = rgbAt(t0);
+    let j = i + 1;
+    while (j < line.length) {
+      const chj = line[j];
+      if (chj === " ") break;
+      const t = j / denom;
+      const [r, g, b] = rgbAt(t);
+      if (r !== r0 || g !== g0 || b !== b0) break;
+      j++;
+    }
+    out += truecolorFg(r0, g0, b0) + line.slice(i, j) + RESET;
+    i = j;
   }
   return out;
 }
 
+/** 16-color fallback: batched SGR per band (cyan / bold cyan / dim cyan). */
 function paintLineFallback(line, maxCols) {
-  let out = "";
+  if (!isColorEnabled()) return line;
   const denom = Math.max(1, maxCols - 1);
-  for (let i = 0; i < line.length; i++) {
+  let out = "";
+  let i = 0;
+  while (i < line.length) {
     const ch = line[i];
     if (ch === " ") {
       out += ch;
+      i++;
       continue;
     }
-    const t = i / denom;
-    const band = Math.min(2, Math.floor(t * 3));
-    if (band === 0) out += cyan(ch);
-    else if (band === 1) out += bold(cyan(ch));
-    else out += dim(cyan(ch));
+    const band0 = Math.min(2, Math.floor((i / denom) * 3));
+    let j = i + 1;
+    while (j < line.length) {
+      const chj = line[j];
+      if (chj === " ") break;
+      const band = Math.min(2, Math.floor((j / denom) * 3));
+      if (band !== band0) break;
+      j++;
+    }
+    const chunk = line.slice(i, j);
+    if (band0 === 0) out += `\x1b[36m${chunk}\x1b[0m`;
+    else if (band0 === 1) out += `\x1b[1;36m${chunk}\x1b[0m`;
+    else out += `\x1b[2;36m${chunk}\x1b[0m`;
+    i = j;
   }
   return out;
 }
@@ -168,7 +191,7 @@ export function printWelcomeBanner(opts) {
   const nl = compact ? "\n" : "\n\n";
   console.log(nl + centered.join("\n"));
 
-  const tag = "✦ Discover · Inspect · Call · 10,000+ capabilities · 智能编排 ✦";
+  const tag = "✦ Discover · Inspect · Call · 10,000+ capabilities · intelligent orchestration ✦";
   const meta = dim(`v${version} · ${shortenPath(processCwd())}`);
   const tagLine = centerLine(dim(cyan(tag)), termCols);
   const metaLine = centerLine(meta, termCols);
@@ -188,7 +211,7 @@ function printPlainBanner({ version, compact }) {
   const centered = centerBlock(rawLines, termCols);
   const nl = compact ? "\n" : "\n\n";
   console.log(nl + centered.join("\n"));
-  const tag = "✦ Discover · Inspect · Call · 10,000+ capabilities · 智能编排 ✦";
+  const tag = "✦ Discover · Inspect · Call · 10,000+ capabilities · intelligent orchestration ✦";
   const meta = `v${version} · ${shortenPath(processCwd())}`;
   const tagLine = centerLine(dim(tag), termCols);
   const metaLine = centerLine(dim(meta), termCols);

--- a/packages/cli/src/output/colors.mjs
+++ b/packages/cli/src/output/colors.mjs
@@ -1,9 +1,9 @@
-const enabled =
+export const isColorEnabled = () =>
   !process.env.NO_COLOR &&
   (process.env.FORCE_COLOR === "1" || (process.stdout.isTTY && process.stderr.isTTY));
 
-const code = (open, close) =>
-  enabled ? (s) => `\x1b[${open}m${s}\x1b[${close}m` : (s) => s;
+const code = (open, close) => (s) =>
+  isColorEnabled() ? `\x1b[${open}m${s}\x1b[${close}m` : s;
 
 export const bold = code("1", "22");
 export const dim = code("2", "22");
@@ -12,5 +12,3 @@ export const green = code("32", "39");
 export const yellow = code("33", "39");
 export const cyan = code("36", "39");
 export const gray = code("90", "39");
-
-export const isColorEnabled = () => enabled;

--- a/packages/cli/src/output/colors.mjs
+++ b/packages/cli/src/output/colors.mjs
@@ -1,6 +1,10 @@
-export const isColorEnabled = () =>
-  !process.env.NO_COLOR &&
-  (process.env.FORCE_COLOR === "1" || (process.stdout.isTTY && process.stderr.isTTY));
+let memoizedEnabled;
+export const isColorEnabled = () => {
+  if (memoizedEnabled !== undefined) return memoizedEnabled;
+  memoizedEnabled = !process.env.NO_COLOR &&
+    (process.env.FORCE_COLOR === "1" || (process.stdout.isTTY && process.stderr.isTTY));
+  return memoizedEnabled;
+};
 
 const code = (open, close) => (s) =>
   isColorEnabled() ? `\x1b[${open}m${s}\x1b[${close}m` : s;


### PR DESCRIPTION
## Summary
Adds a colorful QVeris CLI welcome and login experience: solid block **QVERIS** banner (Figlet Banner3, `█` + horizontal cyan→indigo gradient), tagline and version/cwd lines centered under the logo.

## Behavior
- **Help / no subcommand**: banner + existing usage (skipped with `--json`).
- **login**: banner + secure-login frame; skipped for `--token` / `--json`.
- **interactive**: compact banner; skipped with `--json`.
- **`--no-color` / `NO_COLOR`**: plain text banner.

## Implementation notes
- `colors.mjs`: lazy `isColorEnabled()`; `main` sets `NO_COLOR` when `--no-color` so child modules match.
- Centering uses `stripAnsi` + `displayWidth` (Han/Hangul/fullwidth) so colored lines and CJK taglines align correctly in the terminal.

## How to test
```bash
cd packages/cli && node bin/qveris.mjs
node bin/qveris.mjs login
```
Run in a real TTY for correct column width and colors.

Made with [Cursor](https://cursor.com)