### PR TITLE
feat: getting-started docs + CLI multi-region fixes

### DIFF
--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -16,7 +16,32 @@ QVeris 在 Agent 循环中表现出色（发现 → 检查 → 调用 → 将结
 
 ## 快速开始
 
-QVeris 提供三种使用方式。
+QVeris 提供多种使用方式，选择最适合你的即可。
+
+### 使用 QVeris CLI
+
+在终端中直接发现、检查和调用能力。
+
+**安装**
+
+```bash
+curl -fsSL https://qveris.cn/cli/install | bash
+```
+
+也可通过 npm 安装（`npm install -g @qverisai/cli`）或免安装运行（`npx @qverisai/cli`）。
+
+**快速上手**
+
+```bash
+qveris login                              # 登录认证
+qveris discover "weather forecast"        # 发现能力
+qveris inspect 1                          # 查看详情
+qveris call 1 --params '{"wfo":"LWX","x":90,"y":90}'  # 调用执行
+```
+
+CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen curl|python|js`）和 Shell 自动补全。完整参考见 [CLI 文档](https://github.com/QVerisAI/QVerisAI/blob/main/packages/cli/README.md)。
+
+---
 
 ### 通过 MCP 使用 QVeris
 
@@ -288,6 +313,14 @@ if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
 const data = await resp.json();
 console.log(data);
 ```
