### PR TITLE
feat(cli): add init first-call wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ npm install -g @qverisai/cli
 ```
 
 ```bash
+# Guided first call: auth → discover → inspect → call → reconcile
+$ qveris init
+
 # Agent workflow: discover → inspect → call
 $ qveris discover "weather forecast API"
 Found 5 capabilities matching your query

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -142,6 +142,9 @@ npm install -g @qverisai/cli
 ```
 
 ```bash
+# 引导式首次调用：认证 → 发现 → 检查 → 调用 → 对账
+$ qveris init
+
 # Agent 工作流：discover → inspect → call
 $ qveris discover "weather forecast API"
 Found 5 capabilities matching your query

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -36,6 +36,10 @@ npx @qverisai/cli discover "weather API"
 ## Quick Start
 
 ```bash
+# Guided first call
+qveris init
+
+# Manual flow
 # 1. Authenticate (saves key to ~/.config/qveris/config.json)
 qveris login
 
@@ -52,6 +56,34 @@ qveris call 1 --params '{"wfo": "LWX", "x": 90, "y": 90}'
 ---
 
 ## Commands
+
+### `qveris init`
+
+Guided first-call wizard: resolve auth, discover a capability, inspect it, call it, and finish with usage/ledger reconciliation guidance.
+
+```bash
+qveris init [query] [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--query <query>` | Discovery query override | `weather forecast API` |
+| `--params <json\|@file\|->` | Call parameters override | sample parameters when available |
+| `--resume` | Reuse the last discovery session after a recoverable failure | false |
+| `--dry-run` | Print planned discovery/call payload without executing the call | false |
+| `--tool-id <id>` | Select a specific tool ID instead of the first result | first result |
+| `--json` | Output machine-readable wizard state | false |
+
+**Examples:**
+
+```bash
+qveris init
+qveris init --query "stock price API"
+qveris init --dry-run
+qveris init --resume --params '{"city": "London"}'
+```
+
+The final step prints exact `qveris usage` and `qveris ledger` commands so you can reconcile the call.
 
 ### `qveris discover`
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -36,6 +36,10 @@ npx @qverisai/cli discover "天气 API"
 ## 快速开始
 
 ```bash
+# 引导式首次调用
+qveris init
+
+# 手动流程
 # 1. 认证（保存到 ~/.config/qveris/config.json）
 qveris login
 
@@ -52,6 +56,34 @@ qveris call 1 --params '{"wfo": "LWX", "x": 90, "y": 90}'
 ---
 
 ## 命令
+
+### `qveris init`
+
+引导式首次调用向导：解析认证、发现能力、检查能力、执行调用，并在最后给出 usage/ledger 对账命令。
+
+```bash
+qveris init [query] [flags]
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--query <query>` | 覆盖发现查询 | `weather forecast API` |
+| `--params <json\|@file\|->` | 覆盖调用参数 | 能力示例参数（如可用） |
+| `--resume` | 在可恢复失败后复用上一次发现会话 | false |
+| `--dry-run` | 打印计划执行的发现/调用载荷，但不实际调用 | false |
+| `--tool-id <id>` | 指定工具 ID，而不是使用第一个发现结果 | 第一个结果 |
+| `--json` | 输出机器可读的向导状态 | false |
+
+**示例：**
+
+```bash
+qveris init
+qveris init --query "股票价格 API"
+qveris init --dry-run
+qveris init --resume --params '{"city": "London"}'
+```
+
+最后一步会打印精确的 `qveris usage` 和 `qveris ledger` 命令，便于确认最终扣费结果。
 
 ### `qveris discover`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,12 @@
 
 Discover, inspect, and call 10,000+ API capabilities from your terminal.
 
+New users can run the guided first-call wizard:
+
+```bash
+qveris init
+```
+
 ```
 $ qveris discover "weather forecast API"
 Found 5 capabilities matching your query
@@ -81,6 +87,10 @@ Requires Node.js 18+.
 ## Quick Start
 
 ```bash
+# Guided path: auth → discover → inspect → call → usage/ledger guidance
+qveris init
+
+# Manual path
 # 1. Authenticate
 qveris login
 
@@ -100,6 +110,7 @@ qveris call 1 --params '{"wfo": "LWX", "x": 90, "y": 90}'
 
 | Command | Description |
 |---------|-------------|
+| `qveris init` | Guided first-call wizard: auth, discover, inspect, call, and usage/ledger reconciliation guidance. |
 | `qveris discover <query>` | Find capabilities by natural language. Shows tool ID, provider, description, relevance, success rate, latency, and billing rule when available. |
 | `qveris inspect <id\|index>` | View full tool details: parameters (type, required, description, enum values), example, provider info, execution history. |
 | `qveris call <id\|index>` | Execute a capability. Shows result data, execution time, pre-settlement billing, and remaining credits. |
@@ -125,6 +136,20 @@ qveris call 1 --params '{"wfo": "LWX", "x": 90, "y": 90}'
 | `qveris completions <shell>` | Generate shell completions (bash/zsh/fish) |
 
 ## Usage
+
+### Init
+
+Run the guided first-call wizard:
+
+```bash
+qveris init
+qveris init --query "weather forecast API"
+qveris init --dry-run
+qveris init --resume --params '{"city": "London"}'
+qveris init --json
+```
+
+`init` discovers a capability, inspects the selected result, calls it with sample parameters when available, and ends with exact `usage` / `ledger` commands so you can reconcile final billing. Use `--resume` after recoverable parameter or provider failures to reuse the last discovery session.
 
 ### Discover
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "qveris": "./bin/qveris.mjs"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -36,6 +36,7 @@ export async function runInit(queryArg, flags) {
   let selected;
   const query = flags.query || queryArg || DEFAULT_QUERY;
   const limit = parseInt(flags.limit, 10) || DEFAULT_LIMIT;
+  const maxResponseSize = resolveInitMaxResponseSize(flags);
 
   if (flags.resume) {
     const session = readSession();
@@ -108,7 +109,7 @@ export async function runInit(queryArg, flags) {
   record(steps, "call", flags.dryRun ? "skipped" : "running", flags.dryRun ? "Dry run requested" : "Calling selected capability", {
     tool_id: selected.tool_id,
     params_source: paramsSource,
-    max_response_size: DEFAULT_MAX_RESPONSE_SIZE,
+    max_response_size: maxResponseSize,
   });
 
   const nextCommands = buildNextCommands({ selected, discoveryId, parameters });
@@ -126,14 +127,14 @@ export async function runInit(queryArg, flags) {
     toolId: selected.tool_id,
     discoveryId,
     parameters,
-    maxResponseSize: DEFAULT_MAX_RESPONSE_SIZE,
+    maxResponseSize,
     timeoutMs,
   });
 
   if (!callResult.success) {
     const err = new CliError("TOOL_CALL_FAILED", callResult.error_message || "The selected capability returned success=false.");
     if (looksLikeProviderFailure(callResult.error_message)) err.code = "PROVIDER_FAILURE";
-    err.hint = `Rerun with adjusted params: qveris init --resume --params '${JSON.stringify(parameters)}'`;
+    err.hint = `Rerun with adjusted params: qveris init --resume --params ${shellSingleQuote(JSON.stringify(parameters))}`;
     throw err;
   }
 
@@ -200,11 +201,22 @@ function pickInspectedTool(response, toolId) {
   return list.find((t) => t?.tool_id === toolId) || list[0] || null;
 }
 
-function buildNextCommands({ selected, discoveryId, parameters }) {
-  const paramsJson = JSON.stringify(parameters);
+export function resolveInitMaxResponseSize(flags) {
+  if (flags.maxSize === undefined) return DEFAULT_MAX_RESPONSE_SIZE;
+  const parsed = parseInt(flags.maxSize, 10);
+  if (!Number.isFinite(parsed)) throw new CliError("API_ERROR", "Invalid --max-size: must be an integer");
+  return parsed;
+}
+
+export function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+export function buildNextCommands({ selected, discoveryId, parameters }) {
+  const paramsJson = shellSingleQuote(JSON.stringify(parameters));
   const executionPlaceholder = "<execution_id>";
   return {
-    retry: `qveris call ${selected.tool_id} --discovery-id ${discoveryId} --params '${paramsJson}'`,
+    retry: `qveris call ${selected.tool_id} --discovery-id ${discoveryId} --params ${paramsJson}`,
     usage: `qveris usage --mode search --execution-id ${executionPlaceholder}`,
     ledger: "qveris ledger --mode summary",
   };

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -145,9 +145,11 @@ export async function runInit(queryArg, flags) {
   });
 
   if (!callResult.success) {
-    const err = new CliError("TOOL_CALL_FAILED", callResult.error_message || "The selected capability returned success=false.");
-    if (looksLikeProviderFailure(callResult.error_message)) err.code = "PROVIDER_FAILURE";
-    err.hint = `Rerun with adjusted params: qveris init --resume --params ${shellSingleQuote(JSON.stringify(parameters))}`;
+    const code = looksLikeProviderFailure(callResult.error_message) ? "PROVIDER_FAILURE" : "TOOL_CALL_FAILED";
+    const err = new CliError(code, callResult.error_message || "The selected capability returned success=false.");
+    if (code === "TOOL_CALL_FAILED") {
+      err.hint = `Rerun with adjusted params: qveris init --resume --params ${shellSingleQuote(JSON.stringify(parameters))}`;
+    }
     throw err;
   }
 

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -344,7 +344,9 @@ function printHumanSummary(payload) {
     }
     if (step.name === "discover") {
       console.log(`      ${dim("search_id")} ${step.search_id || payload.discovery.search_id}`);
-      if (step.selected_tool_id) console.log(`      ${dim("selected")} ${cyan(step.selected_tool_id)}`);
+    }
+    if (step.name === "inspect" && step.tool_id) {
+      console.log(`      ${dim("selected")} ${cyan(step.tool_id)}`);
     }
     if (step.name === "call" && step.execution_id) {
       console.log(`      ${dim("execution_id")} ${step.execution_id}`);

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -34,9 +34,11 @@ export async function runInit(queryArg, flags) {
   let discovery;
   let discoveryId;
   let selected;
+  let candidateTools = [];
   const query = flags.query || queryArg || DEFAULT_QUERY;
   const limit = parseInt(flags.limit, 10) || DEFAULT_LIMIT;
   const maxResponseSize = resolveInitMaxResponseSize(flags);
+  const flagParameters = flags.params ? resolveParams(flags.params) : null;
 
   if (flags.resume) {
     const session = readSession();
@@ -44,9 +46,9 @@ export async function runInit(queryArg, flags) {
       throw new CliError("SESSION_EXPIRED", "No resumable init session found. Run 'qveris init' without --resume first.");
     }
     discoveryId = session.discoveryId;
-    selected = flags.toolId
-      ? { tool_id: flags.toolId, name: flags.toolId }
-      : session.results[0];
+    candidateTools = flags.toolId
+      ? [{ tool_id: flags.toolId, name: flags.toolId }]
+      : session.results;
     discovery = {
       search_id: discoveryId,
       query: session.query,
@@ -56,7 +58,6 @@ export async function runInit(queryArg, flags) {
     record(steps, "discover", "ok", "Resumed previous discovery session", {
       query: session.query,
       search_id: discoveryId,
-      selected_tool_id: selected.tool_id,
     });
   } else {
     record(steps, "discover", "running", `Discovering capabilities for "${query}"`, { query, limit });
@@ -66,9 +67,9 @@ export async function runInit(queryArg, flags) {
       throw new CliError("TOOL_NOT_FOUND", `No capabilities matched "${query}". Try 'qveris init --query <broader-query>'.`);
     }
     discoveryId = discovery.search_id;
-    selected = flags.toolId
-      ? { tool_id: flags.toolId, name: flags.toolId }
-      : results[0];
+    candidateTools = flags.toolId
+      ? [{ tool_id: flags.toolId, name: flags.toolId }]
+      : results;
     writeSession({
       discoveryId,
       query,
@@ -85,27 +86,39 @@ export async function runInit(queryArg, flags) {
       query,
       search_id: discoveryId,
       total: discovery.total ?? results.length,
-      selected_tool_id: selected.tool_id,
-      selected_name: selected.name,
     });
   }
 
-  record(steps, "inspect", "running", "Inspecting selected capability", { tool_id: selected.tool_id });
+  const candidateToolIds = candidateTools.map((tool) => tool?.tool_id).filter(Boolean);
+  if (candidateToolIds.length === 0) {
+    throw new CliError("TOOL_NOT_FOUND", "No selectable capabilities were returned.");
+  }
+
+  record(
+    steps,
+    "inspect",
+    "running",
+    candidateToolIds.length === 1 ? "Inspecting selected capability" : "Inspecting candidate capabilities",
+    { tool_ids: candidateToolIds }
+  );
   const inspected = await inspectToolsByIds({
     apiKey,
     baseUrl,
-    toolIds: [selected.tool_id],
+    toolIds: candidateToolIds,
     discoveryId,
     timeoutMs,
   });
-  const inspectedTool = pickInspectedTool(inspected, selected.tool_id) || selected;
+  const inspectedTools = mergeCandidateTools(candidateTools, normalizeToolList(inspected));
+  selected = pickInitTool(inspectedTools, { toolId: flags.toolId, parameters: flagParameters });
+  const inspectedTool = pickInspectedTool(inspectedTools, selected.tool_id) || selected;
   updateLast(steps, "ok", "Inspection completed", {
     tool_id: inspectedTool.tool_id || selected.tool_id,
     tool_name: inspectedTool.name || selected.name,
+    selected_reason: flagParameters && !flags.toolId ? "params_match" : flags.toolId ? "explicit_tool" : "first_candidate",
     has_sample_parameters: Boolean(getSampleParameters(inspectedTool)),
   });
 
-  const { parameters, source: paramsSource } = getInitParameters(flags, inspectedTool);
+  const { parameters, source: paramsSource } = getInitParameters(flags, inspectedTool, flagParameters);
   record(steps, "call", flags.dryRun ? "skipped" : "running", flags.dryRun ? "Dry run requested" : "Calling selected capability", {
     tool_id: selected.tool_id,
     params_source: paramsSource,
@@ -167,9 +180,9 @@ function getInitApiKey(flags) {
   }
 }
 
-function getInitParameters(flags, tool) {
+function getInitParameters(flags, tool, flagParameters = null) {
   if (flags.params) {
-    return { parameters: resolveParams(flags.params), source: "flag" };
+    return { parameters: flagParameters ?? resolveParams(flags.params), source: "flag" };
   }
 
   const sample = getSampleParameters(tool);
@@ -196,9 +209,68 @@ function getSampleParameters(tool) {
 }
 
 function pickInspectedTool(response, toolId) {
-  const list = Array.isArray(response) ? response : response?.results ?? response?.tools ?? [];
+  const list = normalizeToolList(response);
   if (!Array.isArray(list)) return null;
   return list.find((t) => t?.tool_id === toolId) || list[0] || null;
+}
+
+function normalizeToolList(response) {
+  if (Array.isArray(response)) return response;
+  return response?.results ?? response?.tools ?? [];
+}
+
+function mergeCandidateTools(discoveredTools, inspectedTools) {
+  const inspectedById = new Map(
+    normalizeToolList(inspectedTools)
+      .filter((tool) => tool?.tool_id)
+      .map((tool) => [tool.tool_id, tool])
+  );
+  return discoveredTools.map((tool) => ({
+    ...tool,
+    ...(inspectedById.get(tool.tool_id) ?? {}),
+  }));
+}
+
+export function pickInitTool(tools, { toolId, parameters } = {}) {
+  const list = normalizeToolList(tools).filter((tool) => tool?.tool_id);
+  if (toolId) return list.find((tool) => tool.tool_id === toolId) || { tool_id: toolId, name: toolId };
+  if (!parameters) return list[0];
+
+  const ranked = list
+    .map((tool, index) => ({ tool, index, score: scoreParameterMatch(tool, parameters) }))
+    .filter((item) => item.score > Number.NEGATIVE_INFINITY)
+    .sort((a, b) => b.score - a.score || a.index - b.index);
+
+  if (ranked.length > 0) return ranked[0].tool;
+
+  const err = new CliError("INIT_PARAMS_REQUIRED", "Provided --params do not satisfy any discovered capability.");
+  err.hint = `Inspect candidates and retry with matching params: ${summarizeRequiredParams(list)}`;
+  throw err;
+}
+
+function scoreParameterMatch(tool, parameters) {
+  const schema = Array.isArray(tool?.params) ? tool.params : [];
+  if (schema.length === 0) return 0;
+
+  const provided = new Set(Object.keys(parameters ?? {}));
+  const required = schema.filter((param) => param?.required).map((param) => param.name).filter(Boolean);
+  const allNames = schema.map((param) => param?.name).filter(Boolean);
+  const missingRequired = required.filter((name) => !provided.has(name));
+  if (missingRequired.length > 0) return Number.NEGATIVE_INFINITY;
+
+  const overlap = allNames.filter((name) => provided.has(name)).length;
+  if (overlap === 0 && required.length > 0) return Number.NEGATIVE_INFINITY;
+  return required.length * 10 + overlap;
+}
+
+function summarizeRequiredParams(tools) {
+  return tools.slice(0, 5).map((tool, index) => {
+    const required = (Array.isArray(tool?.params) ? tool.params : [])
+      .filter((param) => param?.required)
+      .map((param) => param.name)
+      .filter(Boolean);
+    return `${index + 1}. ${tool.tool_id}: ${required.length ? required.join(", ") : "no required params"}`;
+  }).join("; ");
 }
 
 export function resolveInitMaxResponseSize(flags) {

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -213,7 +213,7 @@ function getSampleParameters(tool) {
 function pickInspectedTool(response, toolId) {
   const list = normalizeToolList(response);
   if (!Array.isArray(list)) return null;
-  return list.find((t) => t?.tool_id === toolId) || list[0] || null;
+  return (toolId ? list.find((t) => t?.tool_id === toolId) : list[0]) || null;
 }
 
 function normalizeToolList(response) {

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -166,7 +166,7 @@ export async function runInit(queryArg, flags) {
     ledger: finalNextCommands.ledger,
   });
 
-  const payload = buildPayload({ steps, discovery, inspectedTool, parameters, callResult, nextCommands: finalNextCommands, startedAt, dryRun: false });
+  const payload = buildPayload({ steps, discovery, inspectedTool, parameters, callResult, nextCommands, startedAt, dryRun: false });
   if (flags.json) outputJson(payload);
   else printHumanSummary(payload);
 }

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -1,0 +1,290 @@
+import { resolveApiKey } from "../client/auth.mjs";
+import { callTool, discoverTools, inspectToolsByIds } from "../client/api.mjs";
+import { resolve } from "../config/resolve.mjs";
+import { resolveBaseUrl } from "../config/region.mjs";
+import { CliError } from "../errors/handler.mjs";
+import { bold, cyan, dim, green, red, yellow } from "../output/colors.mjs";
+import { outputJson } from "../output/json.mjs";
+import { readSession, writeSession } from "../session/session.mjs";
+import { resolveParams } from "../utils/params.mjs";
+
+const DEFAULT_QUERY = "weather forecast API";
+const DEFAULT_LIMIT = 5;
+const DEFAULT_MAX_RESPONSE_SIZE = 20480;
+
+export async function runInit(queryArg, flags) {
+  const steps = [];
+  const startedAt = Date.now();
+
+  if (!flags.json) {
+    console.log(`\n  ${bold("QVeris init")} ${dim("first-call wizard")}\n`);
+  }
+
+  const timeoutMs = (parseInt(flags.timeout, 10) || 60) * 1000;
+  const apiKey = getInitApiKey(flags);
+  const { region, baseUrl, source: regionSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
+  record(steps, "auth", "ok", "API key resolved", {
+    source: resolve("api_key", flags.apiKey || flags.token).source,
+    key: maskKey(apiKey),
+    region,
+    base_url: baseUrl,
+    region_source: regionSource,
+  });
+
+  let discovery;
+  let discoveryId;
+  let selected;
+  const query = flags.query || queryArg || DEFAULT_QUERY;
+  const limit = parseInt(flags.limit, 10) || DEFAULT_LIMIT;
+
+  if (flags.resume) {
+    const session = readSession();
+    if (!session?.discoveryId || !Array.isArray(session.results) || session.results.length === 0) {
+      throw new CliError("SESSION_EXPIRED", "No resumable init session found. Run 'qveris init' without --resume first.");
+    }
+    discoveryId = session.discoveryId;
+    selected = flags.toolId
+      ? { tool_id: flags.toolId, name: flags.toolId }
+      : session.results[0];
+    discovery = {
+      search_id: discoveryId,
+      query: session.query,
+      results: session.results,
+      resumed: true,
+    };
+    record(steps, "discover", "ok", "Resumed previous discovery session", {
+      query: session.query,
+      search_id: discoveryId,
+      selected_tool_id: selected.tool_id,
+    });
+  } else {
+    record(steps, "discover", "running", `Discovering capabilities for "${query}"`, { query, limit });
+    discovery = await discoverTools({ apiKey, baseUrl, query, limit, timeoutMs });
+    const results = discovery.results ?? [];
+    if (results.length === 0) {
+      throw new CliError("TOOL_NOT_FOUND", `No capabilities matched "${query}". Try 'qveris init --query <broader-query>'.`);
+    }
+    discoveryId = discovery.search_id;
+    selected = flags.toolId
+      ? { tool_id: flags.toolId, name: flags.toolId }
+      : results[0];
+    writeSession({
+      discoveryId,
+      query,
+      region,
+      baseUrl,
+      results: results.map((t, i) => ({
+        index: i + 1,
+        tool_id: t.tool_id,
+        name: t.name,
+        provider_name: t.provider_name,
+      })),
+    });
+    updateLast(steps, "ok", "Discovery completed", {
+      query,
+      search_id: discoveryId,
+      total: discovery.total ?? results.length,
+      selected_tool_id: selected.tool_id,
+      selected_name: selected.name,
+    });
+  }
+
+  record(steps, "inspect", "running", "Inspecting selected capability", { tool_id: selected.tool_id });
+  const inspected = await inspectToolsByIds({
+    apiKey,
+    baseUrl,
+    toolIds: [selected.tool_id],
+    discoveryId,
+    timeoutMs,
+  });
+  const inspectedTool = pickInspectedTool(inspected, selected.tool_id) || selected;
+  updateLast(steps, "ok", "Inspection completed", {
+    tool_id: inspectedTool.tool_id || selected.tool_id,
+    tool_name: inspectedTool.name || selected.name,
+    has_sample_parameters: Boolean(getSampleParameters(inspectedTool)),
+  });
+
+  const { parameters, source: paramsSource } = getInitParameters(flags, inspectedTool);
+  record(steps, "call", flags.dryRun ? "skipped" : "running", flags.dryRun ? "Dry run requested" : "Calling selected capability", {
+    tool_id: selected.tool_id,
+    params_source: paramsSource,
+    max_response_size: DEFAULT_MAX_RESPONSE_SIZE,
+  });
+
+  const nextCommands = buildNextCommands({ selected, discoveryId, parameters });
+
+  if (flags.dryRun) {
+    const payload = buildPayload({ steps, discovery, inspectedTool, parameters, callResult: null, nextCommands, startedAt, dryRun: true });
+    if (flags.json) outputJson(payload);
+    else printHumanSummary(payload);
+    return;
+  }
+
+  const callResult = await callTool({
+    apiKey,
+    baseUrl,
+    toolId: selected.tool_id,
+    discoveryId,
+    parameters,
+    maxResponseSize: DEFAULT_MAX_RESPONSE_SIZE,
+    timeoutMs,
+  });
+
+  if (!callResult.success) {
+    const err = new CliError("TOOL_CALL_FAILED", callResult.error_message || "The selected capability returned success=false.");
+    if (looksLikeProviderFailure(callResult.error_message)) err.code = "PROVIDER_FAILURE";
+    err.hint = `Rerun with adjusted params: qveris init --resume --params '${JSON.stringify(parameters)}'`;
+    throw err;
+  }
+
+  updateLast(steps, "ok", "First call succeeded", {
+    execution_id: callResult.execution_id,
+    elapsed_time_ms: callResult.elapsed_time_ms ?? callResult.execution_time,
+  });
+  const finalNextCommands = {
+    ...nextCommands,
+    usage: nextCommands.usage.replace("<execution_id>", callResult.execution_id),
+  };
+  record(steps, "audit", "ok", "Use usage and ledger commands to reconcile final billing", {
+    usage: finalNextCommands.usage,
+    ledger: finalNextCommands.ledger,
+  });
+
+  const payload = buildPayload({ steps, discovery, inspectedTool, parameters, callResult, nextCommands: finalNextCommands, startedAt, dryRun: false });
+  if (flags.json) outputJson(payload);
+  else printHumanSummary(payload);
+}
+
+function getInitApiKey(flags) {
+  try {
+    return resolveApiKey(flags.apiKey || flags.token);
+  } catch (err) {
+    if (err instanceof CliError && err.code === "AUTH_MISSING_KEY") {
+      err.hint = "Run 'qveris login', set QVERIS_API_KEY, or pass --api-key/--token to qveris init.";
+    }
+    throw err;
+  }
+}
+
+function getInitParameters(flags, tool) {
+  if (flags.params) {
+    return { parameters: resolveParams(flags.params), source: "flag" };
+  }
+
+  const sample = getSampleParameters(tool);
+  if (sample) {
+    return { parameters: sample, source: "example" };
+  }
+
+  throw new CliError("INIT_PARAMS_REQUIRED");
+}
+
+function getSampleParameters(tool) {
+  const examples = tool?.examples;
+  if (!examples || typeof examples !== "object") return null;
+  if (examples.sample_parameters && typeof examples.sample_parameters === "object") {
+    return examples.sample_parameters;
+  }
+  if (Array.isArray(examples) && examples[0]?.parameters && typeof examples[0].parameters === "object") {
+    return examples[0].parameters;
+  }
+  if (examples.parameters && typeof examples.parameters === "object") {
+    return examples.parameters;
+  }
+  return null;
+}
+
+function pickInspectedTool(response, toolId) {
+  const list = Array.isArray(response) ? response : response?.results ?? response?.tools ?? [];
+  if (!Array.isArray(list)) return null;
+  return list.find((t) => t?.tool_id === toolId) || list[0] || null;
+}
+
+function buildNextCommands({ selected, discoveryId, parameters }) {
+  const paramsJson = JSON.stringify(parameters);
+  const executionPlaceholder = "<execution_id>";
+  return {
+    retry: `qveris call ${selected.tool_id} --discovery-id ${discoveryId} --params '${paramsJson}'`,
+    usage: `qveris usage --mode search --execution-id ${executionPlaceholder}`,
+    ledger: "qveris ledger --mode summary",
+  };
+}
+
+function buildPayload({ steps, discovery, inspectedTool, parameters, callResult, nextCommands, startedAt, dryRun }) {
+  return {
+    ok: dryRun ? true : Boolean(callResult?.success),
+    dry_run: dryRun,
+    elapsed_ms: Date.now() - startedAt,
+    steps,
+    discovery: {
+      query: discovery?.query,
+      search_id: discovery?.search_id,
+      total: discovery?.total ?? discovery?.results?.length,
+    },
+    selected_tool: {
+      tool_id: inspectedTool?.tool_id,
+      name: inspectedTool?.name,
+      provider_name: inspectedTool?.provider_name,
+    },
+    parameters,
+    call: callResult ? {
+      success: callResult.success,
+      execution_id: callResult.execution_id,
+      elapsed_time_ms: callResult.elapsed_time_ms ?? callResult.execution_time,
+      billing: callResult.billing ?? callResult.pre_settlement_bill,
+    } : null,
+    next_commands: callResult?.execution_id
+      ? { ...nextCommands, usage: nextCommands.usage.replace("<execution_id>", callResult.execution_id) }
+      : nextCommands,
+  };
+}
+
+function record(steps, name, status, message, data = {}) {
+  steps.push({ name, status, message, ...data });
+}
+
+function updateLast(steps, status, message, data = {}) {
+  const last = steps[steps.length - 1];
+  Object.assign(last, { status, message }, data);
+}
+
+function printHumanSummary(payload) {
+  for (let i = 0; i < payload.steps.length; i++) {
+    const step = payload.steps[i];
+    const icon = step.status === "ok" ? green("\u2713") : step.status === "skipped" ? yellow("!") : red("\u2718");
+    console.log(`  ${icon} ${i + 1}/5 ${bold(step.name)} ${dim(step.message)}`);
+    if (step.name === "auth") {
+      console.log(`      ${dim("key")} ${step.key}  ${dim("region")} ${step.region}  ${dim(step.base_url)}`);
+    }
+    if (step.name === "discover") {
+      console.log(`      ${dim("search_id")} ${step.search_id || payload.discovery.search_id}`);
+      if (step.selected_tool_id) console.log(`      ${dim("selected")} ${cyan(step.selected_tool_id)}`);
+    }
+    if (step.name === "call" && step.execution_id) {
+      console.log(`      ${dim("execution_id")} ${step.execution_id}`);
+    }
+  }
+
+  console.log(`\n  ${green("First-call path complete.")}`);
+  if (payload.dry_run) {
+    console.log(`  ${yellow("Dry run only:")} remove --dry-run to perform the call.`);
+  }
+  if (payload.call?.execution_id) {
+    console.log(`\n  ${bold("Reconcile final billing:")}`);
+    console.log(`    ${cyan(payload.next_commands.usage)}`);
+    console.log(`    ${cyan(payload.next_commands.ledger)}`);
+  }
+  console.log(`\n  ${dim("Retry selected capability:")}`);
+  console.log(`    ${cyan(payload.next_commands.retry)}\n`);
+}
+
+function maskKey(key) {
+  if (!key) return "none";
+  if (key.length <= 10) return "***";
+  return `${key.slice(0, 6)}...${key.slice(-4)}`;
+}
+
+function looksLikeProviderFailure(message = "") {
+  const text = String(message).toLowerCase();
+  return text.includes("provider") || text.includes("upstream") || text.includes("third-party");
+}

--- a/packages/cli/src/errors/codes.mjs
+++ b/packages/cli/src/errors/codes.mjs
@@ -29,8 +29,23 @@ export const ERROR_CODES = {
   },
   PARAMS_INVALID_JSON: {
     message: "Invalid JSON in --params",
-    hint: "Check JSON syntax in --params value",
+    hint: "Check JSON syntax in --params value, or pass a file with --params @params.json",
     exit: EX_USAGE,
+  },
+  INIT_PARAMS_REQUIRED: {
+    message: "Init could not infer safe parameters for the selected capability",
+    hint: "Run 'qveris inspect 1' to review required params, then rerun 'qveris init --resume --params <json>'",
+    exit: EX_USAGE,
+  },
+  TOOL_CALL_FAILED: {
+    message: "Capability call failed",
+    hint: "Review the error, adjust --params, then rerun 'qveris init --resume --params <json>'",
+    exit: EX_UNAVAILABLE,
+  },
+  PROVIDER_FAILURE: {
+    message: "Remote provider failed",
+    hint: "Try another discovered capability with 'qveris inspect 2' and 'qveris call 2', or rerun discovery with a broader query",
+    exit: EX_UNAVAILABLE,
   },
   TOOL_NOT_FOUND: {
     message: "Tool not found",
@@ -44,12 +59,12 @@ export const ERROR_CODES = {
   },
   CREDITS_INSUFFICIENT: {
     message: "Insufficient credits",
-    hint: "Purchase credits at https://qveris.ai/pricing",
+    hint: "Purchase credits at https://qveris.ai/pricing, then confirm balance with 'qveris credits'",
     exit: EX_NOPERM,
   },
   SESSION_EXPIRED: {
     message: "Session expired",
-    hint: "Run 'qveris discover' to start a new session",
+    hint: "Run 'qveris discover' or 'qveris init' to start a new session",
     exit: EX_USAGE,
   },
 };

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -52,6 +52,11 @@ export async function main(argv) {
         await runCall(rest[0], flags);
         break;
       }
+      case "init": {
+        const { runInit } = await import("./commands/init.mjs");
+        await runInit(rest.join(" "), flags);
+        break;
+      }
       case "login": {
         const { runLogin } = await import("./commands/login.mjs");
         await runLogin(flags);
@@ -129,6 +134,7 @@ const VALUE_FLAGS = {
   "api-key": "apiKey", "base-url": "baseUrl", timeout: "timeout",
   limit: "limit", "discovery-id": "discoveryId", params: "params",
   "max-size": "maxSize", codegen: "codegen", token: "token",
+  query: "query", "tool-id": "toolId",
   mode: "mode", "start-date": "startDate", "end-date": "endDate",
   bucket: "bucket", "execution-id": "executionId", "search-id": "searchId",
   "event-type": "eventType", kind: "kind", success: "success",
@@ -192,6 +198,8 @@ function extractGlobalFlags(args) {
         flags.version = true; break;
       case "--dry-run":
         flags.dryRun = true; break;
+      case "--resume":
+        flags.resume = true; break;
       case "--no-browser":
         flags.noBrowser = true; break;
       case "--clear":
@@ -214,6 +222,10 @@ function extractGlobalFlags(args) {
         flags.codegen = takeNext(args, i++, arg); break;
       case "--token":
         flags.token = takeNext(args, i++, arg); break;
+      case "--query":
+        flags.query = takeNext(args, i++, arg); break;
+      case "--tool-id":
+        flags.toolId = takeNext(args, i++, arg); break;
       case "--mode":
         flags.mode = takeNext(args, i++, arg); break;
       case "--start-date":
@@ -262,6 +274,7 @@ function printUsage(flags = {}) {
     qveris <command> [args] [flags]
 
   ${bold("Core Commands:")}
+    ${cyan("init")}                         Guided first-call wizard
     ${cyan("discover")} <query>             Find capabilities by natural language
     ${cyan("inspect")}  <tool_id|index>     View tool details, parameters, and stats
     ${cyan("call")}     <tool_id|index>     Execute a capability
@@ -288,6 +301,9 @@ function printUsage(flags = {}) {
     --api-key <key>        Override API key
     --base-url <url>       Override API base URL
     --timeout <seconds>    Request timeout
+    --query <query>        Init discovery query override
+    --tool-id <id>         Init selected capability override
+    --resume               Resume init from the last discovery session
     --mode <mode>          summary | search | export-file for usage/ledger
     --start-date <date>    Usage/ledger range start (YYYY-MM-DD)
     --end-date <date>      Usage/ledger range end (YYYY-MM-DD)
@@ -304,6 +320,9 @@ function printUsage(flags = {}) {
     QVERIS_BASE_URL        Custom API base URL
 
   ${bold("Examples:")}
+    qveris init
+    qveris init --query "weather forecast API"
+    qveris init --resume --params '{"city": "London"}'
     qveris discover "weather forecast API"
     qveris inspect 1
     qveris call 1 --params '{"city": "London"}'

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  buildNextCommands,
+  resolveInitMaxResponseSize,
+  runInit,
+  shellSingleQuote,
+} from "../src/commands/init.mjs";
+import { CliError } from "../src/errors/handler.mjs";
+
+function withTempConfig(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "qveris-cli-init-"));
+  const previous = {
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    QVERIS_API_KEY: process.env.QVERIS_API_KEY,
+    QVERIS_BASE_URL: process.env.QVERIS_BASE_URL,
+    QVERIS_REGION: process.env.QVERIS_REGION,
+    NO_COLOR: process.env.NO_COLOR,
+  };
+  process.env.XDG_CONFIG_HOME = dir;
+  process.env.NO_COLOR = "1";
+  delete process.env.QVERIS_API_KEY;
+  delete process.env.QVERIS_BASE_URL;
+  delete process.env.QVERIS_REGION;
+
+  return Promise.resolve()
+    .then(() => fn(dir))
+    .finally(() => {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    });
+}
+
+async function captureStdout(fn) {
+  const chunks = [];
+  const original = process.stdout.write;
+  process.stdout.write = function write(chunk, ...args) {
+    chunks.push(String(chunk));
+    const callback = args.find((arg) => typeof arg === "function");
+    if (callback) callback();
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = original;
+  }
+  return chunks.join("");
+}
+
+function withMockFetch(handler, fn) {
+  const original = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (url, options) => {
+    const request = {
+      url: new URL(url),
+      method: options.method,
+      body: options.body ? JSON.parse(options.body) : undefined,
+    };
+    requests.push(request);
+    return handler(request);
+  };
+  return Promise.resolve()
+    .then(() => fn(requests))
+    .finally(() => {
+      globalThis.fetch = original;
+    });
+}
+
+function response(payload) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("init helpers respect max size and escape single quotes in shell hints", () => {
+  assert.equal(resolveInitMaxResponseSize({}), 20480);
+  assert.equal(resolveInitMaxResponseSize({ maxSize: "65536" }), 65536);
+  assert.throws(
+    () => resolveInitMaxResponseSize({ maxSize: "abc" }),
+    (err) => err instanceof CliError && err.message.includes("Invalid --max-size")
+  );
+
+  const quoted = shellSingleQuote(JSON.stringify({ city: "L'Ondon" }));
+  assert.equal(quoted, `'{"city":"L'\\''Ondon"}'`);
+  assert.equal(
+    buildNextCommands({
+      selected: { tool_id: "weather.tool.v1" },
+      discoveryId: "search-1",
+      parameters: { city: "L'Ondon" },
+    }).retry,
+    `qveris call weather.tool.v1 --discovery-id search-1 --params ${quoted}`
+  );
+});
+
+test("init dry run records the provided max response size", async () => {
+  await withTempConfig(async () => {
+    await withMockFetch((request) => {
+      if (request.url.pathname.endsWith("/search")) {
+        return response({
+          search_id: "search-1",
+          total: 1,
+          results: [{ tool_id: "weather.tool.v1", name: "Weather" }],
+        });
+      }
+      if (request.url.pathname.endsWith("/tools/by-ids")) {
+        return response({
+          results: [
+            {
+              tool_id: "weather.tool.v1",
+              name: "Weather",
+              examples: { sample_parameters: { city: "London" } },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected path ${request.url.pathname}`);
+    }, async () => {
+      const stdout = await captureStdout(() => runInit(null, {
+        apiKey: "sk-test",
+        baseUrl: "https://unit.test/api/v1",
+        json: true,
+        dryRun: true,
+        maxSize: "65536",
+      }));
+      const payload = JSON.parse(stdout);
+      const callStep = payload.steps.find((step) => step.name === "call");
+      assert.equal(callStep.max_response_size, 65536);
+    });
+  });
+});
+
+test("init call uses max size and failure hint remains copyable with single quotes", async () => {
+  await withTempConfig(async () => {
+    await withMockFetch((request) => {
+      if (request.url.pathname.endsWith("/search")) {
+        return response({
+          search_id: "search-1",
+          total: 1,
+          results: [{ tool_id: "weather.tool.v1", name: "Weather" }],
+        });
+      }
+      if (request.url.pathname.endsWith("/tools/by-ids")) {
+        return response({
+          results: [
+            {
+              tool_id: "weather.tool.v1",
+              name: "Weather",
+              examples: { sample_parameters: { city: "L'Ondon" } },
+            },
+          ],
+        });
+      }
+      if (request.url.pathname.endsWith("/tools/execute")) {
+        assert.equal(request.body.max_response_size, 65536);
+        return response({
+          execution_id: "exec-1",
+          success: false,
+          error_message: "bad params",
+        });
+      }
+      throw new Error(`unexpected path ${request.url.pathname}`);
+    }, async () => {
+      await assert.rejects(
+        () => runInit(null, {
+          apiKey: "sk-test",
+          baseUrl: "https://unit.test/api/v1",
+          json: true,
+          maxSize: "65536",
+        }),
+        (err) => (
+          err instanceof CliError &&
+          err.code === "TOOL_CALL_FAILED" &&
+          err.hint.includes(`--params '{"city":"L'\\''Ondon"}'`)
+        )
+      );
+    });
+  });
+});

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -253,3 +253,50 @@ test("init call uses max size and failure hint remains copyable with single quot
     });
   });
 });
+
+test("init provider failures keep provider recovery hint", async () => {
+  await withTempConfig(async () => {
+    await withMockFetch((request) => {
+      if (request.url.pathname.endsWith("/search")) {
+        return response({
+          search_id: "search-1",
+          total: 1,
+          results: [{ tool_id: "weather.tool.v1", name: "Weather" }],
+        });
+      }
+      if (request.url.pathname.endsWith("/tools/by-ids")) {
+        return response({
+          results: [
+            {
+              tool_id: "weather.tool.v1",
+              name: "Weather",
+              examples: { sample_parameters: { city: "London" } },
+            },
+          ],
+        });
+      }
+      if (request.url.pathname.endsWith("/tools/execute")) {
+        return response({
+          execution_id: "exec-1",
+          success: false,
+          error_message: "upstream provider temporarily unavailable",
+        });
+      }
+      throw new Error(`unexpected path ${request.url.pathname}`);
+    }, async () => {
+      await assert.rejects(
+        () => runInit(null, {
+          apiKey: "sk-test",
+          baseUrl: "https://unit.test/api/v1",
+          json: true,
+        }),
+        (err) => (
+          err instanceof CliError &&
+          err.code === "PROVIDER_FAILURE" &&
+          err.hint.includes("Try another discovered capability") &&
+          !err.hint.includes("--params")
+        )
+      );
+    });
+  });
+});

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   buildNextCommands,
+  pickInitTool,
   resolveInitMaxResponseSize,
   runInit,
   shellSingleQuote,
@@ -99,6 +100,17 @@ test("init helpers respect max size and escape single quotes in shell hints", ()
     }).retry,
     `qveris call weather.tool.v1 --discovery-id search-1 --params ${quoted}`
   );
+
+  assert.equal(
+    pickInitTool(
+      [
+        { tool_id: "icons", params: [{ name: "set", required: true }] },
+        { tool_id: "weather", params: [{ name: "city", required: true }] },
+      ],
+      { parameters: { city: "London" } }
+    ).tool_id,
+    "weather"
+  );
 });
 
 test("init dry run records the provided max response size", async () => {
@@ -134,6 +146,62 @@ test("init dry run records the provided max response size", async () => {
       const payload = JSON.parse(stdout);
       const callStep = payload.steps.find((step) => step.name === "call");
       assert.equal(callStep.max_response_size, 65536);
+    });
+  });
+});
+
+test("init selects a candidate whose required params match provided params", async () => {
+  await withTempConfig(async () => {
+    await withMockFetch((request) => {
+      if (request.url.pathname.endsWith("/search")) {
+        return response({
+          search_id: "search-1",
+          total: 2,
+          results: [
+            { tool_id: "weather.icons.v1", name: "Icons" },
+            { tool_id: "weather.city.v1", name: "City Weather" },
+          ],
+        });
+      }
+      if (request.url.pathname.endsWith("/tools/by-ids")) {
+        assert.deepEqual(request.body.tool_ids, ["weather.icons.v1", "weather.city.v1"]);
+        return response({
+          results: [
+            {
+              tool_id: "weather.icons.v1",
+              name: "Icons",
+              params: [
+                { name: "set", required: true },
+                { name: "timeOfDay", required: true },
+              ],
+              examples: { sample_parameters: { set: "land", timeOfDay: "day" } },
+            },
+            {
+              tool_id: "weather.city.v1",
+              name: "City Weather",
+              params: [{ name: "city", required: true }],
+              examples: { sample_parameters: { city: "London" } },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected path ${request.url.pathname}`);
+    }, async () => {
+      const stdout = await captureStdout(() => runInit(null, {
+        apiKey: "sk-test",
+        baseUrl: "https://unit.test/api/v1",
+        json: true,
+        dryRun: true,
+        params: '{"city":"London"}',
+      }));
+      const payload = JSON.parse(stdout);
+      const inspectStep = payload.steps.find((step) => step.name === "inspect");
+      const callStep = payload.steps.find((step) => step.name === "call");
+
+      assert.equal(payload.selected_tool.tool_id, "weather.city.v1");
+      assert.equal(inspectStep.selected_reason, "params_match");
+      assert.equal(callStep.tool_id, "weather.city.v1");
+      assert.match(payload.next_commands.retry, /qveris call weather\.city\.v1/);
     });
   });
 });

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -206,6 +206,42 @@ test("init selects a candidate whose required params match provided params", asy
   });
 });
 
+test("init human summary prints selected tool after inspection", async () => {
+  await withTempConfig(async () => {
+    await withMockFetch((request) => {
+      if (request.url.pathname.endsWith("/search")) {
+        return response({
+          search_id: "search-1",
+          total: 1,
+          results: [{ tool_id: "weather.tool.v1", name: "Weather" }],
+        });
+      }
+      if (request.url.pathname.endsWith("/tools/by-ids")) {
+        return response({
+          results: [
+            {
+              tool_id: "weather.tool.v1",
+              name: "Weather",
+              params: [{ name: "city", required: true }],
+              examples: { sample_parameters: { city: "London" } },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected path ${request.url.pathname}`);
+    }, async () => {
+      const stdout = await captureStdout(() => runInit(null, {
+        apiKey: "sk-test",
+        baseUrl: "https://unit.test/api/v1",
+        dryRun: true,
+      }));
+
+      assert.match(stdout, /search_id\s+search-1/);
+      assert.match(stdout, /inspect[\s\S]*selected\s+weather\.tool\.v1/);
+    });
+  });
+});
+
 test("init call uses max size and failure hint remains copyable with single quotes", async () => {
   await withTempConfig(async () => {
     await withMockFetch((request) => {


### PR DESCRIPTION
## Summary
- add `qveris init` guided first-call wizard for auth, discover, inspect, call, and billing reconciliation guidance
- support `--json`, `--dry-run`, `--resume`, `--query`, `--tool-id`, and `--params` for recoverable first-call flows
- add action-oriented error hints and CLI/docs coverage for the new command

## Verification
- `node --check packages/cli/src/commands/init.mjs`
- `node --check packages/cli/src/main.mjs`
- `node packages/cli/bin/qveris.mjs --help`
- `XDG_CONFIG_HOME=/private/tmp/qveris-empty QVERIS_API_KEY= node packages/cli/bin/qveris.mjs init --json`
- `node packages/cli/bin/qveris.mjs init --dry-run --json --query "weather forecast API" --timeout 20`
- `node packages/cli/bin/qveris.mjs init --dry-run --json --resume --timeout 20`
- `git diff --check`

Note: the init integration checks used dry-run mode, so they exercised discover/inspect without executing a paid call.

Fixes #25