### PR TITLE
feat: add ecosystem templates and manifest validation

### DIFF
--- a/.github/workflows/ecosystem-validate.yml
+++ b/.github/workflows/ecosystem-validate.yml
@@ -1,0 +1,36 @@
+name: Validate ecosystem manifests
+
+on:
+  pull_request:
+    paths:
+      - "ecosystem/**"
+      - "recipes/**"
+      - "scripts/validate-ecosystem-manifests.mjs"
+      - ".github/workflows/ecosystem-validate.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "ecosystem/**"
+      - "recipes/**"
+      - "scripts/validate-ecosystem-manifests.mjs"
+      - ".github/workflows/ecosystem-validate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate manifests
+        run: node scripts/validate-ecosystem-manifests.mjs

--- a/.github/workflows/ecosystem-validate.yml
+++ b/.github/workflows/ecosystem-validate.yml
@@ -6,6 +6,7 @@ on:
       - "ecosystem/**"
       - "recipes/**"
       - "scripts/validate-ecosystem-manifests.mjs"
+      - "scripts/test-ecosystem-validator.mjs"
       - ".github/workflows/ecosystem-validate.yml"
   push:
     branches:
@@ -14,6 +15,7 @@ on:
       - "ecosystem/**"
       - "recipes/**"
       - "scripts/validate-ecosystem-manifests.mjs"
+      - "scripts/test-ecosystem-validator.mjs"
       - ".github/workflows/ecosystem-validate.yml"
 
 permissions:
@@ -34,3 +36,6 @@ jobs:
 
       - name: Validate manifests
         run: node scripts/validate-ecosystem-manifests.mjs
+
+      - name: Test manifest validator
+        run: node scripts/test-ecosystem-validator.mjs

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -1,0 +1,102 @@
+name: Publish Python SDK to PyPI
+
+on:
+  push:
+    tags:
+      - "python-sdk-v*" # Trigger on tags like python-sdk-v0.1.0, python-sdk-v1.0.0
+
+permissions:
+  contents: write # For creating GitHub Releases
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/python-sdk
+
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: packages/python-sdk/uv.lock
+
+      - name: Run tests
+        run: uv run --extra dev pytest
+
+      - name: Compile package and examples
+        run: uv run python -m compileall qveris examples
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/python-sdk
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: packages/python-sdk/uv.lock
+
+      - name: Verify package version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#python-sdk-v}"
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python-sdk/dist
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "QVeris Python SDK v${{ env.VERSION }}"
+          body: |
+            ## Install
+
+            ```bash
+            pip install qveris==${{ env.VERSION }}
+            ```
+
+            ## Highlights
+
+            - Publishes the typed Python SDK for the QVeris Agent External Data & Tool Harness.
+            - Includes discover, inspect, call, usage, and ledger client methods.
+            - Includes the built-in agent runtime and OpenAI-compatible provider support.
+
+            See [README](packages/python-sdk/README.md) for usage.
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ This repository (`QVerisAI/qveris-agent-toolkit`) is the primary monorepo for QV
 | Agent docs | [`agent/`](agent) | — |
 | Skills | [`skills/`](skills) | — |
 
+### Recipes and ecosystem manifests
+
+Use [`recipes/`](recipes) for copy-paste workflow templates across finance research, risk/compliance, crypto monitoring, data analysis, and developer automation.
+
+Use [`ecosystem/`](ecosystem) for the versioned QVeris manifest schema, marketplace-ready listing fields, permission declarations, contribution guide, and compatibility matrix.
+
 ### Other repositories
 
 | Repository | Description |

--- a/ecosystem/CONTRIBUTING.md
+++ b/ecosystem/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Ecosystem Contribution Guide
+
+Use this guide for adding QVeris recipes, skills, plugins, or marketplace listing metadata.
+
+## Add A Recipe
+
+1. Create a directory under `recipes/<kebab-case-name>/`.
+2. Add `README.md` with a copy-paste complete CLI path and a Python SDK path when relevant.
+3. Add `qveris.manifest.json` using `ecosystem/manifest.schema.json`.
+4. Declare every permission needed by the workflow:
+   - `capability.discover` for finding capabilities.
+   - `capability.inspect` for reading parameter, billing, and quality metadata.
+   - `capability.call` only when the recipe executes a capability.
+   - `capability.audit` when the recipe reads usage history or credits ledger data.
+5. Add marketplace fields that can be consumed by a future listing service.
+6. Run `node scripts/validate-ecosystem-manifests.mjs`.
+
+## Metadata Rules
+
+- Keep `id` stable once published.
+- Use semver for `version`.
+- Set `status` to `experimental`, `beta`, or `stable`.
+- Keep `summary` under 160 characters.
+- Prefer product-neutral use-case language in `marketplace.use_cases`.
+- Do not declare a permission unless the workflow needs it.
+
+## Compatibility
+
+Update [`compatibility.md`](compatibility.md) when a recipe requires a newer CLI, MCP, Python SDK, skill, or plugin surface.
+
+## Review Checklist
+
+- Manifest validates locally.
+- README commands are copy-paste complete.
+- Example paths in the manifest exist.
+- Permission reasons explain the user-facing need.
+- Marketplace fields are suitable for website ingestion without rewriting.

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -1,0 +1,43 @@
+# QVeris Ecosystem Manifests
+
+QVeris ecosystem entries use a versioned manifest to describe recipes, skills, plugins, and marketplace-ready listings with the same metadata surface.
+
+The current schema is [`manifest.schema.json`](manifest.schema.json), version `2026-05-13`.
+
+## What The Manifest Covers
+
+- Identity: stable `id`, `kind`, `name`, `version`, and lifecycle `status`.
+- Marketplace listing fields: `listing_slug`, `headline`, `audience`, `use_cases`, `integration_methods`, and `primary_cta`.
+- Permissions: QVeris capability scopes, network hosts, local files, and secrets.
+- Compatibility: minimum CLI, MCP, Python SDK, skill, or plugin versions.
+- Docs and examples: required local README plus runnable or copy-paste complete commands.
+
+## Validation
+
+Run the validator from the repository root:
+
+```bash
+node scripts/validate-ecosystem-manifests.mjs
+```
+
+Validate a specific manifest or directory:
+
+```bash
+node scripts/validate-ecosystem-manifests.mjs recipes/finance-research/qveris.manifest.json
+node scripts/validate-ecosystem-manifests.mjs recipes
+```
+
+CI runs the same validator on recipe, schema, and validator changes. A manifest fails validation when required metadata is missing, permission declarations are incomplete, examples point at missing docs, or marketplace listing fields are absent.
+
+## Manifest Templates
+
+- [`templates/skill-manifest.template.json`](templates/skill-manifest.template.json)
+- [`templates/plugin-manifest.template.json`](templates/plugin-manifest.template.json)
+
+Use these as starting points, then replace every placeholder before committing a real `qveris.manifest.json`.
+
+## Related Docs
+
+- [Contribution guide](CONTRIBUTING.md)
+- [Compatibility matrix](compatibility.md)
+- [Recipes](../recipes/README.md)

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -29,6 +29,12 @@ node scripts/validate-ecosystem-manifests.mjs recipes
 
 CI runs the same validator on recipe, schema, and validator changes. A manifest fails validation when required metadata is missing, permission declarations are incomplete, examples point at missing docs, or marketplace listing fields are absent.
 
+Run validator regression tests:
+
+```bash
+node scripts/test-ecosystem-validator.mjs
+```
+
 ## Manifest Templates
 
 - [`templates/skill-manifest.template.json`](templates/skill-manifest.template.json)

--- a/ecosystem/compatibility.md
+++ b/ecosystem/compatibility.md
@@ -1,0 +1,19 @@
+# Ecosystem Compatibility Matrix
+
+The ecosystem manifest is designed to keep recipes, skills, plugins, and marketplace listings aligned across QVeris integration surfaces.
+
+| Surface | Minimum version | Used for |
+|---------|-----------------|----------|
+| Manifest schema | `2026-05-13` | Shared metadata, permissions, docs, examples, and marketplace listing fields |
+| QVeris CLI | `>=0.5.0` | `discover`, `inspect`, `call`, `usage`, `ledger`, and `init` recipe commands |
+| QVeris MCP server | `>=0.6.0` | Canonical MCP tools plus usage and credits ledger audit tools |
+| QVeris Python SDK | `>=0.1.0` | Typed `QverisClient`, `Agent`, and audit methods |
+| QVeris agent skill | `>=0.1.0` | Agent-facing discover, inspect, call, and audit workflow guidance |
+
+## Compatibility Policy
+
+- Recipe manifests should declare every surface they depend on.
+- Existing recipe IDs remain stable across recipe version updates.
+- Deprecated tool aliases must not be used in new manifests or examples.
+- New required manifest fields require a new `schema_version`.
+- Additive marketplace fields may be introduced without invalidating the `2026-05-13` schema only when the validator treats them as optional.

--- a/ecosystem/manifest.schema.json
+++ b/ecosystem/manifest.schema.json
@@ -1,0 +1,284 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qveris.ai/schemas/ecosystem-manifest-2026-05-13.json",
+  "title": "QVeris Ecosystem Manifest",
+  "description": "Versioned manifest for QVeris recipes, skills, plugins, and marketplace-ready listings.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "kind",
+    "name",
+    "summary",
+    "description",
+    "version",
+    "status",
+    "owner",
+    "tags",
+    "categories",
+    "permissions",
+    "compatibility",
+    "marketplace",
+    "docs",
+    "examples"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "2026-05-13"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^qveris\\.(recipe|skill|plugin)\\.[a-z0-9][a-z0-9-]*(\\.[a-z0-9][a-z0-9-]*)*$"
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["recipe", "skill", "plugin"]
+    },
+    "name": {
+      "type": "string",
+      "minLength": 3
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 20,
+      "maxLength": 160
+    },
+    "description": {
+      "type": "string",
+      "minLength": 40
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["experimental", "beta", "stable"]
+    },
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 2
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      },
+      "uniqueItems": true
+    },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["finance", "risk", "crypto", "analytics", "developer-tools", "automation", "compliance"]
+      },
+      "uniqueItems": true
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["qveris"],
+      "properties": {
+        "qveris": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/permission"
+          }
+        },
+        "network": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/network_permission"
+          }
+        },
+        "local_files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/permission"
+          }
+        },
+        "secrets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/permission"
+          }
+        }
+      }
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minProperties": 1,
+      "properties": {
+        "cli": {
+          "type": "string"
+        },
+        "mcp": {
+          "type": "string"
+        },
+        "python_sdk": {
+          "type": "string"
+        },
+        "agent_skill": {
+          "type": "string"
+        }
+      }
+    },
+    "marketplace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "listing_slug",
+        "headline",
+        "audience",
+        "use_cases",
+        "integration_methods",
+        "primary_cta"
+      ],
+      "properties": {
+        "listing_slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "headline": {
+          "type": "string",
+          "minLength": 12,
+          "maxLength": 120
+        },
+        "audience": {
+          "type": "string",
+          "minLength": 10
+        },
+        "use_cases": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "string",
+            "minLength": 8
+          }
+        },
+        "integration_methods": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["cli", "mcp", "python-sdk", "rest-api", "skill", "plugin"]
+          },
+          "uniqueItems": true
+        },
+        "primary_cta": {
+          "type": "string",
+          "minLength": 3
+        },
+        "docs_url": {
+          "type": "string"
+        }
+      }
+    },
+    "docs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["readme"],
+      "properties": {
+        "readme": {
+          "type": "string",
+          "minLength": 1
+        },
+        "quickstart": {
+          "type": "string"
+        },
+        "configuration": {
+          "type": "string"
+        }
+      }
+    },
+    "examples": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "path", "language", "command"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 3
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "language": {
+            "type": "string",
+            "enum": ["shell", "python", "typescript", "json", "markdown"]
+          },
+          "command": {
+            "type": "string",
+            "minLength": 5
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "permission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "reason", "required"],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "minLength": 3
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 12
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "network_permission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "reason", "required"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "minLength": 3
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 12
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/ecosystem/templates/plugin-manifest.template.json
+++ b/ecosystem/templates/plugin-manifest.template.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../manifest.schema.json",
+  "schema_version": "2026-05-13",
+  "id": "qveris.plugin.replace-with-plugin-slug",
+  "kind": "plugin",
+  "name": "Replace With Plugin Name",
+  "summary": "Replace with a concise plugin summary for developers and marketplace listings.",
+  "description": "Replace with a complete description of the plugin, the integration surface it adds, and the expected runtime requirements.",
+  "version": "0.1.0",
+  "status": "experimental",
+  "owner": {
+    "name": "Your Team",
+    "url": "https://example.com"
+  },
+  "tags": ["replace-me", "qveris"],
+  "categories": ["developer-tools"],
+  "permissions": {
+    "qveris": [
+      {
+        "scope": "capability.discover",
+        "reason": "Find relevant external capabilities for this plugin workflow.",
+        "required": true
+      }
+    ],
+    "network": [
+      {
+        "host": "qveris.ai",
+        "reason": "Use QVeris APIs for capability discovery and execution.",
+        "required": true
+      }
+    ]
+  },
+  "compatibility": {
+    "cli": ">=0.5.0",
+    "python_sdk": ">=0.1.0"
+  },
+  "marketplace": {
+    "listing_slug": "replace-with-plugin-slug",
+    "headline": "Replace with a marketplace-ready headline.",
+    "audience": "Developers and agents who need this integration.",
+    "use_cases": ["Replace with use case one", "Replace with use case two"],
+    "integration_methods": ["plugin", "cli", "python-sdk"],
+    "primary_cta": "Install plugin"
+  },
+  "docs": {
+    "readme": "README.md"
+  },
+  "examples": [
+    {
+      "name": "CLI smoke test",
+      "path": "README.md",
+      "language": "shell",
+      "command": "qveris discover \"replace with capability query\" --limit 3"
+    }
+  ]
+}

--- a/ecosystem/templates/skill-manifest.template.json
+++ b/ecosystem/templates/skill-manifest.template.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../manifest.schema.json",
+  "schema_version": "2026-05-13",
+  "id": "qveris.skill.replace-with-skill-slug",
+  "kind": "skill",
+  "name": "Replace With Skill Name",
+  "summary": "Replace with a concise skill summary for agents and marketplace listings.",
+  "description": "Replace with a complete description of the skill, what it helps agents do, and when it should be used.",
+  "version": "0.1.0",
+  "status": "experimental",
+  "owner": {
+    "name": "Your Team",
+    "url": "https://example.com"
+  },
+  "tags": ["replace-me", "qveris"],
+  "categories": ["automation"],
+  "permissions": {
+    "qveris": [
+      {
+        "scope": "capability.discover",
+        "reason": "Find relevant external capabilities for this skill workflow.",
+        "required": true
+      }
+    ],
+    "network": [
+      {
+        "host": "qveris.ai",
+        "reason": "Use QVeris APIs for capability discovery and execution.",
+        "required": true
+      }
+    ]
+  },
+  "compatibility": {
+    "agent_skill": ">=0.1.0",
+    "mcp": ">=0.6.0"
+  },
+  "marketplace": {
+    "listing_slug": "replace-with-skill-slug",
+    "headline": "Replace with a marketplace-ready headline.",
+    "audience": "Agents and developers who need this workflow.",
+    "use_cases": ["Replace with use case one", "Replace with use case two"],
+    "integration_methods": ["skill", "mcp"],
+    "primary_cta": "Install skill"
+  },
+  "docs": {
+    "readme": "README.md"
+  },
+  "examples": [
+    {
+      "name": "Agent prompt",
+      "path": "README.md",
+      "language": "markdown",
+      "command": "Use this skill to discover and inspect a capability for <task>."
+    }
+  ]
+}

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,22 @@
+# QVeris Recipes
+
+Recipes are copy-paste complete workflow templates for the QVeris Agent External Data & Tool Harness. Each recipe includes:
+
+- `README.md` with CLI and Python SDK paths.
+- `qveris.manifest.json` with permissions, compatibility, examples, and marketplace listing fields.
+
+Validate all recipes:
+
+```bash
+node scripts/validate-ecosystem-manifests.mjs
+```
+
+## Included Recipes
+
+| Recipe | Scenario | Primary integration |
+|--------|----------|---------------------|
+| [Finance research](finance-research/README.md) | Public company quote and market data research | CLI, Python SDK |
+| [Risk and compliance](risk-compliance/README.md) | Sanctions, adverse media, and entity screening | CLI, Python SDK |
+| [Crypto monitoring](crypto-monitoring/README.md) | Token price and market movement monitoring | CLI, Python SDK |
+| [Data analysis](data-analysis/README.md) | Dataset enrichment with external data | CLI, Python SDK |
+| [Developer automation](developer-automation/README.md) | Repository, issue, package, or API metadata lookup | CLI, Python SDK |

--- a/recipes/crypto-monitoring/README.md
+++ b/recipes/crypto-monitoring/README.md
@@ -1,0 +1,52 @@
+# Crypto Monitoring Recipe
+
+Use this recipe to discover and call a cryptocurrency market data capability.
+
+## Quickstart
+
+```bash
+export QVERIS_API_KEY="sk-..."
+qveris init --query "cryptocurrency market price and volume API" --params '{"symbol":"BTC","currency":"USD"}' --json
+```
+
+## CLI
+
+```bash
+qveris init \
+  --query "cryptocurrency market price and volume API" \
+  --params '{"symbol":"BTC","currency":"USD"}' \
+  --max-response-size 20480 \
+  --json
+```
+
+Use audit commands after execution:
+
+```bash
+qveris usage --execution-id "exec_..." --summary --json
+qveris ledger --limit 5 --summary --json
+```
+
+## Python SDK
+
+```python
+import asyncio
+from qveris import QverisClient
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        discovered = await client.discover("cryptocurrency market price and volume API", limit=5)
+        tool = discovered.results[0]
+        inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
+        selected = inspected.results[0] if inspected.results else tool
+        result = await client.call(
+            selected.tool_id,
+            {"symbol": "BTC", "currency": "USD"},
+            search_id=discovered.search_id,
+        )
+        print(result.model_dump())
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```

--- a/recipes/crypto-monitoring/README.md
+++ b/recipes/crypto-monitoring/README.md
@@ -36,6 +36,9 @@ async def main() -> None:
     client = QverisClient()
     try:
         discovered = await client.discover("cryptocurrency market price and volume API", limit=5)
+        if not discovered.results:
+            print("No capabilities found.")
+            return
         tool = discovered.results[0]
         inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
         selected = inspected.results[0] if inspected.results else tool

--- a/recipes/crypto-monitoring/qveris.manifest.json
+++ b/recipes/crypto-monitoring/qveris.manifest.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "../../ecosystem/manifest.schema.json",
+  "schema_version": "2026-05-13",
+  "id": "qveris.recipe.crypto-monitoring",
+  "kind": "recipe",
+  "name": "Crypto Monitoring",
+  "summary": "Discover token price and crypto market data capabilities for monitoring workflows.",
+  "description": "A copy-paste recipe for finding cryptocurrency price and market data capabilities, calling a selected provider, and checking final usage records.",
+  "version": "0.1.0",
+  "status": "beta",
+  "owner": {
+    "name": "QVeris",
+    "url": "https://qveris.ai"
+  },
+  "tags": ["crypto", "market-data", "monitoring", "tokens"],
+  "categories": ["crypto", "analytics"],
+  "permissions": {
+    "qveris": [
+      {
+        "scope": "capability.discover",
+        "reason": "Find cryptocurrency market data capabilities by natural-language intent.",
+        "required": true
+      },
+      {
+        "scope": "capability.inspect",
+        "reason": "Read required token, currency, billing, and quality metadata before execution.",
+        "required": true
+      },
+      {
+        "scope": "capability.call",
+        "reason": "Execute the selected crypto market data capability with token parameters.",
+        "required": true
+      },
+      {
+        "scope": "capability.audit",
+        "reason": "Verify usage and ledger records after execution.",
+        "required": false
+      }
+    ],
+    "network": [
+      {
+        "host": "qveris.ai",
+        "reason": "Call QVeris API endpoints for discovery, execution, and audit.",
+        "required": true
+      }
+    ],
+    "secrets": [
+      {
+        "scope": "QVERIS_API_KEY",
+        "reason": "Authenticate QVeris API requests.",
+        "required": true
+      }
+    ]
+  },
+  "compatibility": {
+    "cli": ">=0.5.0",
+    "mcp": ">=0.6.0",
+    "python_sdk": ">=0.1.0",
+    "agent_skill": ">=0.1.0"
+  },
+  "marketplace": {
+    "listing_slug": "crypto-monitoring",
+    "headline": "Crypto market data discovery for token monitoring.",
+    "audience": "Agents and developers that need token price or crypto market data APIs.",
+    "use_cases": ["Fetch BTC market data", "Compare crypto data providers", "Audit execution charges"],
+    "integration_methods": ["cli", "python-sdk", "mcp", "skill"],
+    "primary_cta": "Run crypto recipe",
+    "docs_url": "recipes/crypto-monitoring/README.md"
+  },
+  "docs": {
+    "readme": "README.md",
+    "quickstart": "README.md#quickstart"
+  },
+  "examples": [
+    {
+      "name": "CLI first call",
+      "path": "README.md#cli",
+      "language": "shell",
+      "command": "qveris init --query \"cryptocurrency market price and volume API\" --params '{\"symbol\":\"BTC\",\"currency\":\"USD\"}' --json"
+    },
+    {
+      "name": "Python SDK workflow",
+      "path": "README.md#python-sdk",
+      "language": "python",
+      "command": "python crypto_monitoring.py"
+    }
+  ]
+}

--- a/recipes/data-analysis/README.md
+++ b/recipes/data-analysis/README.md
@@ -1,0 +1,48 @@
+# Data Analysis Enrichment Recipe
+
+Use this recipe to test an external data enrichment capability before applying it to a larger dataset.
+
+## Quickstart
+
+```bash
+export QVERIS_API_KEY="sk-..."
+qveris init --query "company domain enrichment API" --params '{"domain":"qveris.ai"}' --json
+```
+
+## CLI
+
+```bash
+qveris init \
+  --query "company domain enrichment API" \
+  --params '{"domain":"qveris.ai"}' \
+  --max-response-size 20480 \
+  --json
+```
+
+Audit the sample call:
+
+```bash
+qveris usage --execution-id "exec_..." --summary --json
+qveris ledger --limit 5 --summary --json
+```
+
+## Python SDK
+
+```python
+import asyncio
+from qveris import QverisClient
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        discovered = await client.discover("company domain enrichment API", limit=5)
+        tool = discovered.results[0]
+        inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
+        selected = inspected.results[0] if inspected.results else tool
+        result = await client.call(selected.tool_id, {"domain": "qveris.ai"}, search_id=discovered.search_id)
+        print(result.model_dump())
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```

--- a/recipes/data-analysis/README.md
+++ b/recipes/data-analysis/README.md
@@ -36,6 +36,9 @@ async def main() -> None:
     client = QverisClient()
     try:
         discovered = await client.discover("company domain enrichment API", limit=5)
+        if not discovered.results:
+            print("No capabilities found.")
+            return
         tool = discovered.results[0]
         inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
         selected = inspected.results[0] if inspected.results else tool

--- a/recipes/data-analysis/qveris.manifest.json
+++ b/recipes/data-analysis/qveris.manifest.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "../../ecosystem/manifest.schema.json",
+  "schema_version": "2026-05-13",
+  "id": "qveris.recipe.data-analysis",
+  "kind": "recipe",
+  "name": "Data Analysis Enrichment",
+  "summary": "Enrich datasets by discovering and calling external data capabilities.",
+  "description": "A copy-paste recipe for using QVeris to discover enrichment APIs, inspect their parameters, run a sample row, and audit usage records.",
+  "version": "0.1.0",
+  "status": "beta",
+  "owner": {
+    "name": "QVeris",
+    "url": "https://qveris.ai"
+  },
+  "tags": ["data-analysis", "enrichment", "datasets", "automation"],
+  "categories": ["analytics", "automation"],
+  "permissions": {
+    "qveris": [
+      {
+        "scope": "capability.discover",
+        "reason": "Find enrichment capabilities for a dataset field or entity.",
+        "required": true
+      },
+      {
+        "scope": "capability.inspect",
+        "reason": "Inspect required enrichment inputs and output metadata before execution.",
+        "required": true
+      },
+      {
+        "scope": "capability.call",
+        "reason": "Execute the selected enrichment capability on a sample record.",
+        "required": true
+      },
+      {
+        "scope": "capability.audit",
+        "reason": "Verify usage and ledger records after enrichment execution.",
+        "required": false
+      }
+    ],
+    "network": [
+      {
+        "host": "qveris.ai",
+        "reason": "Call QVeris API endpoints for discovery, execution, and audit.",
+        "required": true
+      }
+    ],
+    "secrets": [
+      {
+        "scope": "QVERIS_API_KEY",
+        "reason": "Authenticate QVeris API requests.",
+        "required": true
+      }
+    ]
+  },
+  "compatibility": {
+    "cli": ">=0.5.0",
+    "mcp": ">=0.6.0",
+    "python_sdk": ">=0.1.0",
+    "agent_skill": ">=0.1.0"
+  },
+  "marketplace": {
+    "listing_slug": "data-analysis",
+    "headline": "External data enrichment for analysis workflows.",
+    "audience": "Data analysts and agents that need to enrich records with external APIs.",
+    "use_cases": ["Enrich company domains", "Inspect API output structure", "Audit usage for sampled rows"],
+    "integration_methods": ["cli", "python-sdk", "mcp", "skill"],
+    "primary_cta": "Run data recipe",
+    "docs_url": "recipes/data-analysis/README.md"
+  },
+  "docs": {
+    "readme": "README.md",
+    "quickstart": "README.md#quickstart"
+  },
+  "examples": [
+    {
+      "name": "CLI first call",
+      "path": "README.md#cli",
+      "language": "shell",
+      "command": "qveris init --query \"company domain enrichment API\" --params '{\"domain\":\"qveris.ai\"}' --json"
+    },
+    {
+      "name": "Python SDK workflow",
+      "path": "README.md#python-sdk",
+      "language": "python",
+      "command": "python data_analysis.py"
+    }
+  ]
+}

--- a/recipes/developer-automation/README.md
+++ b/recipes/developer-automation/README.md
@@ -1,0 +1,52 @@
+# Developer Automation Recipe
+
+Use this recipe to discover and test a developer-facing API, such as repository metadata, package metadata, release lookup, or issue search.
+
+## Quickstart
+
+```bash
+export QVERIS_API_KEY="sk-..."
+qveris init --query "GitHub repository metadata API" --params '{"owner":"QVerisAI","repo":"qveris-agent-toolkit"}' --json
+```
+
+## CLI
+
+```bash
+qveris init \
+  --query "GitHub repository metadata API" \
+  --params '{"owner":"QVerisAI","repo":"qveris-agent-toolkit"}' \
+  --max-response-size 20480 \
+  --json
+```
+
+Audit the call:
+
+```bash
+qveris usage --execution-id "exec_..." --summary --json
+qveris ledger --limit 5 --summary --json
+```
+
+## Python SDK
+
+```python
+import asyncio
+from qveris import QverisClient
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        discovered = await client.discover("GitHub repository metadata API", limit=5)
+        tool = discovered.results[0]
+        inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
+        selected = inspected.results[0] if inspected.results else tool
+        result = await client.call(
+            selected.tool_id,
+            {"owner": "QVerisAI", "repo": "qveris-agent-toolkit"},
+            search_id=discovered.search_id,
+        )
+        print(result.model_dump())
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```

--- a/recipes/developer-automation/README.md
+++ b/recipes/developer-automation/README.md
@@ -36,6 +36,9 @@ async def main() -> None:
     client = QverisClient()
     try:
         discovered = await client.discover("GitHub repository metadata API", limit=5)
+        if not discovered.results:
+            print("No capabilities found.")
+            return
         tool = discovered.results[0]
         inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
         selected = inspected.results[0] if inspected.results else tool

--- a/recipes/developer-automation/qveris.manifest.json
+++ b/recipes/developer-automation/qveris.manifest.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "../../ecosystem/manifest.schema.json",
+  "schema_version": "2026-05-13",
+  "id": "qveris.recipe.developer-automation",
+  "kind": "recipe",
+  "name": "Developer Automation",
+  "summary": "Discover and call developer-facing APIs for repository and package automation.",
+  "description": "A copy-paste recipe for finding developer automation capabilities, inspecting required repository or package parameters, executing a candidate, and auditing usage.",
+  "version": "0.1.0",
+  "status": "beta",
+  "owner": {
+    "name": "QVeris",
+    "url": "https://qveris.ai"
+  },
+  "tags": ["developer-tools", "automation", "repositories", "packages"],
+  "categories": ["developer-tools", "automation"],
+  "permissions": {
+    "qveris": [
+      {
+        "scope": "capability.discover",
+        "reason": "Find developer automation APIs by natural-language intent.",
+        "required": true
+      },
+      {
+        "scope": "capability.inspect",
+        "reason": "Inspect required repository or package parameters before execution.",
+        "required": true
+      },
+      {
+        "scope": "capability.call",
+        "reason": "Execute the selected developer automation capability with repository inputs.",
+        "required": true
+      },
+      {
+        "scope": "capability.audit",
+        "reason": "Verify usage and ledger records after execution.",
+        "required": false
+      }
+    ],
+    "network": [
+      {
+        "host": "qveris.ai",
+        "reason": "Call QVeris API endpoints for discovery, execution, and audit.",
+        "required": true
+      }
+    ],
+    "secrets": [
+      {
+        "scope": "QVERIS_API_KEY",
+        "reason": "Authenticate QVeris API requests.",
+        "required": true
+      }
+    ]
+  },
+  "compatibility": {
+    "cli": ">=0.5.0",
+    "mcp": ">=0.6.0",
+    "python_sdk": ">=0.1.0",
+    "agent_skill": ">=0.1.0"
+  },
+  "marketplace": {
+    "listing_slug": "developer-automation",
+    "headline": "External developer API discovery for automation workflows.",
+    "audience": "Developers and agents that need repository, issue, package, or API metadata.",
+    "use_cases": ["Lookup repository metadata", "Inspect package or release data", "Audit execution charges"],
+    "integration_methods": ["cli", "python-sdk", "mcp", "skill"],
+    "primary_cta": "Run developer recipe",
+    "docs_url": "recipes/developer-automation/README.md"
+  },
+  "docs": {
+    "readme": "README.md",
+    "quickstart": "README.md#quickstart"
+  },
+  "examples": [
+    {
+      "name": "CLI first call",
+      "path": "README.md#cli",
+      "language": "shell",
+      "command": "qveris init --query \"GitHub repository metadata API\" --params '{\"owner\":\"QVerisAI\",\"repo\":\"qveris-agent-toolkit\"}' --json"
+    },
+    {
+      "name": "Python SDK workflow",
+      "path": "README.md#python-sdk",
+      "language": "python",
+      "command": "python developer_automation.py"
+    }
+  ]
+}

--- a/recipes/finance-research/README.md
+++ b/recipes/finance-research/README.md
@@ -1,0 +1,51 @@
+# Finance Research Recipe
+
+Use this recipe to discover, inspect, call, and audit a public company market data capability.
+
+## Quickstart
+
+```bash
+export QVERIS_API_KEY="sk-..."
+qveris init --query "public company stock quote and market data API" --params '{"symbol":"AAPL"}' --json
+```
+
+## CLI
+
+Use the first-call flow when you want QVeris to discover, inspect, select, and call a matching capability in one command:
+
+```bash
+qveris init \
+  --query "public company stock quote and market data API" \
+  --params '{"symbol":"AAPL"}' \
+  --max-response-size 20480 \
+  --json
+```
+
+After a call returns an `execution_id`, audit charge outcome:
+
+```bash
+qveris usage --execution-id "exec_..." --summary --json
+qveris ledger --limit 5 --summary --json
+```
+
+## Python SDK
+
+```python
+import asyncio
+from qveris import QverisClient
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        discovered = await client.discover("public company stock quote and market data API", limit=5)
+        tool = discovered.results[0]
+        inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
+        selected = inspected.results[0] if inspected.results else tool
+        result = await client.call(selected.tool_id, {"symbol": "AAPL"}, search_id=discovered.search_id)
+        print(result.model_dump())
+        print((await client.usage(execution_id=result.execution_id, summary=True)).model_dump())
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```

--- a/recipes/finance-research/README.md
+++ b/recipes/finance-research/README.md
@@ -38,6 +38,9 @@ async def main() -> None:
     client = QverisClient()
     try:
         discovered = await client.discover("public company stock quote and market data API", limit=5)
+        if not discovered.results:
+            print("No capabilities found.")
+            return
         tool = discovered.results[0]
         inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
         selected = inspected.results[0] if inspected.results else tool

--- a/recipes/finance-research/qveris.manifest.json
+++ b/recipes/finance-research/qveris.manifest.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "../../ecosystem/manifest.schema.json",
+  "schema_version": "2026-05-13",
+  "id": "qveris.recipe.finance-research",
+  "kind": "recipe",
+  "name": "Finance Research",
+  "summary": "Discover and call market data capabilities for public company research workflows.",
+  "description": "A copy-paste recipe for finding a stock quote or market data capability, inspecting its parameters, executing it, and auditing the final charge outcome.",
+  "version": "0.1.0",
+  "status": "beta",
+  "owner": {
+    "name": "QVeris",
+    "url": "https://qveris.ai"
+  },
+  "tags": ["finance", "market-data", "stocks", "research"],
+  "categories": ["finance", "analytics"],
+  "permissions": {
+    "qveris": [
+      {
+        "scope": "capability.discover",
+        "reason": "Find public company market data capabilities by natural-language intent.",
+        "required": true
+      },
+      {
+        "scope": "capability.inspect",
+        "reason": "Read parameter, billing, quality, and example metadata before execution.",
+        "required": true
+      },
+      {
+        "scope": "capability.call",
+        "reason": "Execute the selected market data capability with a stock symbol.",
+        "required": true
+      },
+      {
+        "scope": "capability.audit",
+        "reason": "Verify usage and ledger records after execution.",
+        "required": false
+      }
+    ],
+    "network": [
+      {
+        "host": "qveris.ai",
+        "reason": "Call QVeris API endpoints for discovery, execution, and audit.",
+        "required": true
+      }
+    ],
+    "secrets": [
+      {
+        "scope": "QVERIS_API_KEY",
+        "reason": "Authenticate QVeris API requests.",
+        "required": true
+      }
+    ]
+  },
+  "compatibility": {
+    "cli": ">=0.5.0",
+    "mcp": ">=0.6.0",
+    "python_sdk": ">=0.1.0",
+    "agent_skill": ">=0.1.0"
+  },
+  "marketplace": {
+    "listing_slug": "finance-research",
+    "headline": "Market data discovery and execution for public company research.",
+    "audience": "Analysts and agents that need quick access to stock quote or market data APIs.",
+    "use_cases": ["Fetch current quote data", "Compare candidate market data providers", "Audit final credit charges"],
+    "integration_methods": ["cli", "python-sdk", "mcp", "skill"],
+    "primary_cta": "Run finance recipe",
+    "docs_url": "recipes/finance-research/README.md"
+  },
+  "docs": {
+    "readme": "README.md",
+    "quickstart": "README.md#quickstart"
+  },
+  "examples": [
+    {
+      "name": "CLI first call",
+      "path": "README.md#cli",
+      "language": "shell",
+      "command": "qveris init --query \"public company stock quote and market data API\" --params '{\"symbol\":\"AAPL\"}' --json"
+    },
+    {
+      "name": "Python SDK workflow",
+      "path": "README.md#python-sdk",
+      "language": "python",
+      "command": "python finance_research.py"
+    }
+  ]
+}

--- a/recipes/risk-compliance/README.md
+++ b/recipes/risk-compliance/README.md
@@ -1,0 +1,48 @@
+# Risk And Compliance Recipe
+
+Use this recipe to find and test a sanctions, adverse media, or entity screening capability.
+
+## Quickstart
+
+```bash
+export QVERIS_API_KEY="sk-..."
+qveris init --query "sanctions screening or adverse media compliance API" --params '{"name":"Acme Trading Ltd"}' --json
+```
+
+## CLI
+
+```bash
+qveris init \
+  --query "sanctions screening or adverse media compliance API" \
+  --params '{"name":"Acme Trading Ltd"}' \
+  --max-response-size 20480 \
+  --json
+```
+
+Audit the execution after you receive `execution_id`:
+
+```bash
+qveris usage --execution-id "exec_..." --summary --json
+qveris ledger --limit 5 --summary --json
+```
+
+## Python SDK
+
+```python
+import asyncio
+from qveris import QverisClient
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        discovered = await client.discover("sanctions screening or adverse media compliance API", limit=5)
+        tool = discovered.results[0]
+        inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
+        selected = inspected.results[0] if inspected.results else tool
+        result = await client.call(selected.tool_id, {"name": "Acme Trading Ltd"}, search_id=discovered.search_id)
+        print(result.model_dump())
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```

--- a/recipes/risk-compliance/README.md
+++ b/recipes/risk-compliance/README.md
@@ -36,6 +36,9 @@ async def main() -> None:
     client = QverisClient()
     try:
         discovered = await client.discover("sanctions screening or adverse media compliance API", limit=5)
+        if not discovered.results:
+            print("No capabilities found.")
+            return
         tool = discovered.results[0]
         inspected = await client.inspect(tool.tool_id, search_id=discovered.search_id)
         selected = inspected.results[0] if inspected.results else tool

--- a/recipes/risk-compliance/qveris.manifest.json
+++ b/recipes/risk-compliance/qveris.manifest.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "../../ecosystem/manifest.schema.json",
+  "schema_version": "2026-05-13",
+  "id": "qveris.recipe.risk-compliance",
+  "kind": "recipe",
+  "name": "Risk And Compliance Screening",
+  "summary": "Find and call compliance screening capabilities for entity risk checks.",
+  "description": "A copy-paste recipe for discovering sanctions, adverse media, or entity screening capabilities, executing a candidate, and auditing charge outcome.",
+  "version": "0.1.0",
+  "status": "beta",
+  "owner": {
+    "name": "QVeris",
+    "url": "https://qveris.ai"
+  },
+  "tags": ["risk", "compliance", "sanctions", "screening"],
+  "categories": ["risk", "compliance"],
+  "permissions": {
+    "qveris": [
+      {
+        "scope": "capability.discover",
+        "reason": "Find compliance screening capabilities by natural-language intent.",
+        "required": true
+      },
+      {
+        "scope": "capability.inspect",
+        "reason": "Inspect required identity fields, examples, billing, and quality metadata.",
+        "required": true
+      },
+      {
+        "scope": "capability.call",
+        "reason": "Execute the selected compliance screening capability with entity details.",
+        "required": true
+      },
+      {
+        "scope": "capability.audit",
+        "reason": "Verify usage and ledger records after screening execution.",
+        "required": false
+      }
+    ],
+    "network": [
+      {
+        "host": "qveris.ai",
+        "reason": "Call QVeris API endpoints for discovery, execution, and audit.",
+        "required": true
+      }
+    ],
+    "secrets": [
+      {
+        "scope": "QVERIS_API_KEY",
+        "reason": "Authenticate QVeris API requests.",
+        "required": true
+      }
+    ]
+  },
+  "compatibility": {
+    "cli": ">=0.5.0",
+    "mcp": ">=0.6.0",
+    "python_sdk": ">=0.1.0",
+    "agent_skill": ">=0.1.0"
+  },
+  "marketplace": {
+    "listing_slug": "risk-compliance",
+    "headline": "Compliance capability discovery for entity risk checks.",
+    "audience": "Risk teams and agents that need sanctions, adverse media, or entity screening APIs.",
+    "use_cases": ["Screen an organization name", "Inspect required compliance parameters", "Audit final charge outcome"],
+    "integration_methods": ["cli", "python-sdk", "mcp", "skill"],
+    "primary_cta": "Run compliance recipe",
+    "docs_url": "recipes/risk-compliance/README.md"
+  },
+  "docs": {
+    "readme": "README.md",
+    "quickstart": "README.md#quickstart"
+  },
+  "examples": [
+    {
+      "name": "CLI first call",
+      "path": "README.md#cli",
+      "language": "shell",
+      "command": "qveris init --query \"sanctions screening or adverse media compliance API\" --params '{\"name\":\"Acme Trading Ltd\"}' --json"
+    },
+    {
+      "name": "Python SDK workflow",
+      "path": "README.md#python-sdk",
+      "language": "python",
+      "command": "python risk_compliance.py"
+    }
+  ]
+}

--- a/scripts/test-ecosystem-validator.mjs
+++ b/scripts/test-ecosystem-validator.mjs
@@ -16,6 +16,9 @@ const tests = [
   ["rejects missing required recipe permission", testMissingInspectPermission],
   ["rejects missing docs path", testMissingDocsPath],
   ["rejects invalid marketplace integration method", testInvalidIntegrationMethod],
+  ["rejects invalid marketplace docs url type", testInvalidMarketplaceDocsUrlType],
+  ["rejects schema string length violations", testStringLengthViolations],
+  ["rejects schema string max length violations", testStringMaxLengthViolations],
   ["rejects unsupported schema version", testUnsupportedSchemaVersion],
   ["rejects missing example path", testMissingExamplePath],
 ];
@@ -64,6 +67,63 @@ function testInvalidIntegrationMethod() {
   const result = runValidator(manifestPath);
   assertEqualStatus(result, 1);
   assert.match(result.stderr, /marketplace\.integration_methods has unsupported value: spreadsheet/);
+}
+
+function testInvalidMarketplaceDocsUrlType() {
+  const manifestPath = writeFixture("invalid-docs-url", (manifest) => {
+    manifest.marketplace.docs_url = 42;
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /marketplace\.docs_url must be a string/);
+}
+
+function testStringLengthViolations() {
+  const manifestPath = writeFixture("short-strings", (manifest) => {
+    manifest.name = "No";
+    manifest.summary = "Too short";
+    manifest.description = "Too short";
+    manifest.owner.name = "Q";
+    manifest.permissions.qveris[0].reason = "Too short";
+    manifest.permissions.network[0].host = "qa";
+    manifest.permissions.network[0].reason = "Too short";
+    manifest.permissions.secrets[0].scope = "SK";
+    manifest.permissions.secrets[0].reason = "Too short";
+    manifest.marketplace.headline = "Too short";
+    manifest.marketplace.audience = "Too short";
+    manifest.marketplace.use_cases = ["Short", "Also"];
+    manifest.marketplace.primary_cta = "Go";
+    manifest.examples[0].name = "Ex";
+    manifest.examples[0].command = "run";
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /name must be at least 3 characters/);
+  assert.match(result.stderr, /summary must be at least 20 characters/);
+  assert.match(result.stderr, /description must be at least 40 characters/);
+  assert.match(result.stderr, /owner\.name must be at least 2 characters/);
+  assert.match(result.stderr, /permissions\.qveris\[0\]\.reason must be at least 12 characters/);
+  assert.match(result.stderr, /permissions\.network\[0\]\.host must be at least 3 characters/);
+  assert.match(result.stderr, /permissions\.network\[0\]\.reason must be at least 12 characters/);
+  assert.match(result.stderr, /permissions\.secrets\[0\]\.scope must be at least 3 characters/);
+  assert.match(result.stderr, /permissions\.secrets\[0\]\.reason must be at least 12 characters/);
+  assert.match(result.stderr, /marketplace\.headline must be at least 12 characters/);
+  assert.match(result.stderr, /marketplace\.audience must be at least 10 characters/);
+  assert.match(result.stderr, /marketplace\.use_cases values must be at least 8 characters/);
+  assert.match(result.stderr, /marketplace\.primary_cta must be at least 3 characters/);
+  assert.match(result.stderr, /examples\[0\]\.name must be at least 3 characters/);
+  assert.match(result.stderr, /examples\[0\]\.command must be at least 5 characters/);
+}
+
+function testStringMaxLengthViolations() {
+  const manifestPath = writeFixture("long-strings", (manifest) => {
+    manifest.summary = "A".repeat(161);
+    manifest.marketplace.headline = "B".repeat(121);
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /summary must be 160 characters or less/);
+  assert.match(result.stderr, /marketplace\.headline must be 120 characters or less/);
 }
 
 function testUnsupportedSchemaVersion() {

--- a/scripts/test-ecosystem-validator.mjs
+++ b/scripts/test-ecosystem-validator.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const VALIDATOR = path.join(REPO_ROOT, "scripts/validate-ecosystem-manifests.mjs");
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "qveris-manifest-validator-"));
+
+const tests = [
+  ["accepts valid recipe manifest", testValidManifest],
+  ["rejects missing required recipe permission", testMissingInspectPermission],
+  ["rejects missing docs path", testMissingDocsPath],
+  ["rejects invalid marketplace integration method", testInvalidIntegrationMethod],
+  ["rejects unsupported schema version", testUnsupportedSchemaVersion],
+  ["rejects missing example path", testMissingExamplePath],
+];
+
+try {
+  for (const [name, testFn] of tests) {
+    testFn();
+    console.log(`ok ${name}`);
+  }
+  console.log(`\n${tests.length} validator regression test(s) passed.`);
+} finally {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
+
+function testValidManifest() {
+  const manifestPath = writeFixture("valid");
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 0);
+  assert.match(result.stdout, /Validated 1 ecosystem manifest\(s\)\./);
+}
+
+function testMissingInspectPermission() {
+  const manifestPath = writeFixture("missing-inspect", (manifest) => {
+    manifest.permissions.qveris = manifest.permissions.qveris.filter(
+      (permission) => permission.scope !== "capability.inspect",
+    );
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /recipe manifests must declare capability\.inspect/);
+}
+
+function testMissingDocsPath() {
+  const manifestPath = writeFixture("missing-docs", (manifest) => {
+    manifest.docs.readme = "MISSING.md";
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /docs\.readme path does not exist: MISSING\.md/);
+}
+
+function testInvalidIntegrationMethod() {
+  const manifestPath = writeFixture("invalid-method", (manifest) => {
+    manifest.marketplace.integration_methods = ["cli", "spreadsheet"];
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /marketplace\.integration_methods has unsupported value: spreadsheet/);
+}
+
+function testUnsupportedSchemaVersion() {
+  const manifestPath = writeFixture("bad-schema-version", (manifest) => {
+    manifest.schema_version = "2026-01-01";
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /schema_version must be 2026-05-13/);
+}
+
+function testMissingExamplePath() {
+  const manifestPath = writeFixture("missing-example", (manifest) => {
+    manifest.examples[0].path = "missing-example.md";
+  });
+  const result = runValidator(manifestPath);
+  assertEqualStatus(result, 1);
+  assert.match(result.stderr, /examples\[0\]\.path does not exist: missing-example\.md/);
+}
+
+function runValidator(manifestPath) {
+  return spawnSync(process.execPath, [VALIDATOR, manifestPath], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+}
+
+function writeFixture(name, mutate = () => {}) {
+  const dir = path.join(tmpRoot, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "README.md"), `# ${name}\n`, "utf8");
+
+  const manifest = validManifest();
+  manifest.id = `qveris.recipe.${name}`;
+  manifest.marketplace.listing_slug = name;
+  mutate(manifest);
+
+  const manifestPath = path.join(dir, "qveris.manifest.json");
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return manifestPath;
+}
+
+function assertEqualStatus(result, expected) {
+  assert.equal(
+    result.status,
+    expected,
+    [
+      `Expected exit status ${expected}, got ${result.status}`,
+      `stdout:\n${result.stdout}`,
+      `stderr:\n${result.stderr}`,
+    ].join("\n\n"),
+  );
+}
+
+function validManifest() {
+  return {
+    "$schema": "../../ecosystem/manifest.schema.json",
+    schema_version: "2026-05-13",
+    id: "qveris.recipe.valid",
+    kind: "recipe",
+    name: "Valid Recipe",
+    summary: "A valid recipe manifest used by the validator regression tests.",
+    description:
+      "This manifest exercises the validator success path with complete permissions, docs, examples, compatibility, and marketplace metadata.",
+    version: "0.1.0",
+    status: "beta",
+    owner: {
+      name: "QVeris",
+      url: "https://qveris.ai",
+    },
+    tags: ["test", "recipe"],
+    categories: ["automation"],
+    permissions: {
+      qveris: [
+        {
+          scope: "capability.discover",
+          reason: "Find external capabilities for this recipe.",
+          required: true,
+        },
+        {
+          scope: "capability.inspect",
+          reason: "Inspect candidate capability metadata before execution.",
+          required: true,
+        },
+      ],
+      network: [
+        {
+          host: "qveris.ai",
+          reason: "Call QVeris API endpoints.",
+          required: true,
+        },
+      ],
+      secrets: [
+        {
+          scope: "QVERIS_API_KEY",
+          reason: "Authenticate QVeris API requests.",
+          required: true,
+        },
+      ],
+    },
+    compatibility: {
+      cli: ">=0.5.0",
+      python_sdk: ">=0.1.0",
+    },
+    marketplace: {
+      listing_slug: "valid",
+      headline: "Valid manifest fixture for validator regression coverage.",
+      audience: "Maintainers who need confidence in ecosystem manifest validation.",
+      use_cases: ["Validate complete recipe metadata", "Catch permission and listing mistakes"],
+      integration_methods: ["cli", "python-sdk"],
+      primary_cta: "Run test",
+      docs_url: "recipes/valid/README.md",
+    },
+    docs: {
+      readme: "README.md",
+    },
+    examples: [
+      {
+        name: "CLI example",
+        path: "README.md",
+        language: "shell",
+        command: "qveris discover \"example capability\" --limit 3",
+      },
+    ],
+  };
+}

--- a/scripts/validate-ecosystem-manifests.mjs
+++ b/scripts/validate-ecosystem-manifests.mjs
@@ -19,6 +19,7 @@ const VALID_CATEGORIES = new Set([
   "compliance",
 ]);
 const VALID_METHODS = new Set(["cli", "mcp", "python-sdk", "rest-api", "skill", "plugin"]);
+const VALID_EXAMPLE_LANGUAGES = new Set(["shell", "python", "typescript", "json", "markdown"]);
 const REQUIRED_RECIPE_SCOPES = ["capability.discover", "capability.inspect"];
 
 const args = process.argv.slice(2);
@@ -94,9 +95,9 @@ function validateManifest(manifestPath) {
   requiredString(errors, manifest, "schema_version");
   requiredString(errors, manifest, "id");
   requiredString(errors, manifest, "kind");
-  requiredString(errors, manifest, "name");
-  requiredString(errors, manifest, "summary");
-  requiredString(errors, manifest, "description");
+  requiredString(errors, manifest, "name", { minLength: 3 });
+  requiredString(errors, manifest, "summary", { minLength: 20, maxLength: 160 });
+  requiredString(errors, manifest, "description", { minLength: 40 });
   requiredString(errors, manifest, "version");
   requiredString(errors, manifest, "status");
 
@@ -114,8 +115,6 @@ function validateManifest(manifestPath) {
     errors.push("version must be semver");
   }
   if (!VALID_STATUS.has(manifest.status)) errors.push("status must be experimental, beta, or stable");
-  if ((manifest.summary || "").length > 160) errors.push("summary must be 160 characters or less");
-
   validateOwner(errors, manifest.owner);
   validateStringArray(errors, manifest.tags, "tags", { min: 2, pattern: /^[a-z0-9][a-z0-9-]*$/ });
   validateStringArray(errors, manifest.categories, "categories", { min: 1, allowed: VALID_CATEGORIES });
@@ -133,7 +132,7 @@ function validateOwner(errors, owner) {
     errors.push("owner is required");
     return;
   }
-  requiredString(errors, owner, "owner.name");
+  requiredString(errors, owner, "owner.name", { minLength: 2 });
   requiredString(errors, owner, "owner.url");
   if (owner.url && !/^https?:\/\//.test(owner.url)) errors.push("owner.url must be an absolute HTTP URL");
 }
@@ -167,9 +166,15 @@ function validatePermissions(errors, permissions, kind) {
       permissions.network.forEach((permission, index) => {
         if (!permission?.host || typeof permission.host !== "string") {
           errors.push(`permissions.network[${index}].host is required`);
+        } else {
+          validateStringLength(errors, permission.host, `permissions.network[${index}].host`, { minLength: 3 });
         }
         if (!permission?.reason || typeof permission.reason !== "string") {
           errors.push(`permissions.network[${index}].reason is required`);
+        } else {
+          validateStringLength(errors, permission.reason, `permissions.network[${index}].reason`, {
+            minLength: 12,
+          });
         }
         if (typeof permission?.required !== "boolean") {
           errors.push(`permissions.network[${index}].required must be boolean`);
@@ -190,8 +195,16 @@ function validatePermission(errors, permission, prefix) {
     errors.push(`${prefix} must be an object`);
     return;
   }
-  if (!permission.scope || typeof permission.scope !== "string") errors.push(`${prefix}.scope is required`);
-  if (!permission.reason || typeof permission.reason !== "string") errors.push(`${prefix}.reason is required`);
+  if (!permission.scope || typeof permission.scope !== "string") {
+    errors.push(`${prefix}.scope is required`);
+  } else {
+    validateStringLength(errors, permission.scope, `${prefix}.scope`, { minLength: 3 });
+  }
+  if (!permission.reason || typeof permission.reason !== "string") {
+    errors.push(`${prefix}.reason is required`);
+  } else {
+    validateStringLength(errors, permission.reason, `${prefix}.reason`, { minLength: 12 });
+  }
   if (typeof permission.required !== "boolean") errors.push(`${prefix}.required must be boolean`);
 }
 
@@ -212,13 +225,14 @@ function validateMarketplace(errors, marketplace) {
     return;
   }
   requiredString(errors, marketplace, "marketplace.listing_slug");
-  requiredString(errors, marketplace, "marketplace.headline");
-  requiredString(errors, marketplace, "marketplace.audience");
-  requiredString(errors, marketplace, "marketplace.primary_cta");
+  requiredString(errors, marketplace, "marketplace.headline", { minLength: 12, maxLength: 120 });
+  requiredString(errors, marketplace, "marketplace.audience", { minLength: 10 });
+  requiredString(errors, marketplace, "marketplace.primary_cta", { minLength: 3 });
+  optionalString(errors, marketplace, "marketplace.docs_url");
   if (marketplace.listing_slug && !/^[a-z0-9][a-z0-9-]*$/.test(marketplace.listing_slug)) {
     errors.push("marketplace.listing_slug must be kebab-case");
   }
-  validateStringArray(errors, marketplace.use_cases, "marketplace.use_cases", { min: 2 });
+  validateStringArray(errors, marketplace.use_cases, "marketplace.use_cases", { min: 2, itemMinLength: 8 });
   validateStringArray(errors, marketplace.integration_methods, "marketplace.integration_methods", {
     min: 1,
     allowed: VALID_METHODS,
@@ -233,6 +247,10 @@ function validateDocs(errors, docs, baseDir) {
   requiredString(errors, docs, "docs.readme");
   for (const [key, value] of Object.entries(docs)) {
     if (!value) continue;
+    if (typeof value !== "string") {
+      errors.push(`docs.${key} must be a string`);
+      continue;
+    }
     const localPath = stripAnchor(value);
     if (!fs.existsSync(path.resolve(baseDir, localPath))) {
       errors.push(`docs.${key} path does not exist: ${value}`);
@@ -249,7 +267,11 @@ function validateExamples(errors, examples, baseDir) {
     requiredString(errors, example, `examples[${index}].name`);
     requiredString(errors, example, `examples[${index}].path`);
     requiredString(errors, example, `examples[${index}].language`);
-    requiredString(errors, example, `examples[${index}].command`);
+    requiredString(errors, example, `examples[${index}].command`, { minLength: 5 });
+    if (example.name) validateStringLength(errors, example.name, `examples[${index}].name`, { minLength: 3 });
+    if (example.language && !VALID_EXAMPLE_LANGUAGES.has(example.language)) {
+      errors.push(`examples[${index}].language has unsupported value: ${example.language}`);
+    }
     if (example.path && !fs.existsSync(path.resolve(baseDir, stripAnchor(example.path)))) {
       errors.push(`examples[${index}].path does not exist: ${example.path}`);
     }
@@ -270,16 +292,44 @@ function validateStringArray(errors, value, label, options = {}) {
     }
     if (seen.has(item)) errors.push(`${label} contains duplicate value: ${item}`);
     seen.add(item);
+    if (options.itemMinLength && item.length < options.itemMinLength) {
+      errors.push(`${label} values must be at least ${options.itemMinLength} characters`);
+    }
     if (options.pattern && !options.pattern.test(item)) errors.push(`${label} has invalid value: ${item}`);
     if (options.allowed && !options.allowed.has(item)) errors.push(`${label} has unsupported value: ${item}`);
   }
 }
 
-function requiredString(errors, object, key) {
+function requiredString(errors, object, key, options = {}) {
   const parts = key.split(".");
   const prop = parts.at(-1);
   const value = object?.[prop];
-  if (!value || typeof value !== "string") errors.push(`${key} is required`);
+  if (!value || typeof value !== "string") {
+    errors.push(`${key} is required`);
+    return;
+  }
+  validateStringLength(errors, value, key, options);
+}
+
+function optionalString(errors, object, key, options = {}) {
+  const parts = key.split(".");
+  const prop = parts.at(-1);
+  const value = object?.[prop];
+  if (value === undefined) return;
+  if (typeof value !== "string") {
+    errors.push(`${key} must be a string`);
+    return;
+  }
+  validateStringLength(errors, value, key, options);
+}
+
+function validateStringLength(errors, value, key, options = {}) {
+  if (options.minLength !== undefined && value.length < options.minLength) {
+    errors.push(`${key} must be at least ${options.minLength} characters`);
+  }
+  if (options.maxLength !== undefined && value.length > options.maxLength) {
+    errors.push(`${key} must be ${options.maxLength} characters or less`);
+  }
 }
 
 function stripAnchor(filePath) {

--- a/scripts/validate-ecosystem-manifests.mjs
+++ b/scripts/validate-ecosystem-manifests.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const DEFAULT_MANIFESTS = ["recipes"];
+const SUPPORTED_SCHEMA_VERSION = "2026-05-13";
+const VALID_KINDS = new Set(["recipe", "skill", "plugin"]);
+const VALID_STATUS = new Set(["experimental", "beta", "stable"]);
+const VALID_CATEGORIES = new Set([
+  "finance",
+  "risk",
+  "crypto",
+  "analytics",
+  "developer-tools",
+  "automation",
+  "compliance",
+]);
+const VALID_METHODS = new Set(["cli", "mcp", "python-sdk", "rest-api", "skill", "plugin"]);
+const REQUIRED_RECIPE_SCOPES = ["capability.discover", "capability.inspect"];
+
+const args = process.argv.slice(2);
+const targets = args.length > 0 ? args : DEFAULT_MANIFESTS;
+const manifestPaths = collectManifestPaths(targets);
+
+if (manifestPaths.length === 0) {
+  console.error("No qveris.manifest.json files found.");
+  process.exit(1);
+}
+
+let failures = 0;
+for (const manifestPath of manifestPaths) {
+  const errors = validateManifest(manifestPath);
+  if (errors.length > 0) {
+    failures += 1;
+    console.error(`\n${relative(manifestPath)}`);
+    for (const error of errors) console.error(`  - ${error}`);
+  } else {
+    console.log(`ok ${relative(manifestPath)}`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} manifest(s) failed validation.`);
+  process.exit(1);
+}
+
+console.log(`\nValidated ${manifestPaths.length} ecosystem manifest(s).`);
+
+function collectManifestPaths(inputPaths) {
+  const paths = [];
+  for (const input of inputPaths) {
+    const resolved = path.resolve(REPO_ROOT, input);
+    if (!fs.existsSync(resolved)) {
+      paths.push(resolved);
+      continue;
+    }
+    const stat = fs.statSync(resolved);
+    if (stat.isFile()) {
+      paths.push(resolved);
+      continue;
+    }
+    walk(resolved, paths);
+  }
+  return paths.filter((item) => path.basename(item) === "qveris.manifest.json").sort();
+}
+
+function walk(dir, paths) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === ".git" || entry.name === ".venv") continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, paths);
+    } else if (entry.isFile() && entry.name === "qveris.manifest.json") {
+      paths.push(fullPath);
+    }
+  }
+}
+
+function validateManifest(manifestPath) {
+  const errors = [];
+  if (!fs.existsSync(manifestPath)) return [`File does not exist: ${relative(manifestPath)}`];
+
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    return [`Invalid JSON: ${error.message}`];
+  }
+
+  const baseDir = path.dirname(manifestPath);
+  requiredString(errors, manifest, "schema_version");
+  requiredString(errors, manifest, "id");
+  requiredString(errors, manifest, "kind");
+  requiredString(errors, manifest, "name");
+  requiredString(errors, manifest, "summary");
+  requiredString(errors, manifest, "description");
+  requiredString(errors, manifest, "version");
+  requiredString(errors, manifest, "status");
+
+  if (manifest.schema_version !== SUPPORTED_SCHEMA_VERSION) {
+    errors.push(`schema_version must be ${SUPPORTED_SCHEMA_VERSION}`);
+  }
+  if (!/^qveris\.(recipe|skill|plugin)\.[a-z0-9][a-z0-9-]*(\.[a-z0-9][a-z0-9-]*)*$/.test(manifest.id || "")) {
+    errors.push("id must match qveris.<kind>.<slug>");
+  }
+  if (!VALID_KINDS.has(manifest.kind)) errors.push("kind must be recipe, skill, or plugin");
+  if (!manifest.id?.startsWith(`qveris.${manifest.kind}.`)) {
+    errors.push("id kind prefix must match kind");
+  }
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/.test(manifest.version || "")) {
+    errors.push("version must be semver");
+  }
+  if (!VALID_STATUS.has(manifest.status)) errors.push("status must be experimental, beta, or stable");
+  if ((manifest.summary || "").length > 160) errors.push("summary must be 160 characters or less");
+
+  validateOwner(errors, manifest.owner);
+  validateStringArray(errors, manifest.tags, "tags", { min: 2, pattern: /^[a-z0-9][a-z0-9-]*$/ });
+  validateStringArray(errors, manifest.categories, "categories", { min: 1, allowed: VALID_CATEGORIES });
+  validatePermissions(errors, manifest.permissions, manifest.kind);
+  validateCompatibility(errors, manifest.compatibility);
+  validateMarketplace(errors, manifest.marketplace);
+  validateDocs(errors, manifest.docs, baseDir);
+  validateExamples(errors, manifest.examples, baseDir);
+
+  return errors;
+}
+
+function validateOwner(errors, owner) {
+  if (!owner || typeof owner !== "object") {
+    errors.push("owner is required");
+    return;
+  }
+  requiredString(errors, owner, "owner.name");
+  requiredString(errors, owner, "owner.url");
+  if (owner.url && !/^https?:\/\//.test(owner.url)) errors.push("owner.url must be an absolute HTTP URL");
+}
+
+function validatePermissions(errors, permissions, kind) {
+  if (!permissions || typeof permissions !== "object") {
+    errors.push("permissions is required");
+    return;
+  }
+  if (!Array.isArray(permissions.qveris) || permissions.qveris.length === 0) {
+    errors.push("permissions.qveris must declare at least one QVeris permission");
+    return;
+  }
+  for (const [index, permission] of permissions.qveris.entries()) {
+    validatePermission(errors, permission, `permissions.qveris[${index}]`);
+  }
+  for (const group of ["local_files", "secrets"]) {
+    if (!permissions[group]) continue;
+    if (!Array.isArray(permissions[group])) {
+      errors.push(`permissions.${group} must be an array`);
+      continue;
+    }
+    permissions[group].forEach((permission, index) => {
+      validatePermission(errors, permission, `permissions.${group}[${index}]`);
+    });
+  }
+  if (permissions.network) {
+    if (!Array.isArray(permissions.network)) {
+      errors.push("permissions.network must be an array");
+    } else {
+      permissions.network.forEach((permission, index) => {
+        if (!permission?.host || typeof permission.host !== "string") {
+          errors.push(`permissions.network[${index}].host is required`);
+        }
+        if (!permission?.reason || typeof permission.reason !== "string") {
+          errors.push(`permissions.network[${index}].reason is required`);
+        }
+        if (typeof permission?.required !== "boolean") {
+          errors.push(`permissions.network[${index}].required must be boolean`);
+        }
+      });
+    }
+  }
+  if (kind === "recipe") {
+    const scopes = new Set(permissions.qveris.map((permission) => permission.scope));
+    for (const scope of REQUIRED_RECIPE_SCOPES) {
+      if (!scopes.has(scope)) errors.push(`recipe manifests must declare ${scope}`);
+    }
+  }
+}
+
+function validatePermission(errors, permission, prefix) {
+  if (!permission || typeof permission !== "object") {
+    errors.push(`${prefix} must be an object`);
+    return;
+  }
+  if (!permission.scope || typeof permission.scope !== "string") errors.push(`${prefix}.scope is required`);
+  if (!permission.reason || typeof permission.reason !== "string") errors.push(`${prefix}.reason is required`);
+  if (typeof permission.required !== "boolean") errors.push(`${prefix}.required must be boolean`);
+}
+
+function validateCompatibility(errors, compatibility) {
+  if (!compatibility || typeof compatibility !== "object") {
+    errors.push("compatibility is required");
+    return;
+  }
+  if (Object.keys(compatibility).length === 0) errors.push("compatibility must declare at least one integration");
+  for (const [key, value] of Object.entries(compatibility)) {
+    if (!value || typeof value !== "string") errors.push(`compatibility.${key} must be a non-empty string`);
+  }
+}
+
+function validateMarketplace(errors, marketplace) {
+  if (!marketplace || typeof marketplace !== "object") {
+    errors.push("marketplace is required");
+    return;
+  }
+  requiredString(errors, marketplace, "marketplace.listing_slug");
+  requiredString(errors, marketplace, "marketplace.headline");
+  requiredString(errors, marketplace, "marketplace.audience");
+  requiredString(errors, marketplace, "marketplace.primary_cta");
+  if (marketplace.listing_slug && !/^[a-z0-9][a-z0-9-]*$/.test(marketplace.listing_slug)) {
+    errors.push("marketplace.listing_slug must be kebab-case");
+  }
+  validateStringArray(errors, marketplace.use_cases, "marketplace.use_cases", { min: 2 });
+  validateStringArray(errors, marketplace.integration_methods, "marketplace.integration_methods", {
+    min: 1,
+    allowed: VALID_METHODS,
+  });
+}
+
+function validateDocs(errors, docs, baseDir) {
+  if (!docs || typeof docs !== "object") {
+    errors.push("docs is required");
+    return;
+  }
+  requiredString(errors, docs, "docs.readme");
+  for (const [key, value] of Object.entries(docs)) {
+    if (!value) continue;
+    const localPath = stripAnchor(value);
+    if (!fs.existsSync(path.resolve(baseDir, localPath))) {
+      errors.push(`docs.${key} path does not exist: ${value}`);
+    }
+  }
+}
+
+function validateExamples(errors, examples, baseDir) {
+  if (!Array.isArray(examples) || examples.length === 0) {
+    errors.push("examples must include at least one runnable or copy-paste complete example");
+    return;
+  }
+  for (const [index, example] of examples.entries()) {
+    requiredString(errors, example, `examples[${index}].name`);
+    requiredString(errors, example, `examples[${index}].path`);
+    requiredString(errors, example, `examples[${index}].language`);
+    requiredString(errors, example, `examples[${index}].command`);
+    if (example.path && !fs.existsSync(path.resolve(baseDir, stripAnchor(example.path)))) {
+      errors.push(`examples[${index}].path does not exist: ${example.path}`);
+    }
+  }
+}
+
+function validateStringArray(errors, value, label, options = {}) {
+  if (!Array.isArray(value)) {
+    errors.push(`${label} must be an array`);
+    return;
+  }
+  if (value.length < (options.min ?? 0)) errors.push(`${label} must contain at least ${options.min} item(s)`);
+  const seen = new Set();
+  for (const item of value) {
+    if (!item || typeof item !== "string") {
+      errors.push(`${label} must contain only non-empty strings`);
+      continue;
+    }
+    if (seen.has(item)) errors.push(`${label} contains duplicate value: ${item}`);
+    seen.add(item);
+    if (options.pattern && !options.pattern.test(item)) errors.push(`${label} has invalid value: ${item}`);
+    if (options.allowed && !options.allowed.has(item)) errors.push(`${label} has unsupported value: ${item}`);
+  }
+}
+
+function requiredString(errors, object, key) {
+  const parts = key.split(".");
+  const prop = parts.at(-1);
+  const value = object?.[prop];
+  if (!value || typeof value !== "string") errors.push(`${key} is required`);
+}
+
+function stripAnchor(filePath) {
+  return filePath.split("#")[0];
+}
+
+function relative(filePath) {
+  return path.relative(REPO_ROOT, filePath);
+}


### PR DESCRIPTION
## Summary

- Add ecosystem manifest schema, contributor docs, and skill/plugin templates.
- Add recipe manifests and documentation for five agent use cases.
- Add manifest validation scripts and CI workflows for ecosystem checks and Python SDK publishing.

## Validation

- node scripts/validate-ecosystem-manifests.mjs
- node scripts/test-ecosystem-validator.mjs