+
+---
+
+### 在 AI Agent 中安装 QVeris
+
+如果你正在配置 AI 编程助手（Claude Code、Cursor、OpenCode、Trae 等），可以将 [Agent 安装指南](https://github.com/QVerisAI/QVerisAI/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给 Agent。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
+
+支持的环境：Claude Code、OpenCode、Cursor、Trae、VS Code、OpenClaw。
 
 ---
 

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -16,7 +16,32 @@ QVeris works well in agent loops (Discover → Inspect → Call → feed results
 
 ## Quick start
 
-There are three ways to use QVeris.
+There are several ways to use QVeris. Pick the one that fits your workflow.
+
+### Use the QVeris CLI
+
+Discover, inspect, and call capabilities directly from your terminal.
+
+**Install**
+
+```bash
+curl -fsSL https://qveris.ai/cli/install | bash
+```
+
+Also available via npm (`npm install -g @qverisai/cli`) or without installing (`npx @qverisai/cli`).
+
+**Quick start**
+
+```bash
+qveris login                              # Authenticate
+qveris discover "weather forecast"        # Find capabilities
+qveris inspect 1                          # View details
+qveris call 1 --params '{"wfo":"LWX","x":90,"y":90}'  # Execute
+```
+
+The CLI also supports interactive mode (`qveris interactive`), code generation (`--codegen curl|python|js`), and shell completions. For the full reference, see [CLI documentation](cli.md).
+
+---
 
 ### Use QVeris MCP anywhere MCP is supported
 
@@ -288,6 +313,14 @@ if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
 const data = await resp.json();
 console.log(data);
 ```
+
+---
+
+### Set up QVeris in your AI Agent
+
+If you are configuring an AI coding agent (Claude Code, Cursor, OpenCode, Trae, etc.), you can give the [Agent Setup Guide](https://github.com/QVerisAI/QVerisAI/blob/main/agent/SETUP.md) to your agent along with your API key. It will auto-detect the environment and configure both the MCP server and skill definition automatically.
+
+Supported environments: Claude Code, OpenCode, Cursor, Trae, VS Code, and OpenClaw.
 
 ---
 

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -16,7 +16,32 @@ QVeris 在 Agent 循环中表现出色（发现 → 检查 → 调用 → 将结
 
 ## 快速开始
 
-QVeris 提供三种使用方式。
+QVeris 提供多种使用方式，选择最适合你的即可。
+
+### 使用 QVeris CLI
+
+在终端中直接发现、检查和调用能力。
+
+**安装**
+
+```bash
+curl -fsSL https://qveris.ai/cli/install | bash
+```
+
+也可通过 npm 安装（`npm install -g @qverisai/cli`）或免安装运行（`npx @qverisai/cli`）。
+
+**快速上手**
+
+```bash
+qveris login                              # 登录认证
+qveris discover "weather forecast"        # 发现能力
+qveris inspect 1                          # 查看详情
+qveris call 1 --params '{"wfo":"LWX","x":90,"y":90}'  # 调用执行
+```
+
+CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen curl|python|js`）和 Shell 自动补全。完整参考见 [CLI 文档](cli.md)。
+
+---
 
 ### 通过 MCP 使用 QVeris
 
@@ -288,6 +313,14 @@ if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
 const data = await resp.json();
 console.log(data);
 ```
+
+---
+
+### 在 AI Agent 中安装 QVeris
+
+如果你正在配置 AI 编程助手（Claude Code、Cursor、OpenCode、Trae 等），可以将 [Agent 安装指南](https://github.com/QVerisAI/QVerisAI/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给 Agent。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
+
+支持的环境：Claude Code、OpenCode、Cursor、Trae、VS Code、OpenClaw。
 
 ---
 

--- a/packages/cli/src/commands/config.mjs
+++ b/packages/cli/src/commands/config.mjs
@@ -1,5 +1,6 @@
 import { getConfigPath, getConfigValue, setConfigValue, writeConfig } from "../config/store.mjs";
-import { resolveAll } from "../config/resolve.mjs";
+import { resolve, resolveAll } from "../config/resolve.mjs";
+import { resolveBaseUrl } from "../config/region.mjs";
 import { bold, dim, cyan } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
 
@@ -64,11 +65,17 @@ function configGet(key, flags) {
 
 function configList(flags) {
   const all = resolveAll();
+
+  // Resolve effective region
+  const { value: apiKey } = resolve("api_key", flags.apiKey);
+  const { region, source: regionSource, baseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
+
   if (flags.json) {
     const obj = {};
     for (const [k, v] of Object.entries(all)) {
       obj[k] = { value: k === "api_key" && v.value ? mask(v.value) : v.value, source: v.source };
     }
+    obj._region = { region, source: regionSource, baseUrl };
     outputJson(obj);
     return;
   }
@@ -78,6 +85,7 @@ function configList(flags) {
     const display = key === "api_key" && value ? mask(value) : String(value ?? dim("(not set)"));
     console.log(`  ${cyan(key.padEnd(20))}${display.padEnd(25)}${dim(source)}`);
   }
+  console.log(`\n  ${bold("Effective region:")} ${region} ${dim(`(${regionSource})`)} → ${dim(baseUrl)}`);
   console.log();
 }
 

--- a/packages/cli/src/commands/credits.mjs
+++ b/packages/cli/src/commands/credits.mjs
@@ -7,8 +7,8 @@ import { createSpinner } from "../output/spinner.mjs";
 
 export async function runCredits(flags) {
   const apiKey = resolveApiKey(flags.apiKey);
-  const { region } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
-  const accountUrl = `${getSiteUrl(region)}/account`;
+  const { region, baseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
+  const accountUrl = `${getSiteUrl(region, baseUrl)}/account`;
 
   const spinner = flags.json ? { stop() {} } : createSpinner("Checking credits...");
 

--- a/packages/cli/src/commands/credits.mjs
+++ b/packages/cli/src/commands/credits.mjs
@@ -1,11 +1,14 @@
 import { resolveApiKey } from "../client/auth.mjs";
 import { discoverTools } from "../client/api.mjs";
+import { resolveBaseUrl, getSiteUrl } from "../config/region.mjs";
 import { bold, dim, cyan, yellow, green } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
 import { createSpinner } from "../output/spinner.mjs";
 
 export async function runCredits(flags) {
   const apiKey = resolveApiKey(flags.apiKey);
+  const { region } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
+  const accountUrl = `${getSiteUrl(region)}/account`;
 
   const spinner = flags.json ? { stop() {} } : createSpinner("Checking credits...");
 
@@ -20,10 +23,10 @@ export async function runCredits(flags) {
       outputJson({ remaining_credits: credits ?? null });
     } else if (credits !== undefined && credits !== null) {
       console.log(`\n  ${green("\u2713")} Credits remaining: ${bold(yellow(String(credits)))}`);
-      console.log(`  ${dim("Manage at:")} ${cyan("https://qveris.ai/account")}\n`);
+      console.log(`  ${dim("Manage at:")} ${cyan(accountUrl)}\n`);
     } else {
       console.log(`\n  ${dim("Credit balance not available in API response.")}`);
-      console.log(`  Check at: ${cyan("https://qveris.ai/account")}\n`);
+      console.log(`  Check at: ${cyan(accountUrl)}\n`);
     }
   } catch (err) {
     spinner.stop();

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -1,5 +1,6 @@
 import { resolveApiKey } from "../client/auth.mjs";
 import { discoverTools } from "../client/api.mjs";
+import { resolveBaseUrl } from "../config/region.mjs";
 import { writeSession } from "../session/session.mjs";
 import { formatDiscoverResult } from "../output/formatter.mjs";
 import { outputJson } from "../output/json.mjs";
@@ -25,9 +26,11 @@ export async function runDiscover(query, flags) {
 
     // Store richer session data for index resolution
     const tools = result.results ?? [];
+    const { region } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
     writeSession({
       discoveryId: result.search_id,
       query,
+      region,
       results: tools.map((t, i) => ({
         index: i + 1,
         tool_id: t.tool_id,

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -26,11 +26,12 @@ export async function runDiscover(query, flags) {
 
     // Store richer session data for index resolution
     const tools = result.results ?? [];
-    const { region } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
+    const { region, baseUrl: resolvedBaseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
     writeSession({
       discoveryId: result.search_id,
       query,
       region,
+      baseUrl: resolvedBaseUrl,
       results: tools.map((t, i) => ({
         index: i + 1,
         tool_id: t.tool_id,

--- a/packages/cli/src/commands/doctor.mjs
+++ b/packages/cli/src/commands/doctor.mjs
@@ -1,5 +1,6 @@
 import { resolve } from "../config/resolve.mjs";
 import { discoverTools } from "../client/api.mjs";
+import { resolveBaseUrl } from "../config/region.mjs";
 import { bold, green, red, dim, cyan } from "../output/colors.mjs";
 
 export async function runDoctor(flags) {
@@ -21,6 +22,10 @@ export async function runDoctor(flags) {
   if (apiKey && apiKey.trim()) {
     const masked = apiKey.slice(0, 6) + "..." + apiKey.slice(-4);
     console.log(`  ${green("\u2713")} API key configured (${masked} via ${source})`);
+
+    // Show resolved region
+    const { baseUrl, region, source: regionSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
+    console.log(`  ${green("\u2713")} Region: ${region} ${dim(`(${regionSource})`)} → ${dim(baseUrl)}`);
 
     // Test connectivity
     process.stderr.write(`  \u2026 Testing API connectivity...\r`);

--- a/packages/cli/src/commands/interactive.mjs
+++ b/packages/cli/src/commands/interactive.mjs
@@ -15,7 +15,7 @@ import { createSpinner } from "../output/spinner.mjs";
 export async function runInteractive(flags) {
   const apiKey = resolveApiKey(flags.apiKey);
   const baseUrl = flags.baseUrl;
-  const { region } = resolveBaseUrl({ baseUrlFlag: baseUrl, apiKey });
+  const { region, baseUrl: resolvedBaseUrl } = resolveBaseUrl({ baseUrlFlag: baseUrl, apiKey });
   const limit = parseInt(flags.limit, 10) || 5;
   const discoverTimeout = (parseInt(flags.timeout, 10) || 30) * 1000;
   const callTimeout = (parseInt(flags.timeout, 10) || 60) * 1000;
@@ -65,7 +65,7 @@ export async function runInteractive(flags) {
             index: i + 1, tool_id: t.tool_id, name: t.name, provider_name: t.provider_name,
           }));
           // Persist session so index shortcuts work in subsequent non-interactive calls
-          writeSession({ discoveryId: result.search_id, query, region, results: state.results });
+          writeSession({ discoveryId: result.search_id, query, region, baseUrl: resolvedBaseUrl, results: state.results });
           console.log(formatDiscoverResult(result));
           break;
         }

--- a/packages/cli/src/commands/interactive.mjs
+++ b/packages/cli/src/commands/interactive.mjs
@@ -1,6 +1,7 @@
 import { createInterface } from "node:readline";
 import { resolveApiKey } from "../client/auth.mjs";
 import { discoverTools, inspectToolsByIds, callTool } from "../client/api.mjs";
+import { resolveBaseUrl } from "../config/region.mjs";
 import { resolveParams } from "../utils/params.mjs";
 import { formatDiscoverResult, formatInspectResult, formatCallResult } from "../output/formatter.mjs";
 import { generateSnippet } from "../output/codegen.mjs";
@@ -14,6 +15,7 @@ import { createSpinner } from "../output/spinner.mjs";
 export async function runInteractive(flags) {
   const apiKey = resolveApiKey(flags.apiKey);
   const baseUrl = flags.baseUrl;
+  const { region } = resolveBaseUrl({ baseUrlFlag: baseUrl, apiKey });
   const limit = parseInt(flags.limit, 10) || 5;
   const discoverTimeout = (parseInt(flags.timeout, 10) || 30) * 1000;
   const callTimeout = (parseInt(flags.timeout, 10) || 60) * 1000;
@@ -63,7 +65,7 @@ export async function runInteractive(flags) {
             index: i + 1, tool_id: t.tool_id, name: t.name, provider_name: t.provider_name,
           }));
           // Persist session so index shortcuts work in subsequent non-interactive calls
-          writeSession({ discoveryId: result.search_id, query, results: state.results });
+          writeSession({ discoveryId: result.search_id, query, region, results: state.results });
           console.log(formatDiscoverResult(result));
           break;
         }

--- a/packages/cli/src/commands/login.mjs
+++ b/packages/cli/src/commands/login.mjs
@@ -5,10 +5,9 @@ import { resolve } from "../config/resolve.mjs";
 import { setConfigValue, deleteConfigValue } from "../config/store.mjs";
 import { discoverTools } from "../client/api.mjs";
 import { VERSION } from "../config/defaults.mjs";
+import { resolveBaseUrl, getSiteUrl } from "../config/region.mjs";
 import { bold, green, red, dim, cyan } from "../output/colors.mjs";
 import { printLoginBanner } from "../output/banner.mjs";
-
-const ACCOUNT_URL = "https://qveris.ai/account?page=api-keys";
 
 function openBrowser(url) {
   const cmds = { darwin: "open", win32: "cmd", linux: "xdg-open" };
@@ -89,18 +88,23 @@ function prompt(question) {
 
 export async function runLogin(flags) {
   if (flags.token) {
-    await validateAndSave(flags.token);
+    await validateAndSave(flags.token, flags.baseUrl);
     return;
   }
+
+  // Resolve region for account URL — at this point we don't have a key yet,
+  // so region comes from flags/env only; defaults to global.
+  const { region } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const accountUrl = `${getSiteUrl(region)}/account?page=api-keys`;
 
   if (!flags.json) {
     printLoginBanner({ version: VERSION, noColor: flags.noColor });
   }
 
-  console.log(`  Get your API key at: ${cyan(ACCOUNT_URL)}\n`);
+  console.log(`  Get your API key at: ${cyan(accountUrl)}\n`);
 
   if (!flags.noBrowser) {
-    openBrowser(ACCOUNT_URL);
+    openBrowser(accountUrl);
   }
 
   let key;
@@ -116,18 +120,21 @@ export async function runLogin(flags) {
     return;
   }
 
-  await validateAndSave(key);
+  await validateAndSave(key, flags.baseUrl);
 }
 
-async function validateAndSave(key) {
+async function validateAndSave(key, baseUrlFlag) {
   process.stderr.write(`  Validating key...`);
 
+  const { baseUrl, region, source } = resolveBaseUrl({ baseUrlFlag, apiKey: key });
+
   try {
-    await discoverTools({ apiKey: key, query: "test", limit: 1, timeoutMs: 10000 });
+    await discoverTools({ apiKey: key, baseUrl, query: "test", limit: 1, timeoutMs: 10000 });
     setConfigValue("api_key", key);
     const masked = key.slice(0, 6) + "..." + key.slice(-4);
     console.error(`\r\x1b[K`);
     console.log(`  ${green("\u2713")} Authenticated as ${bold(masked)}`);
+    console.log(`  ${dim("Region:")} ${region} ${dim(`(${source})`)}`);
     console.log(`  ${dim("Key saved to config.")}`);
   } catch {
     console.error(`\r\x1b[K`);
@@ -151,15 +158,17 @@ export async function runWhoami(flags) {
   }
 
   const masked = key.slice(0, 6) + "..." + key.slice(-4);
+  const { baseUrl, region, source: regionSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey: key });
 
   process.stderr.write(`  Validating...`);
 
   try {
-    await discoverTools({ apiKey: key, query: "test", limit: 1, timeoutMs: 10000 });
+    await discoverTools({ apiKey: key, baseUrl, query: "test", limit: 1, timeoutMs: 10000 });
     process.stderr.write("\r\x1b[K");
     console.log(`\n  ${green("\u2713")} Authenticated`);
     console.log(`  Key:    ${bold(masked)}`);
     console.log(`  Source: ${dim(source)}`);
+    console.log(`  Region: ${region} ${dim(`(${regionSource})`)}`);
   } catch {
     console.error(`\r\x1b[K`);
     console.log(`\n  ${red("\u2718")} Key ${masked} is ${red("invalid")}`);

--- a/packages/cli/src/commands/login.mjs
+++ b/packages/cli/src/commands/login.mjs
@@ -142,8 +142,9 @@ export async function runLogin(flags) {
   }
 
   // Determine region: if already set via flag/env, use that; otherwise ask the user.
-  const { region: presetRegion, source: regionSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const { region: presetRegion, baseUrl: presetBaseUrl, source: regionSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
   let region;
+  let baseUrl = presetBaseUrl;
   if (regionSource !== "default") {
     // Region explicitly configured — use it directly
     region = presetRegion;
@@ -158,7 +159,7 @@ export async function runLogin(flags) {
     region = choice === "2" ? "cn" : "global";
   }
 
-  const accountUrl = `${getSiteUrl(region)}/account?page=api-keys`;
+  const accountUrl = `${getSiteUrl(region, baseUrl)}/account?page=api-keys`;
   console.log(`\n  Get your API key at: ${cyan(accountUrl)}\n`);
 
   if (!flags.noBrowser) {

--- a/packages/cli/src/commands/login.mjs
+++ b/packages/cli/src/commands/login.mjs
@@ -86,22 +86,80 @@ function prompt(question) {
   });
 }
 
+/**
+ * Prompt user to select region interactively.
+ * Skipped if region is already determined via --base-url, QVERIS_REGION, or QVERIS_BASE_URL.
+ */
+function promptRegion() {
+  return new Promise((pResolve, pReject) => {
+    console.log(`  ${bold("Select your region / 选择站点区域:")}\n`);
+    console.log(`    ${cyan("1)")} Global  — qveris.ai  (International users)`);
+    console.log(`    ${cyan("2)")} China   — qveris.cn  (中国大陆用户)\n`);
+
+    if (!process.stdin.isTTY) {
+      const rl = createInterface({ input: process.stdin, output: process.stderr });
+      rl.question("  Enter 1 or 2: ", (answer) => { rl.close(); pResolve(answer.trim()); });
+      return;
+    }
+
+    process.stderr.write("  Enter 1 or 2: ");
+
+    const cleanup = () => {
+      process.stdin.removeListener("data", onData);
+      try { process.stdin.setRawMode(false); } catch {}
+      process.stdin.pause();
+    };
+    const onExit = () => { try { process.stdin.setRawMode(false); } catch {} };
+    process.once("exit", onExit);
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+
+    const onData = (chunk) => {
+      const ch = chunk[0];
+      if (ch === "\x03") { cleanup(); process.removeListener("exit", onExit); process.stderr.write("\n"); pReject(new Error("Aborted")); return; }
+      if (ch === "1" || ch === "2") {
+        cleanup();
+        process.removeListener("exit", onExit);
+        process.stderr.write(`${ch}\n`);
+        pResolve(ch);
+      }
+      // Ignore other keys
+    };
+    process.stdin.on("data", onData);
+  });
+}
+
 export async function runLogin(flags) {
   if (flags.token) {
     await validateAndSave(flags.token, flags.baseUrl);
     return;
   }
 
-  // Resolve region for account URL — at this point we don't have a key yet,
-  // so region comes from flags/env only; defaults to global.
-  const { region } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
-  const accountUrl = `${getSiteUrl(region)}/account?page=api-keys`;
-
   if (!flags.json) {
     printLoginBanner({ version: VERSION, noColor: flags.noColor });
   }
 
-  console.log(`  Get your API key at: ${cyan(accountUrl)}\n`);
+  // Determine region: if already set via flag/env, use that; otherwise ask the user.
+  const { region: presetRegion, source: regionSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  let region;
+  if (regionSource !== "default") {
+    // Region explicitly configured — use it directly
+    region = presetRegion;
+  } else {
+    // No explicit region — let user choose interactively
+    let choice;
+    try {
+      choice = await promptRegion();
+    } catch {
+      return; // Ctrl+C
+    }
+    region = choice === "2" ? "cn" : "global";
+  }
+
+  const accountUrl = `${getSiteUrl(region)}/account?page=api-keys`;
+  console.log(`\n  Get your API key at: ${cyan(accountUrl)}\n`);
 
   if (!flags.noBrowser) {
     openBrowser(accountUrl);

--- a/packages/cli/src/config/region.mjs
+++ b/packages/cli/src/config/region.mjs
@@ -20,10 +20,16 @@ const SITE_URLS = {
 
 /**
  * Get the site URL (not API URL) for a given region.
+ * For custom regions, attempts to infer from the base URL domain.
  * @param {string} region
+ * @param {string} [baseUrl] - The resolved API base URL (used to infer site for custom regions)
  * @returns {string}
  */
-export function getSiteUrl(region) {
+export function getSiteUrl(region, baseUrl) {
+  if (region === "custom" && baseUrl) {
+    if (baseUrl.includes("qveris.cn")) return SITE_URLS.cn;
+    if (baseUrl.includes("qveris.ai")) return SITE_URLS.global;
+  }
   return SITE_URLS[region] || SITE_URLS.global;
 }
 

--- a/packages/cli/src/config/region.mjs
+++ b/packages/cli/src/config/region.mjs
@@ -13,6 +13,20 @@ const REGION_URLS = {
   cn: "https://qveris.cn/api/v1",
 };
 
+const SITE_URLS = {
+  global: "https://qveris.ai",
+  cn: "https://qveris.cn",
+};
+
+/**
+ * Get the site URL (not API URL) for a given region.
+ * @param {string} region
+ * @returns {string}
+ */
+export function getSiteUrl(region) {
+  return SITE_URLS[region] || SITE_URLS.global;
+}
+
 /**
  * Detect region from API key prefix.
  * @param {string} apiKey

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -241,11 +241,17 @@ function printUsage(flags = {}) {
   ${bold("Global Flags:")}
     --json, -j             Output raw JSON
     --api-key <key>        Override API key
+    --base-url <url>       Override API base URL
     --timeout <seconds>    Request timeout
     --no-color             Disable colors
     --verbose, -v          Show request details
     --version, -V          Print version
     --help, -h             Show help
+
+  ${bold("Environment Variables:")}
+    QVERIS_API_KEY         API key
+    QVERIS_REGION          Region override (global | cn)
+    QVERIS_BASE_URL        Custom API base URL
 
   ${bold("Examples:")}
     qveris discover "weather forecast API"
@@ -254,6 +260,6 @@ function printUsage(flags = {}) {
     qveris call 1 --params @params.json --codegen curl
     qveris interactive
 
-  ${dim("https://qveris.ai")}
+  ${dim("https://qveris.ai (global) / https://qveris.cn (China)")}
 `);
 }


### PR DESCRIPTION
## Summary

- **Docs**: Add QVeris CLI and Agent Setup sections to all three getting-started pages (en-US, zh-CN, cn/zh-CN), reorder sections to CLI → MCP → Python SDK → REST API
- **CLI multi-region fixes**: Region-aware account URLs in login/credits/whoami, display region in doctor and config list, pass baseUrl in login validation, store region in session, add `QVERIS_REGION` and `--base-url` to help text
- **cn/zh-CN**: CLI install URL uses `https://qveris.cn/cli/install`

## Files changed

**Docs (3 files)**
- `docs/en-US/getting-started.md`
- `docs/zh-CN/getting-started.md`
- `docs/cn/zh-CN/getting-started.md`

**CLI (8 files)**
- `packages/cli/src/config/region.mjs` — add `getSiteUrl()` helper
- `packages/cli/src/commands/login.mjs` — region-aware URLs + pass baseUrl
- `packages/cli/src/commands/credits.mjs` — region-aware account link
- `packages/cli/src/commands/doctor.mjs` — display region info
- `packages/cli/src/commands/config.mjs` — show effective region in config list
- `packages/cli/src/main.mjs` — help text with env vars and --base-url
- `packages/cli/src/commands/discover.mjs` — write region to session
- `packages/cli/src/commands/interactive.mjs` — write region to session

## Test plan

- [ ] `qveris --help` shows `--base-url`, `QVERIS_REGION`, dual-region footer
- [ ] `qveris doctor` displays detected region and base URL
- [ ] `qveris login` shows region-aware account URL (qveris.cn for cn keys)
- [ ] `qveris whoami` displays region info
- [ ] `qveris credits` shows region-aware account link
- [ ] `qveris config list` shows effective region summary
- [ ] Verify getting-started docs render correctly with new CLI/Agent sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)