### PR TITLE
docs: Python SDK guide + complete cn/zh-CN docs (China region)

### DIFF
--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -1,0 +1,600 @@
+# QVeris CLI
+
+QVeris 能力路由网络的官方命令行工具。直接在终端或 Agent 框架中发现、检查和调用 10,000+ 真实已验证的 API 能力。
+
+**为什么用 CLI？** MCP 会将工具结构注入每轮 LLM 提示词（每个工具消耗数百 token），而 CLI 作为子进程执行 — 零提示词 token、确定性输出、即时启动。
+
+## 安装
+
+### 一键安装（推荐）
+
+```bash
+curl -fsSL https://qveris.cn/cli/install | bash
+```
+
+脚本自动检查 Node.js 18+，全局安装 `@qverisai/cli`，并添加到 PATH。
+
+### npm
+
+```bash
+npm install -g @qverisai/cli
+```
+
+### npx（免安装）
+
+```bash
+npx @qverisai/cli discover "天气 API"
+```
+
+### 环境要求
+
+- Node.js 18+
+- 零运行时依赖（仅使用 Node.js 内置 API）
+
+---
+
+## 快速开始
+
+```bash
+# 引导式首次调用
+qveris init
+
+# 手动流程
+# 1. 认证（保存到 ~/.config/qveris/config.json）
+qveris login
+
+# 2. 发现工具
+qveris discover "天气预报 API"
+
+# 3. 检查工具（使用 discover 结果的索引）
+qveris inspect 1
+
+# 4. 调用
+qveris call 1 --params '{"wfo": "LWX", "x": 90, "y": 90}'
+```
+
+---
+
+## 命令
+
+### `qveris init`
+
+引导式首次调用向导：解析认证、发现能力、检查能力、执行调用，并在最后给出 usage/ledger 对账命令。
+
+```bash
+qveris init [query] [flags]
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--query <query>` | 覆盖发现查询 | `weather forecast API` |
+| `--params <json\|@file\|->` | 覆盖调用参数 | 能力示例参数（如可用） |
+| `--resume` | 在可恢复失败后复用上一次发现会话 | false |
+| `--dry-run` | 打印计划执行的发现/调用载荷，但不实际调用 | false |
+| `--tool-id <id>` | 指定工具 ID，而不是使用第一个发现结果 | 第一个结果 |
+| `--json` | 输出机器可读的向导状态 | false |
+
+**示例：**
+
+```bash
+qveris init
+qveris init --query "股票价格 API"
+qveris init --dry-run
+qveris init --resume --params '{"city": "London"}'
+```
+
+最后一步会打印精确的 `qveris usage` 和 `qveris ledger` 命令，便于确认最终扣费结果。
+
+### `qveris discover`
+
+使用自然语言搜索 API 能力。返回工具名称、提供商、ID、描述、相关性得分、成功率、延迟和计费规则摘要（如可用）。
+
+```bash
+qveris discover <query> [flags]
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--limit <n>` | 最大结果数 | 5 |
+| `--json` | 输出原始 JSON | false |
+
+**示例：**
+
+```bash
+qveris discover "股票价格 API"
+qveris discover "将文本翻译成法语" --limit 10
+qveris discover "加密货币市场数据" --json
+```
+
+**每个工具的输出字段：**
+- 工具名称和提供商
+- `tool_id`（用于 inspect/call）
+- 描述
+- 相关性得分、成功率、延迟、计费规则摘要
+- 分类和区域（如适用）
+- 已验证标记（如工具有执行历史）
+
+---
+
+### `qveris inspect`
+
+查看工具的完整详情。显示参数的类型、描述、枚举值、提供商信息和示例参数。
+
+```bash
+qveris inspect <tool_id|index> [flags]
+```
+
+| 参数 | 说明 |
+|------|------|
+| `--discovery-id <id>` | 引用特定的发现会话 |
+| `--json` | 输出原始 JSON |
+
+数字索引（如 `1`、`2`）引用上一次 `discover` 的结果。
+
+**示例：**
+
+```bash
+# 按索引
+qveris inspect 1
+
+# 按工具 ID
+qveris inspect openweathermap.weather.current.v1
+
+# 检查多个工具
+qveris inspect 1 2 3
+```
+
+**输出包含：**
+- 工具名称、ID、描述
+- 提供商名称和描述
+- 区域、延迟、成功率、计费规则
+- **参数：**名称、类型、必填/可选、描述、允许值（枚举）
+- 示例参数
+- 最近执行记录（如有）
+
+---
+
+### `qveris call`
+
+执行一个能力。返回结构化结果、执行时间、预结算账单和剩余 credits。最终是否扣费请通过 `qveris usage` 或 `qveris ledger` 查询。
+
+```bash
+qveris call <tool_id|index> [flags]
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--params <json\|@file\|->` | JSON、文件路径或 stdin | `{}` |
+| `--discovery-id <id>` | 发现会话 ID | 自动从会话获取 |
+| `--max-size <bytes>` | 响应大小限制（-1 = 无限制） | 4KB (TTY) / 20KB (管道) |
+| `--dry-run` | 预览请求，不实际执行 | false |
+| `--codegen <lang>` | 调用后生成代码片段 | — |
+| `--json` | 输出原始 JSON | false |
+
+**参数输入方式：**
+
+```bash
+# 内联 JSON
+qveris call 1 --params '{"city": "London"}'
+
+# 从文件
+qveris call 1 --params @params.json
+
+# 从 stdin
+echo '{"city": "London"}' | qveris call 1 --params -
+```
+
+**试运行（不消耗 credits）：**
+
+```bash
+qveris call 1 --params '{"symbol": "AAPL"}' --dry-run
+```
+
+**代码生成：**
+
+```bash
+# 调用成功后生成 curl、Python 或 JavaScript 代码片段
+qveris call 1 --params '{"symbol": "AAPL"}' --codegen curl
+qveris call 1 --params '{"symbol": "AAPL"}' --codegen python
+qveris call 1 --params '{"symbol": "AAPL"}' --codegen js
+```
+
+#### 响应截断
+
+终端使用时（TTY），超过 4KB 的结果自动截断。CLI 会显示：
+
+- 截断内容的预览
+- OSS 下载链接（120 分钟有效）
+- 响应的 JSON 结构，帮助理解数据结构
+- 提示：`使用 --max-size -1 获取完整输出`
+
+Agent/脚本场景（`--json` 或管道输出）默认提高到 20KB。用 `--max-size -1` 获取完整结果。
+
+---
+
+### `qveris mcp configure`
+
+为 Cursor、OpenCode、OpenClaw 或通用 stdio 客户端生成 MCP 配置。默认是打印模式，并使用 `YOUR_QVERIS_API_KEY` 占位符，因此输出可以安全粘贴到 issue 或文档中。占位符输出会故意无法通过 API key 校验，直到你替换占位符或使用 `--include-key`。
+
+```bash
+qveris mcp configure --target cursor
+qveris mcp configure --target cursor --write --include-key
+qveris mcp configure --target opencode --write --include-key
+qveris mcp configure --target openclaw --write --include-key
+qveris mcp configure --target generic --json
+```
+
+支持的目标：
+
+| 目标 | 输出 |
+|------|------|
+| `cursor` | `~/.cursor/mcp.json` |
+| `opencode` | OpenCode 本地 MCP 配置 |
+| `openclaw` | OpenClaw qveris 插件配置 |
+| `generic` | 原始 stdio server JSON |
+
+参数：
+
+| 参数 | 说明 |
+|------|------|
+| `--target <target>` | 目标客户端，默认 `cursor` |
+| `--output <path>` | 覆盖配置输出路径 |
+| `--write` | 将生成的配置写入磁盘 |
+| `--include-key` | 使用解析到的 API key，而不是占位符 |
+| `--json` | 输出机器可读 JSON |
+
+### `qveris mcp validate`
+
+校验 MCP 配置文件。静态校验会检查配置结构、QVeris 条目、API key 绑定方式，以及预期的规范工具。
+
+```bash
+qveris mcp validate --target cursor
+qveris mcp validate --target cursor --output ~/.cursor/mcp.json
+```
+
+添加 `--probe` 会启动配置中的 stdio MCP server，并通过 `tools/list` 确认 `discover`、`inspect`、`call` 工具可见。
+
+```bash
+qveris mcp validate --target cursor --probe
+```
+
+`--probe` 需要可执行的 stdio 命令和真实的 `QVERIS_API_KEY`；OpenClaw 插件配置不支持该探测方式。
+
+---
+
+### `qveris login`
+
+使用 QVeris API 密钥认证。如果未预设区域，会先提示选择站点区域（全球 / 中国），然后打开对应的 API 密钥页面并掩码输入。
+
+```bash
+qveris login [flags]
+```
+
+| 参数 | 说明 |
+|------|------|
+| `--token <key>` | 直接提供密钥（跳过浏览器和区域选择） |
+| `--no-browser` | 不打开浏览器 |
+
+```bash
+# 交互式（选择区域 → 打开浏览器 → 掩码输入）
+qveris login
+
+# 非交互式
+qveris login --token "sk-cn-your-key-here"
+```
+
+交互式登录时，如果未设置 `QVERIS_REGION` 或 `--base-url`，会提示选择区域：
+
+```
+选择站点区域：
+
+  1) 全球   — qveris.ai  （国际用户）
+  2) 中国   — qveris.cn  （中国大陆用户）
+
+输入 1 或 2：
+```
+
+密钥保存到 `~/.config/qveris/config.json`，权限为 `0600`（仅所有者可读写）。
+
+### `qveris logout`
+
+从配置中移除已存储的 API 密钥。
+
+### `qveris whoami`
+
+显示当前认证状态、密钥来源、所属区域，并验证密钥有效性。
+
+### `qveris credits`
+
+查看剩余 credits 余额。
+
+### `qveris usage`
+
+查询调用级使用审计，默认使用 `summary` 聚合模式，避免把大量流水直接输出到 Agent 上下文。
+`summary` 模式会优先请求服务端 `summary=true` 聚合摘要；若旧部署暂不支持，则回退到有上限的客户端聚合。
+
+```bash
+qveris usage --mode summary --bucket hour
+qveris usage --mode search --execution-id <execution_id> --json
+qveris usage --mode search --min-credits 30 --max-credits 100 --json
+qveris usage --mode export-file --start-date 2026-05-01 --end-date 2026-05-04
+```
+
+常用过滤参数：`--execution-id`、`--search-id`、`--charge-outcome`、`--min-credits`、`--max-credits`、`--start-date`、`--end-date`。
+
+### `qveris ledger`
+
+查询最终 credits 账本，默认使用 `summary` 聚合模式。
+`summary` 模式会优先请求服务端 `summary=true` 聚合摘要；若旧部署暂不支持，则回退到有上限的客户端聚合。
+
+```bash
+qveris ledger --mode summary --bucket day
+qveris ledger --mode search --direction consume --min-credits 50 --json
+qveris ledger --mode export-file --start-date 2026-05-01 --end-date 2026-05-04
+```
+
+`export-file` 会把原始记录写入 `.qveris/exports/*.jsonl`，只返回文件路径和记录数，不直接打印全量记录。
+
+---
+
+### `qveris interactive`
+
+启动 REPL 会话，支持链式 discover/inspect/call 工作流。会话状态保存在内存中并持久化到磁盘。
+
+```bash
+qveris interactive [flags]
+```
+
+别名：`qveris repl`
+
+**REPL 命令：**
+
+| 命令 | 说明 |
+|------|------|
+| `discover <query>` | 发现能力 |
+| `inspect <index\|id>` | 查看工具详情 |
+| `call <index\|id> {json}` | 执行工具 |
+| `codegen <curl\|js\|python>` | 从上次调用生成代码 |
+| `history` | 显示会话状态 |
+| `help` | 显示命令 |
+| `exit` | 退出 |
+
+```bash
+qveris> discover "加密货币价格 API"
+qveris> inspect 1
+qveris> call 1 {"symbol": "BTC"}
+qveris> codegen python
+qveris> exit
+```
+
+---
+
+### `qveris doctor`
+
+自检诊断：验证 Node.js 版本、API 密钥配置、区域和 API 地址、API 连通性。
+
+### `qveris config`
+
+管理 CLI 设置。
+
+```bash
+qveris config <subcommand> [args]
+```
+
+| 子命令 | 说明 |
+|--------|------|
+| `set <key> <value>` | 设置配置值 |
+| `get <key>` | 获取配置值 |
+| `list` | 列出所有设置及来源 |
+| `reset` | 重置为默认值 |
+| `path` | 打印配置文件路径 |
+
+**配置项：**`api_key`, `base_url`, `default_limit`, `default_max_size`, `color`, `output_format`
+
+### `qveris completions`
+
+生成 Shell 自动补全脚本。
+
+```bash
+# Bash
+eval "$(qveris completions bash)"
+
+# Zsh
+eval "$(qveris completions zsh)"
+
+# Fish
+qveris completions fish | source
+```
+
+### `qveris history`
+
+显示当前会话状态（上次查询、结果、时间）。
+
+```bash
+qveris history [--clear]
+```
+
+---
+
+## 全局参数
+
+所有命令通用：
+
+| 参数 | 缩写 | 说明 |
+|------|------|------|
+| `--json` | `-j` | 输出原始 JSON（适合 Agent/脚本） |
+| `--api-key <key>` | | 覆盖 API 密钥 |
+| `--base-url <url>` | | 覆盖 API 地址 |
+| `--timeout <seconds>` | | 请求超时 |
+| `--no-color` | | 禁用 ANSI 颜色 |
+| `--verbose` | `-v` | 显示详细输出 |
+| `--version` | `-V` | 打印版本 |
+| `--help` | `-h` | 显示帮助 |
+
+支持 `--key=value` 语法和组合短参数（`-jv`）。
+
+用 `--` 结束选项解析：`qveris discover -- --literal-query`。
+
+---
+
+## 环境变量
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `QVERIS_API_KEY` | API 认证密钥 | — |
+| `QVERIS_REGION` | 强制区域：`global` 或 `cn` | 从密钥自动检测 |
+| `QVERIS_BASE_URL` | 覆盖 API 地址 | 从区域自动设置 |
+| `QVERIS_DEFAULT_LIMIT` | 默认 discover 限制 | 5 |
+| `QVERIS_DEFAULT_MAX_SIZE` | 默认响应大小限制 | 4096 |
+| `XDG_CONFIG_HOME` | 配置目录基础路径 | `~/.config` |
+| `NO_COLOR` | 禁用颜色（标准） | — |
+| `FORCE_COLOR` | 强制颜色（即使管道） | — |
+
+**优先级：**`--flag` > 环境变量 > 配置文件 > 默认值
+
+---
+
+## 区域
+
+区域从 API 密钥前缀自动检测，无需额外配置。中国大陆用户使用 `sk-cn-` 前缀的密钥即可自动指向 `https://qveris.cn`。
+
+| 密钥前缀 | 区域 | API 地址 |
+|----------|------|----------|
+| `sk-xxx` | 全球 | `https://qveris.ai/api/v1` |
+| `sk-cn-xxx` | 中国 | `https://qveris.cn/api/v1` |
+
+**交互式登录：**运行 `qveris login` 时，如果未设置 `QVERIS_REGION` 或 `--base-url`，会提示选择区域。仅用于首次人工登录。
+
+**Agent / 脚本使用：**Agent 和脚本应跳过交互式提示。区域自动解析：
+
+```bash
+# 方式 1：密钥前缀自动检测（推荐）
+qveris login --token "sk-cn-xxx"    # 自动检测为中国区
+
+# 方式 2：环境变量
+export QVERIS_REGION=cn
+qveris login --token "sk-xxx"
+
+# 方式 3：显式 API 地址
+export QVERIS_BASE_URL=https://qveris.cn/api/v1
+
+# 方式 4：单次命令参数
+qveris discover "天气" --base-url https://qveris.cn/api/v1
+```
+
+---
+
+## 会话管理
+
+每次 `discover` 后，CLI 将会话状态保存到 `~/.config/qveris/.session.json`：
+
+- 发现 ID
+- 查询内容
+- 区域和 API 地址
+- 结果列表（tool_id、名称、提供商）
+
+后续 `inspect` 和 `call` 自动读取会话，支持数字索引快捷方式：
+
+```bash
+qveris discover "weather API"    # 保存会话
+qveris inspect 1                  # 使用会话中的索引 1
+qveris call 2 --params '{...}'   # 使用索引 2 + 发现 ID
+```
+
+会话 30 分钟后过期。用 `qveris history` 查看，`qveris history --clear` 清除。
+
+---
+
+## Agent / LLM 集成
+
+### CLI vs MCP
+
+| | CLI | MCP |
+|---|---|---|
+| **Token 消耗** | 零 — 子进程执行 | 高 — 工具结构注入每轮提示词 |
+| **可扩展性** | 10,000+ 真实已验证的工具，不会撑大提示词 | 每个工具增加 ~200-500 token |
+| **输出** | 确定性，`--json` 可直接解析 | 因客户端而异 |
+| **调试** | 终端可见，`--dry-run` | 不透明，埋在 MCP 日志里 |
+
+### 智能默认值
+
+CLI 自动检测 Agent 与人类使用场景：
+
+| 场景 | `max_response_size` | 行为 |
+|------|---------------------|------|
+| 终端 (TTY) | 4KB | 人类友好，自动截断 |
+| 管道/脚本 | 20KB | Agent 友好 |
+| `--json` 参数 | 20KB | 显式 Agent 模式 |
+| `--max-size N` | N | 用户覆盖 |
+
+### 脚本示例
+
+```bash
+# 发现 → 提取工具 ID → 调用 → 解析结果
+TOOL=$(qveris discover "weather" --json | jq -r '.results[0].tool_id')
+SEARCH_ID=$(qveris discover "weather" --json | jq -r '.search_id')
+qveris call "$TOOL" --discovery-id "$SEARCH_ID" --params '{"city":"London"}' --json | jq '.result.data'
+```
+
+---
+
+## 退出码
+
+遵循 BSD `sysexits.h` 规范：
+
+| 码 | 常量 | 含义 |
+|----|------|------|
+| 0 | `EX_OK` | 成功 |
+| 2 | `EX_USAGE` | 参数错误 |
+| 69 | `EX_UNAVAILABLE` | 服务不可用 |
+| 75 | `EX_TEMPFAIL` | 超时或限流 |
+| 77 | `EX_NOPERM` | 认证错误或 credits 不足 |
+| 78 | `EX_CONFIG` | 缺少 API 密钥 |
+
+---
+
+## 旧命令兼容
+
+以下别名支持向后兼容（会显示弃用警告）：
+
+| 别名 | 映射到 |
+|------|--------|
+| `search` | `discover` |
+| `execute` | `call` |
+| `invoke` | `call` |
+| `get-by-ids` | `inspect` |
+| `--search-id` | `--discovery-id` |
+
+---
+
+## 架构
+
+```
+@qverisai/cli
+├── bin/qveris.mjs           # 入口
+├── src/
+│   ├── main.mjs              # 命令分发 + 参数解析
+│   ├── commands/              # 12 个命令处理器
+│   ├── client/api.mjs         # HTTP 客户端（原生 fetch）
+│   ├── client/auth.mjs        # API 密钥解析
+│   ├── config/region.mjs      # 区域自动检测
+│   ├── config/store.mjs       # 配置文件读写（0600 权限）
+│   ├── session/session.mjs    # 会话持久化
+│   ├── output/formatter.mjs   # 人类友好格式化
+│   ├── output/codegen.mjs     # 代码片段生成
+│   └── errors/handler.mjs     # 错误处理 + BSD 退出码
+└── scripts/install.sh         # 一键安装脚本
+```
+
+**零运行时依赖。**仅使用 Node.js 18+ 内置 API。没有 chalk、commander、yargs。
+
+---
+
+## 链接
+
+- 官网：[qveris.cn](https://qveris.cn)（中国）/ [qveris.ai](https://qveris.ai)（全球）
+- GitHub：[QVerisAI/qveris-agent-toolkit](https://github.com/QVerisAI/qveris-agent-toolkit)
+- npm：[@qverisai/cli](https://www.npmjs.com/package/@qverisai/cli)
+- REST API：[docs/cn/zh-CN/rest-api.md](rest-api.md)
+- MCP 服务器：[docs/cn/zh-CN/mcp-server.md](mcp-server.md)
+- 获取 API 密钥：[qveris.cn/account](https://qveris.cn/account?page=api-keys) / [qveris.ai/account](https://qveris.ai/account?page=api-keys)

--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -89,6 +89,8 @@ Python SDK 现在位于本 monorepo 的 [`packages/python-sdk`](../../../package
 pip install qveris
 ```
 
+完整指南（client、agent、类型化模型、集成方式）见 [Python SDK](python-sdk.md)。
+
 设置环境变量：
 
 - `QVERIS_API_KEY`（从 [QVeris](https://qveris.cn) 获取）
@@ -343,9 +345,9 @@ console.log(data);
 
 ### 在 AI Agent 中安装 QVeris
 
-如果你正在配置 AI 编程助手（Claude Code、Cursor、OpenCode、Trae 等），可以将 [Agent 安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给 Agent。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
+如果你正在配置 AI 编程助手（Cursor、OpenCode、Trae 等），可以将 [Agent 安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给 Agent。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
 
-支持的环境：Claude Code、OpenCode、Cursor、Trae、VS Code、OpenClaw。
+支持的环境：OpenCode、Cursor、Trae、VS Code、OpenClaw。
 
 ---
 

--- a/docs/cn/zh-CN/ide-cli-setup.md
+++ b/docs/cn/zh-CN/ide-cli-setup.md
@@ -1,0 +1,28 @@
+# IDE 与 CLI 配置指南
+
+QVeris 已集成到多种 IDE 和 CLI 编程工具中。通过自动配置 QVeris MCP 和技能/规则，可以大幅简化基于 QVeris API 和工具的应用开发。
+
+## 图形界面 IDE
+
+对于图形界面 IDE，请访问 [https://qveris.cn/plugins](https://qveris.cn/plugins) 按照说明安装对应插件。
+
+## CLI 编程工具
+
+对于 CLI 编程工具，请访问以下对应页面查看配置说明。
+
+## 通过编程 Agent 自动配置
+
+你也可以让编程 Agent 代为完成配置。只需将配置指南链接和你的 API 密钥提供给 Agent：
+
+```
+请按照 <配置指南链接> 帮我完成配置。API 密钥是 <你的 API 密钥>
+```
+
+大多数有能力的编程 Agent 都能自动完成配置并解决遇到的问题。
+
+### 示例
+
+OpenCode：
+```
+请按照 https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/cn/zh-CN/opencode-setup.md 帮我完成配置。API 密钥是 sk-cn-xxxxxxxxxxxxx
+```

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -1,0 +1,369 @@
+# QVeris MCP 服务器文档
+
+## 简介
+
+`@qverisai/mcp` 是面向 Cursor 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
+
+它通过少量 MCP 工具为 Agent 提供 QVeris 访问能力：
+
+- `discover` — 用自然语言发现能力
+- `inspect` — 获取工具详情（参数、成功率、示例）
+- `call` — 执行工具并传入参数
+- `usage_history` — 上下文安全的调用审计摘要 / 精确查询 / 文件导出
+- `credits_ledger` — 上下文安全的最终 credits 账本摘要 / 精确查询 / 文件导出
+
+换言之，MCP 服务器是本仓库其他文档所描述的 QVeris 核心协议的 Agent 侧传输层。
+
+---
+
+## MCP 与 REST API 对比
+
+**适合使用 MCP 服务器的场景：**
+
+- 将 QVeris 集成到 Cursor、OpenCode 或其他 MCP 客户端
+- 希望 Agent 在对话中直接调用 QVeris 工具
+- 希望客户端自动管理工具调用
+
+**适合使用 REST API 的场景：**
+
+- 编写应用代码或后端服务
+- 需要对请求和响应进行直接的 HTTP 控制
+- 构建 SDK 封装或生产环境集成
+
+两种方式均映射到同一套 QVeris 协议：
+
+| 协议操作 | MCP 工具 | REST API |
+|---------|---------|---------|
+| **发现** | `discover` | `POST /search` |
+| **检查** | `inspect` | `POST /tools/by-ids` |
+| **调用** | `call` | `POST /tools/execute` |
+| **调用审计** | `usage_history` | `GET /auth/usage/history/v2` |
+| **Credits 账本** | `credits_ledger` | `GET /auth/credits/ledger` |
+
+> **注意：**旧工具名称（`search_tools`、`get_tools_by_ids`、`execute_tool`）仍作为弃用别名支持。
+
+---
+
+## 环境要求
+
+- Node.js `18+`
+- 有效的 `QVERIS_API_KEY`
+- MCP 兼容客户端
+
+---
+
+## 快速开始
+
+### 通过 `npx` 安装
+
+```bash
+npx -y @qverisai/mcp
+```
+
+MCP 服务器从以下环境变量读取配置：
+
+```bash
+QVERIS_API_KEY=sk-cn-your-api-key    # 必填
+QVERIS_REGION=cn                      # 可选：强制区域（global | cn）
+QVERIS_BASE_URL=https://...          # 可选：覆盖 API 地址
+```
+
+区域从 API 密钥前缀自动检测（`sk-cn-xxx` → 中国区，`sk-xxx` → 全球）。中国大陆用户使用 `sk-cn-` 前缀的密钥即可自动指向 `https://qveris.cn`，仅在需要覆盖时设置 `QVERIS_REGION`。
+
+### 使用 QVeris CLI 配置
+
+可以用 CLI 生成客户端配置，无需手写 JSON。默认会打印带有 `YOUR_QVERIS_API_KEY` 占位符的安全配置；占位符输出会故意无法通过 API key 校验，直到你替换占位符或使用 `--include-key`。
+
+```bash
+# 打印安全的 Cursor 配置
+qveris mcp configure --target cursor
+
+# 使用 qveris login 或 QVERIS_API_KEY 中的 API key 写入可直接使用的配置
+qveris mcp configure --target cursor --write --include-key
+qveris mcp configure --target opencode --write --include-key
+qveris mcp configure --target openclaw --write --include-key
+```
+
+重启客户端前可以先校验配置：
+
+```bash
+qveris mcp validate --target cursor
+```
+
+对 stdio 客户端，可添加 `--probe` 启动配置中的 MCP server，并通过 `tools/list` 确认 `discover`、`inspect`、`call` 可见：
+
+```bash
+qveris mcp validate --target cursor --probe
+```
+
+### Cursor 配置示例
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "sk-cn-your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+### 中国区配置示例
+
+中国大陆用户使用 `sk-cn-` 前缀的密钥即可自动指向中国区；也可显式添加 `QVERIS_REGION`：
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "sk-cn-your-api-key-here",
+        "QVERIS_REGION": "cn"
+      }
+    }
+  }
+}
+```
+
+各环境的详细配置指南，请参考：
+
+- [Agent 安装指南](../../../agent/SETUP.md)
+- [OpenCode 配置](opencode-setup.md)
+- [IDE / CLI 配置](ide-cli-setup.md)
+
+---
+
+## Hosted MCP
+
+Hosted MCP 已列入规划，但当前接入路径不依赖托管端点。在正式发布托管端点前，请使用上文的 stdio server：`npx -y @qverisai/mcp`。
+
+托管 MCP 端点可用后，接入流程会是：
+
+1. 创建或选择一个 QVeris API key。
+2. 从 QVeris 控制台或文档复制 hosted MCP URL。
+3. 按 MCP 客户端的远程 MCP 配置流程添加该 hosted URL。
+4. 运行 `qveris mcp validate --target <client>` 或使用客户端内置工具列表，确认 `discover`、`inspect`、`call` 可见。
+
+---
+
+## 可用 MCP 工具
+
+### 1. `discover`
+
+使用自然语言发现能力。
+
+这是**发现（Discover）**操作，**免费**使用。
+
+| 参数 | 类型 | 必填 | 说明 |
+|-----|------|------|------|
+| `query` | string | 是 | 用自然语言描述所需能力 |
+| `limit` | number | 否 | 最大返回数量（`1-100`，默认 `20`） |
+| `session_id` | string | 否 | 用于追踪的会话标识符 |
+
+示例：
+
+```json
+{
+  "query": "天气预报 API",
+  "limit": 10
+}
+```
+
+典型响应字段：
+
+- `search_id`
+- `total`
+- `results[]`
+- `results[].tool_id`
+- `results[].params`
+- `results[].examples`
+- `results[].stats`
+
+---
+
+### 2. `inspect`
+
+在复用或调用之前，检查一个或多个已知 `tool_id` 的详情。
+
+这是**检查（Inspect）**操作。
+
+| 参数 | 类型 | 必填 | 说明 |
+|-----|------|------|------|
+| `tool_ids` | array | 是 | 要查询的工具 ID 数组 |
+| `search_id` | string | 否 | 返回该工具的发现操作的搜索 ID |
+| `session_id` | string | 否 | 用于追踪的会话标识符 |
+
+示例：
+
+```json
+{
+  "tool_ids": ["openweathermap.weather.execute.v1"],
+  "search_id": "YOUR_SEARCH_ID"
+}
+```
+
+以下情况建议使用 `inspect`：
+
+- 多个候选能力看起来类似
+- 调用前想重新确认参数
+- 想检查成功率或延迟数据
+- 复用上一轮对话中发现的工具
+
+响应结构与 `/search` 一致，包含所请求工具的参数、示例和统计数据。
+
+---
+
+### 3. `call`
+
+调用已发现的 QVeris 能力。
+
+调用响应可能包含 compact 的 `billing` 预结算账单。最终是否扣费请通过 `usage_history` 或 `credits_ledger` 查询。
+
+| 参数 | 类型 | 必填 | 说明 |
+|-----|------|------|------|
+| `tool_id` | string | 是 | 来自发现结果的工具 ID |
+| `search_id` | string | 是 | 发现该工具的搜索 ID |
+| `params_to_tool` | object | 是 | 传递给工具的参数字典 |
+| `session_id` | string | 否 | 用于追踪的会话标识符 |
+| `max_response_size` | number | 否 | 最大响应字节数（默认 `20480`） |
+
+示例：
+
+```json
+{
+  "tool_id": "openweathermap.weather.execute.v1",
+  "search_id": "YOUR_SEARCH_ID",
+  "params_to_tool": {"city": "北京", "units": "metric"}
+}
+```
+
+典型成功响应字段：
+
+- `execution_id`
+- `tool_id`
+- `success`
+- `result.data`
+- `elapsed_time_ms` 或 `execution_time`
+- `billing` / `pre_settlement_bill`（如可用）
+
+---
+
+### 4. `usage_history`
+
+当用户询问某次调用是否成功、失败或扣费时使用。默认 `summary` 模式，不会把全量历史塞进上下文。
+
+常用参数：
+
+- `mode`: `summary`、`search` 或 `export_file`
+- `execution_id` / `search_id`
+- `charge_outcome`: `charged`、`included`、`failed_not_charged`、`failed_charged_review`
+- `min_credits` / `max_credits`
+- `start_date` / `end_date`
+
+`summary` 模式会优先请求服务端 `summary=true` 聚合摘要；若旧部署暂不支持，则回退到有上限的客户端聚合。
+
+示例：
+
+```json
+{ "mode": "search", "execution_id": "EXECUTION_ID" }
+```
+
+### 5. `credits_ledger`
+
+当用户询问余额为何变化时使用。默认 `summary` 模式。
+
+常用参数：
+
+- `mode`: `summary`、`search` 或 `export_file`
+- `direction`: `consume`、`grant` 或 `any`
+- `entry_type`
+- `min_credits` / `max_credits`
+- `start_date` / `end_date`
+
+`summary` 模式会优先请求服务端 `summary=true` 聚合摘要；若旧部署暂不支持，则回退到有上限的客户端聚合。
+
+示例：
+
+```json
+{ "mode": "search", "direction": "consume", "min_credits": 50 }
+```
+
+大量记录应使用 `mode: "export_file"`，MCP 服务器会写入 `.qveris/exports/*.jsonl` 并返回文件路径，而不是直接输出全量记录。
+
+对于超大的工具调用输出，QVeris 可能返回：
+
+- `truncated_content`
+- `full_content_file_url`
+- `message`
+
+---
+
+## 推荐使用模式
+
+对于大多数 Agent 任务，建议使用以下流程：
+
+1. `discover` — 发现相关能力
+2. `inspect` — 在需要时检查最佳候选
+3. `call` — 调用所选能力
+
+实践中：
+
+- 任务简单且最佳候选明确时，可直接从发现跳到调用
+- 任务风险较高或参数不清晰时，在调用前插入检查步骤
+- 复用上一轮找到的 `tool_id` 时，建议先重新检查再复用
+
+---
+
+## 会话管理
+
+在单次用户会话中提供一致的 `session_id` 有助于：
+
+- 保持用户会话连续性
+- 随时间推移优化工具选择
+- 更连贯的分析和追踪
+
+若省略 `session_id`，MCP 服务器可能会在进程存活期间自动生成一个。
+
+---
+
+## 故障排查
+
+### MCP 服务器未出现在客户端
+
+- 确认已安装 Node.js：`node --version`
+- 确认客户端 MCP 配置为有效 JSON
+- 确认 `QVERIS_API_KEY` 设置正确
+- 修改配置后重启 MCP 客户端
+
+### 工具可见但调用失败
+
+- 验证 API 密钥是否有效
+- 验证所选 `tool_id` 来自此前的发现结果
+- 重新运行 `inspect` 检查工具后再调用
+- 检查 `params_to_tool` 是否为有效对象
+
+### Windows 特定问题
+
+如果在某些客户端中直接执行 `npx` 失败，用 `cmd /c` 包裹：
+
+```json
+{
+  "command": "cmd",
+  "args": ["/c", "npx", "-y", "@qverisai/mcp"]
+}
+```
+
+---
+
+## 相关文档
+
+- [快速开始](getting-started.md)
+- [REST API 文档](rest-api.md)
+- [Agent 安装指南](../../../agent/SETUP.md)
+- [IDE / CLI 配置指南](ide-cli-setup.md)

--- a/docs/cn/zh-CN/opencode-setup.md
+++ b/docs/cn/zh-CN/opencode-setup.md
@@ -1,0 +1,112 @@
+# OpenCode 配置指南
+
+本指南介绍如何在 [OpenCode](https://opencode.ai/) 中以用户级别配置 QVeris MCP 服务器和技能。
+
+## 前置条件
+
+- 已安装 Node.js
+- 已安装 OpenCode（[安装指南](https://opencode.ai/docs/)）
+- QVeris API 密钥（从 [https://qveris.cn](https://qveris.cn) 获取）
+
+## 1. MCP 服务器配置
+
+可以用 QVeris CLI 生成并写入配置：
+
+```bash
+qveris mcp configure --target opencode --write --include-key
+qveris mcp validate --target opencode
+```
+
+也可以手动配置：
+
+创建或编辑全局 OpenCode 配置文件：
+
+**Mac/Linux：**
+```
+~/.config/opencode/opencode.json
+```
+
+**Windows：**
+```
+%USERPROFILE%\.config\opencode\opencode.json
+```
+
+添加以下内容（将 `your-api-key-here` 替换为你的实际 API 密钥）：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "qveris": {
+      "type": "local",
+      "command": ["npx", "-y", "@qverisai/mcp"],
+      "environment": {
+        "QVERIS_API_KEY": "your-api-key-here"
+      },
+      "enabled": true
+    }
+  },
+  "tools": {
+    "qveris*": true
+  }
+}
+```
+
+如果已有 `opencode.json` 文件，请将 `mcp.qveris` 和 `tools["qveris*"]` 部分合并到现有配置中。
+
+## 2. 技能配置
+
+从 GitHub 仓库下载 QVeris MCP/客户端技能：
+
+**仓库地址：**https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/skills/qveris
+
+**Mac/Linux：**
+```bash
+mkdir -p ~/.config/opencode/skill/qveris
+curl -sL https://raw.githubusercontent.com/QVerisAI/qveris-agent-toolkit/main/skills/qveris/SKILL.md -o ~/.config/opencode/skill/qveris/SKILL.md
+```
+
+**Windows（PowerShell）：**
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.config\opencode\skill\qveris"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/QVerisAI/qveris-agent-toolkit/main/skills/qveris/SKILL.md" -OutFile "$env:USERPROFILE\.config\opencode\skill\qveris\SKILL.md"
+```
+
+技能目录结构应如下所示：
+```
+~/.config/opencode/skill/
+└── qveris/
+    └── SKILL.md
+```
+
+## 验证
+
+1. 重启 OpenCode
+2. 运行 `/mcp` 命令查看已连接的服务器
+3. 让 OpenCode 使用 QVeris 搜索工具
+4. 技能会自动发现 — Agent 可通过 `skill` 工具查看可用技能
+
+## 使用
+
+配置完成后，在提示词中引用 QVeris 即可：
+
+```
+请编写一个 Python 脚本，打印当前比特币价格。使用 qveris。
+```
+
+OpenCode 的 Agent 会自动发现 QVeris 技能和 MCP 服务器，找到并执行合适的 API 工具。
+
+## 故障排查
+
+**MCP 服务器未连接：**
+- 验证 Node.js 是否已安装：`node --version`
+- 手动测试 MCP 服务器：`npx -y @qverisai/mcp`
+- 检查 API 密钥是否正确
+
+**技能未加载：**
+- 确认文件名为全大写的 `SKILL.md`
+- 检查 frontmatter 中是否包含 `name` 和 `description`
+- 确保技能目录名与 frontmatter 中的 name 一致
+
+**Windows 问题：**
+- 如果 `npx` 失败，请尝试使用完整路径或确保 Node.js 已添加到 PATH

--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -1,0 +1,301 @@
+# QVeris Python SDK
+
+异步 Python SDK，让你在自己的 Agent 和应用中发现、检查、调用并审计 10,000+ 真实已验证的 API 能力。
+
+SDK 提供两种控制粒度：
+
+- **`QverisClient`** —— QVeris REST API 的轻量类型化封装（`discover`、`inspect`、`call`、`usage`、`ledger`）。
+- **`Agent`** —— 开箱即用的 LLM 工具循环，让模型自主发现并调用能力。
+
+需要完全控制时用 client；想几行代码就跑起来一个可用助手时用 agent。
+
+## 安装
+
+```bash
+pip install qveris
+```
+
+需要 Python 3.8+。运行时依赖：`httpx`、`pydantic`、`pydantic-settings`、`openai`。
+
+## 身份认证（中国区）
+
+SDK 从环境变量 `QVERIS_API_KEY` 读取 API 密钥。**SDK 默认指向全球区 `https://qveris.ai/api/v1/`，中国区用户必须显式指向 `https://qveris.cn`**：
+
+```bash
+export QVERIS_API_KEY="sk-cn-..."
+export QVERIS_BASE_URL="https://qveris.cn/api/v1"
+```
+
+在 [qveris.cn](https://qveris.cn) 获取密钥（中国区密钥为 `sk-cn-` 前缀）。也可以显式传入配置：
+
+```python
+from qveris import QverisClient, QverisConfig
+
+client = QverisClient(QverisConfig(
+    api_key="sk-cn-...",
+    base_url="https://qveris.cn/api/v1",
+))
+```
+
+> 注意：与 CLI / MCP 服务器不同，Python SDK **不会**根据 `sk-cn-` 前缀自动切换区域。中国区必须通过 `QVERIS_BASE_URL` 环境变量或 `QverisConfig(base_url=...)` 显式设置 `https://qveris.cn/api/v1`。
+
+## 快速开始
+
+核心流程是 **discover（发现）→ inspect（检查）→ call（调用）**，之后可选 **audit（审计）**。所有方法都是 `async`。
+
+```python
+import asyncio
+from qveris import QverisClient, QverisConfig
+
+async def main():
+    client = QverisClient(QverisConfig(base_url="https://qveris.cn/api/v1"))
+    try:
+        # 1. 用自然语言发现能力（免费）
+        discovered = await client.discover("天气预报 API", limit=5)
+        tool = discovered.results[0]
+
+        # 2. 检查所选能力，获取完整参数
+        inspected = await client.inspect([tool.tool_id], search_id=discovered.search_id)
+        selected = inspected.results[0]
+
+        # 3. 调用（可能消耗积分）
+        params = (
+            selected.examples.sample_parameters
+            if selected.examples and selected.examples.sample_parameters
+            else {"city": "London"}
+        )
+        result = await client.call(
+            selected.tool_id,
+            params,
+            search_id=discovered.search_id,
+            max_response_size=20480,
+        )
+        print(result.success, result.result)
+
+        # 4. 审计最终扣费结果
+        usage = await client.usage(execution_id=result.execution_id, summary=True)
+        ledger = await client.ledger(summary=True, limit=5)
+        print(usage.total, ledger.total)
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```
+
+> `QverisClient` 持有一个 HTTP 连接池。用完务必 `await client.close()`（建议放在 `finally` 中）。
+>
+> 若已设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1` 环境变量，可直接 `QverisClient()`，无需再传 `base_url`。
+
+## Agent（智能体）
+
+`Agent` 把同一套流程封装成一个 LLM 工具循环。模型会拿到 `discover`、`inspect`、`call` 三个工具并自行决定何时调用。
+
+默认 agent 使用 OpenAI 兼容的 provider。配合国内可用的 OpenAI 兼容服务时，设置：
+
+```bash
+export OPENAI_API_KEY="..."
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"   # 你的 OpenAI 兼容服务地址
+```
+
+QVeris 区域仍由 `QVERIS_BASE_URL` 控制，与 LLM provider 相互独立。
+
+### 流式
+
+```python
+import asyncio
+from qveris import Agent, Message, QverisConfig
+
+async def main():
+    async with Agent(config=QverisConfig(base_url="https://qveris.cn/api/v1")) as agent:
+        messages = [Message(role="user", content="查一下北京现在的天气。")]
+        async for event in agent.run(messages):
+            if event.type == "content" and event.content:
+                print(event.content, end="", flush=True)
+
+asyncio.run(main())
+```
+
+`Agent` 是异步上下文管理器 —— `async with Agent() as agent:` 会自动释放网络资源。
+
+### 仅要最终文本
+
+只需要最终回答时：
+
+```python
+async with Agent(config=QverisConfig(base_url="https://qveris.cn/api/v1")) as agent:
+    answer = await agent.run_to_completion(
+        [Message(role="user", content="找一个股票报价能力并查询 AAPL。")]
+    )
+    print(answer)
+```
+
+### 事件类型
+
+`Agent.run(messages)` 产出 `StreamEvent` 对象。通过 `event.type` 区分：
+
+| `type` | 含义 |
+|--------|------|
+| `content` | 助手文本（流式时为增量分片，否则为完整消息） |
+| `reasoning` / `reasoning_details` | 部分 provider 的推理 token / 结构化推理 |
+| `tool_call` | 模型正在调用 `discover` / `inspect` / `call`（或你的额外工具） |
+| `tool_result` | 工具调用的执行结果（`event.tool_result` 含 `name`、`result`、`is_error`） |
+| `metrics` | provider 上报的 token 用量 / 耗时 |
+| `error` | 终止本次运行的致命错误 |
+
+给 `run(...)` 传 `stream=False` 可改为接收完整助手轮次而非增量分片。
+
+## 配置参考
+
+### `QverisConfig`
+
+| 字段 | 环境变量 | 默认值 | 说明 |
+|------|---------|--------|------|
+| `api_key` | `QVERIS_API_KEY` | `None` | API 密钥，以 `Authorization: Bearer ...` 发送 |
+| `base_url` | `QVERIS_BASE_URL` | `https://qveris.ai/api/v1/` | API 基础地址；**中国区须设为 `https://qveris.cn/api/v1`** |
+| `enable_history_pruning` | — | `True` | 裁剪/压缩旧的工具输出以节省 token（agent 循环） |
+| `max_iterations` | — | `50` | agent 工具循环的最大迭代次数 |
+
+### `AgentConfig`
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `model` | `gpt-4o` | 传给当前 LLM provider 的模型名 |
+| `additional_system_prompt` | `None` | 追加到默认工具使用系统提示词之后 |
+| `temperature` | `0.7` | 在 provider 支持时透传 |
+
+```python
+from qveris import Agent, QverisConfig, AgentConfig
+
+agent = Agent(
+    config=QverisConfig(base_url="https://qveris.cn/api/v1", max_iterations=20),
+    agent_config=AgentConfig(model="gpt-4o", temperature=0.2),
+)
+```
+
+## API 参考
+
+### `QverisClient`
+
+| 方法 | REST 端点 | 用途 |
+|------|-----------|------|
+| `discover(query, limit=20, session_id=None)` | `POST /search` | 用自然语言发现能力（免费） |
+| `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
+| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None)` | `POST /tools/execute` | 执行能力（可能消耗积分） |
+| `usage(**filters)` | `GET /auth/usage/history/v2` | 审计请求状态与扣费结果 |
+| `ledger(**filters)` | `GET /auth/credits/ledger` | 查看最终积分余额变动 |
+| `handle_tool_call(func_name, func_args, session_id=None)` | — | 把 LLM 工具调用桥接到对应的 QVeris 方法 |
+| `close()` | — | 关闭底层 HTTP 客户端 |
+
+`tool_ids` 接受单个字符串或可迭代对象。`usage(...)` 和 `ledger(...)` 接受仅关键字过滤参数，如 `start_date`、`end_date`、`summary`（默认 `True`）、`bucket`、`charge_outcome`、`execution_id`、`search_id`、`direction`、`entry_type`、`min_credits`、`max_credits`、`limit`、`page`、`page_size`。
+
+仍保留向后兼容别名：`search_tools` → `discover`，`get_tools_by_ids` → `inspect`，`execute_tool` → `call`。
+
+### `Agent`
+
+| 成员 | 说明 |
+|------|------|
+| `run(messages, stream=True)` | 产出 `StreamEvent` 的异步生成器；主集成 API |
+| `run_to_completion(messages)` | 非流式；返回最终助手文本 |
+| `get_last_messages()` | 上一次 `run(...)` 的对话历史，含工具调用/结果 |
+| `new_session()` | 重置关联/会话 id |
+| `close()` | 释放网络资源（或用 `async with`） |
+
+构造函数：`Agent(config=None, agent_config=None, llm_provider=None, extra_tools=None, extra_tool_handler=None, debug_callback=None)`。
+
+## 类型化模型
+
+SDK 返回 Pydantic v2 模型，因此你能获得自动补全与校验。未知的后端字段会被保留，因此较新的 API 元数据不会破坏较旧的 SDK 客户端。
+
+- 发现 / 检查：`SearchResponse` → `results: list[ToolInfo]`；`ToolInfo` 含 `tool_id`、`name`、`description`、`params: list[ToolParameter]`、`examples`、`stats`、`billing_rule`。
+- 调用：`ToolExecutionResponse`，含 `execution_id`、`success`、`result`、`error_message`、`billing`（`CompactBillingStatement`）、`cost`、`remaining_credits`。
+- 调用审计：`UsageHistoryResponse` → `items: list[UsageEventItem]`、`total`、`summary`。
+- 积分账本：`CreditsLedgerResponse` → `items: list[CreditsLedgerItem]`、`total`、`summary`。
+
+```python
+from qveris import ToolExecutionResponse
+
+def explain(result: ToolExecutionResponse) -> str:
+    if not result.success:
+        return f"失败：{result.error_message}"
+    charged = result.billing.summary if result.billing else "无计费信息"
+    return f"成功（{charged}）；剩余={result.remaining_credits}"
+```
+
+## 集成方式
+
+按你的应用选择合适的粒度：
+
+- **直接使用类型化 client** —— 在自己的代码里调用 `discover`/`inspect`/`call`/`usage`/`ledger`。
+- **内置流式 agent** —— `Agent.run(messages)` 并消费 `StreamEvent`。
+- **内置非流式 agent** —— `Agent.run(messages, stream=False)`，获取完整轮次与事件。
+- **仅要最终文本** —— `Agent.run_to_completion(messages)`。
+- **自带循环** —— 把 QVeris 工具 schema 暴露给你自己的 LLM provider，再把工具调用路由回 client：
+
+```python
+from qveris import QverisClient, QverisConfig
+from qveris.client.tools import DISCOVER_TOOL_DEF, INSPECT_TOOL_DEF, CALL_TOOL_DEF
+
+tools = [DISCOVER_TOOL_DEF, INSPECT_TOOL_DEF, CALL_TOOL_DEF]
+client = QverisClient(QverisConfig(base_url="https://qveris.cn/api/v1"))
+
+# ... 你的 LLM 产出一个工具调用 (func_name, func_args) ...
+result, is_error, handled = await client.handle_tool_call(func_name, func_args)
+if handled and not is_error:
+    ...  # 把 result 回传给模型
+```
+
+### 自定义 LLM provider
+
+默认 `Agent()` 使用内置的 OpenAI 兼容 provider。如需对接其他模型 API，实现 `LLMProvider` 并传入：
+
+```python
+from typing import AsyncGenerator, List
+from openai.types.chat import ChatCompletionToolParam
+from qveris import Agent
+from qveris.config import AgentConfig
+from qveris.llm.base import LLMProvider
+from qveris.types import ChatResponse, Message, StreamEvent
+
+class MyProvider(LLMProvider):
+    async def chat_stream(self, messages: List[Message], tools: List[ChatCompletionToolParam], config: AgentConfig) -> AsyncGenerator[StreamEvent, None]:
+        ...
+
+    async def chat(self, messages: List[Message], tools: List[ChatCompletionToolParam], config: AgentConfig) -> ChatResponse:
+        ...
+
+agent = Agent(llm_provider=MyProvider())
+```
+
+## 错误处理
+
+- HTTP 错误抛出 `httpx.HTTPStatusError`；业务失败信封抛出 `RuntimeError`。
+- 在 agent 循环内部，provider/传输错误不会抛出 —— 它们以 `error` 类型的 `StreamEvent` 暴露并结束本次运行。`run_to_completion(...)` 会将其重新抛为 `RuntimeError`。
+- `result.success` 只反映能力调用本身。**不要**把它当作最终扣费结论 —— 用 `usage(...)` / `ledger(...)` 确认扣费。
+
+## 示例
+
+可运行示例位于 [`packages/python-sdk/examples/`](https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk/examples)：
+
+| 示例 | 场景 |
+|------|------|
+| `finance_research.py` | 股票报价 / 市场数据研究 |
+| `risk_compliance.py` | 制裁、负面舆情、合规筛查 |
+| `crypto_market.py` | 加密货币价格与成交量数据 |
+| `data_analysis.py` | 用外部能力数据丰富数据集 |
+| `agent_loop_integration.py` | LLM agent 循环集成 |
+
+设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。运行前请确保已设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1`。
+
+## 兼容性
+
+- Python `>=3.8`。
+- 公开方法与 Pydantic 模型字段尽量遵循增量兼容。
+- 规范方法替代上线后，弃用别名至少保留一个小版本。
+- 破坏性变更需要主版本号升级并附迁移说明。
+
+## 链接
+
+- 包：[PyPI 上的 `qveris`](https://pypi.org/project/qveris/)
+- 源码：[`packages/python-sdk`](https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk)
+- REST API：[rest-api.md](rest-api.md)
+- 获取 API 密钥：[qveris.cn](https://qveris.cn)

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -89,6 +89,8 @@ The Python SDK now lives in this monorepo at [`packages/python-sdk`](../../packa
 pip install qveris
 ```
 
+For the full guide (client, agent, typed models, integration patterns), see [Python SDK](python-sdk.md).
+
 Set environment variables:
 
 - `QVERIS_API_KEY` (from [QVeris](https://qveris.ai))

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -1,0 +1,293 @@
+# QVeris Python SDK
+
+Async Python SDK to discover, inspect, call, and audit 10,000+ real-world API capabilities from your own agents and applications.
+
+The SDK gives you two levels of control:
+
+- **`QverisClient`** — a thin typed wrapper over the QVeris REST API (`discover`, `inspect`, `call`, `usage`, `ledger`).
+- **`Agent`** — a ready-made LLM tool loop that lets a model discover and call capabilities on its own.
+
+Use the client when you want full control, or the agent when you want a working assistant in a few lines.
+
+## Installation
+
+```bash
+pip install qveris
+```
+
+Requires Python 3.8+. Runtime dependencies: `httpx`, `pydantic`, `pydantic-settings`, `openai`.
+
+## Authentication
+
+The SDK reads your API key from the `QVERIS_API_KEY` environment variable:
+
+```bash
+export QVERIS_API_KEY="sk-..."
+```
+
+Get a key at [qveris.ai](https://qveris.ai). You can also pass configuration explicitly:
+
+```python
+from qveris import QverisClient, QverisConfig
+
+client = QverisClient(QverisConfig(api_key="sk-..."))
+```
+
+The default API base URL is `https://qveris.ai/api/v1/`. Override it with the `QVERIS_BASE_URL` environment variable or `QverisConfig(base_url=...)` when targeting another region or a custom endpoint.
+
+## Quickstart
+
+The core workflow is **discover → inspect → call**, then optionally **audit** what happened. All methods are `async`.
+
+```python
+import asyncio
+from qveris import QverisClient
+
+async def main():
+    client = QverisClient()
+    try:
+        # 1. Discover capabilities with natural language (free)
+        discovered = await client.discover("weather forecast API", limit=5)
+        tool = discovered.results[0]
+
+        # 2. Inspect the selected capability for full parameters
+        inspected = await client.inspect([tool.tool_id], search_id=discovered.search_id)
+        selected = inspected.results[0]
+
+        # 3. Call it (may consume credits)
+        params = (
+            selected.examples.sample_parameters
+            if selected.examples and selected.examples.sample_parameters
+            else {"city": "London"}
+        )
+        result = await client.call(
+            selected.tool_id,
+            params,
+            search_id=discovered.search_id,
+            max_response_size=20480,
+        )
+        print(result.success, result.result)
+
+        # 4. Audit the final charge outcome
+        usage = await client.usage(execution_id=result.execution_id, summary=True)
+        ledger = await client.ledger(summary=True, limit=5)
+        print(usage.total, ledger.total)
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```
+
+> `QverisClient` owns an HTTP connection pool. Always `await client.close()` when you are done (e.g. in a `finally` block).
+
+## The Agent
+
+`Agent` wraps the same workflow into an LLM tool loop. The model is given the `discover`, `inspect`, and `call` tools and decides when to use them.
+
+The default agent uses an OpenAI-compatible provider, so set:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export OPENAI_BASE_URL="https://api.openai.com/v1"   # optional; for OpenAI-compatible providers
+```
+
+### Streaming
+
+```python
+import asyncio
+from qveris import Agent, Message
+
+async def main():
+    async with Agent() as agent:
+        messages = [Message(role="user", content="Check the current weather in New York.")]
+        async for event in agent.run(messages):
+            if event.type == "content" and event.content:
+                print(event.content, end="", flush=True)
+
+asyncio.run(main())
+```
+
+`Agent` is an async context manager — `async with Agent() as agent:` closes network resources automatically.
+
+### Final text only
+
+When you just want the finished answer:
+
+```python
+async with Agent() as agent:
+    answer = await agent.run_to_completion(
+        [Message(role="user", content="Find a stock quote capability and quote AAPL.")]
+    )
+    print(answer)
+```
+
+### Event types
+
+`Agent.run(messages)` yields `StreamEvent` objects. Inspect `event.type`:
+
+| `type` | Meaning |
+|--------|---------|
+| `content` | Assistant text (delta chunks when streaming, full message otherwise) |
+| `reasoning` / `reasoning_details` | Optional reasoning tokens / structured reasoning from some providers |
+| `tool_call` | The model is invoking `discover` / `inspect` / `call` (or one of your extra tools) |
+| `tool_result` | Output of an executed tool call (`event.tool_result` has `name`, `result`, `is_error`) |
+| `metrics` | Token usage / timing, when the provider reports it |
+| `error` | Fatal error that ended the run |
+
+Pass `stream=False` to `run(...)` to receive complete assistant turns instead of deltas.
+
+## Configuration reference
+
+### `QverisConfig`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `api_key` | `QVERIS_API_KEY` | `None` | API key, sent as `Authorization: Bearer ...` |
+| `base_url` | `QVERIS_BASE_URL` | `https://qveris.ai/api/v1/` | API base URL |
+| `enable_history_pruning` | — | `True` | Prune/compress old tool outputs to save tokens (agent loop) |
+| `max_iterations` | — | `50` | Max agent tool-loop iterations |
+
+### `AgentConfig`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `model` | `gpt-4o` | Model name passed to the active LLM provider |
+| `additional_system_prompt` | `None` | Appended to the default tool-use system prompt |
+| `temperature` | `0.7` | Forwarded to the provider when supported |
+
+```python
+from qveris import Agent, QverisConfig, AgentConfig
+
+agent = Agent(
+    config=QverisConfig(max_iterations=20),
+    agent_config=AgentConfig(model="gpt-4o", temperature=0.2),
+)
+```
+
+## API reference
+
+### `QverisClient`
+
+| Method | REST endpoint | Purpose |
+|--------|---------------|---------|
+| `discover(query, limit=20, session_id=None)` | `POST /search` | Find capabilities with natural language (free) |
+| `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | Fetch full capability metadata (free) |
+| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None)` | `POST /tools/execute` | Execute a capability (may consume credits) |
+| `usage(**filters)` | `GET /auth/usage/history/v2` | Audit request status and charge outcome |
+| `ledger(**filters)` | `GET /auth/credits/ledger` | Inspect final credit balance movements |
+| `handle_tool_call(func_name, func_args, session_id=None)` | — | Bridge an LLM tool call to the right QVeris method |
+| `close()` | — | Close the underlying HTTP client |
+
+`tool_ids` accepts a single string or an iterable. `usage(...)` and `ledger(...)` take keyword-only filters such as `start_date`, `end_date`, `summary` (default `True`), `bucket`, `charge_outcome`, `execution_id`, `search_id`, `direction`, `entry_type`, `min_credits`, `max_credits`, `limit`, `page`, `page_size`.
+
+Backward-compatible aliases remain available: `search_tools` → `discover`, `get_tools_by_ids` → `inspect`, `execute_tool` → `call`.
+
+### `Agent`
+
+| Member | Description |
+|--------|-------------|
+| `run(messages, stream=True)` | Async generator of `StreamEvent`; primary integration API |
+| `run_to_completion(messages)` | Non-streaming; returns the final assistant text |
+| `get_last_messages()` | Conversation history from the last `run(...)`, including tool calls/results |
+| `new_session()` | Reset the correlation/session id |
+| `close()` | Close network resources (or use `async with`) |
+
+Constructor: `Agent(config=None, agent_config=None, llm_provider=None, extra_tools=None, extra_tool_handler=None, debug_callback=None)`.
+
+## Typed models
+
+The SDK returns Pydantic v2 models, so you get autocomplete and validation. Unknown backend fields are preserved, so newer API metadata will not break older SDK clients.
+
+- Discovery / inspect: `SearchResponse` → `results: list[ToolInfo]`; `ToolInfo` has `tool_id`, `name`, `description`, `params: list[ToolParameter]`, `examples`, `stats`, `billing_rule`.
+- Call: `ToolExecutionResponse` with `execution_id`, `success`, `result`, `error_message`, `billing` (`CompactBillingStatement`), `cost`, `remaining_credits`.
+- Usage audit: `UsageHistoryResponse` → `items: list[UsageEventItem]`, `total`, `summary`.
+- Credits ledger: `CreditsLedgerResponse` → `items: list[CreditsLedgerItem]`, `total`, `summary`.
+
+```python
+from qveris import ToolExecutionResponse
+
+def explain(result: ToolExecutionResponse) -> str:
+    if not result.success:
+        return f"failed: {result.error_message}"
+    charged = result.billing.summary if result.billing else "no billing info"
+    return f"ok ({charged}); remaining={result.remaining_credits}"
+```
+
+## Integration patterns
+
+Use the level that matches your application:
+
+- **Direct typed client** — call `discover`/`inspect`/`call`/`usage`/`ledger` from your own code.
+- **Built-in streaming agent** — `Agent.run(messages)` and consume `StreamEvent` values.
+- **Built-in non-streaming agent** — `Agent.run(messages, stream=False)` for complete turns plus events.
+- **Final text only** — `Agent.run_to_completion(messages)`.
+- **Bring your own loop** — expose the QVeris tool schemas to your own LLM provider, then route tool calls back through the client:
+
+```python
+from qveris import QverisClient
+from qveris.client.tools import DISCOVER_TOOL_DEF, INSPECT_TOOL_DEF, CALL_TOOL_DEF
+
+tools = [DISCOVER_TOOL_DEF, INSPECT_TOOL_DEF, CALL_TOOL_DEF]
+client = QverisClient()
+
+# ... your LLM emits a tool call (func_name, func_args) ...
+result, is_error, handled = await client.handle_tool_call(func_name, func_args)
+if handled and not is_error:
+    ...  # feed result back to your model
+```
+
+### Custom LLM providers
+
+The default `Agent()` uses the built-in OpenAI-compatible provider. For other model APIs, implement `LLMProvider` and pass it in:
+
+```python
+from typing import AsyncGenerator, List
+from openai.types.chat import ChatCompletionToolParam
+from qveris import Agent
+from qveris.config import AgentConfig
+from qveris.llm.base import LLMProvider
+from qveris.types import ChatResponse, Message, StreamEvent
+
+class MyProvider(LLMProvider):
+    async def chat_stream(self, messages: List[Message], tools: List[ChatCompletionToolParam], config: AgentConfig) -> AsyncGenerator[StreamEvent, None]:
+        ...
+
+    async def chat(self, messages: List[Message], tools: List[ChatCompletionToolParam], config: AgentConfig) -> ChatResponse:
+        ...
+
+agent = Agent(llm_provider=MyProvider())
+```
+
+## Error handling
+
+- HTTP errors raise `httpx.HTTPStatusError`; business-failure envelopes raise `RuntimeError`.
+- Inside the agent loop, provider/transport errors do not raise — they are surfaced as an `error` `StreamEvent` and end the run. `run_to_completion(...)` re-raises them as `RuntimeError`.
+- `result.success` reflects the capability call only. **Do not** treat it as the final billing outcome — confirm charges with `usage(...)` / `ledger(...)`.
+
+## Examples
+
+Runnable examples live under [`packages/python-sdk/examples/`](https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk/examples):
+
+| Example | Scenario |
+|---------|----------|
+| `finance_research.py` | Stock quote / market data research |
+| `risk_compliance.py` | Sanctions, adverse media, compliance screening |
+| `crypto_market.py` | Crypto price and volume data |
+| `data_analysis.py` | Dataset enrichment with external capability data |
+| `agent_loop_integration.py` | LLM agent loop integration |
+
+Capability examples run `discover`/`inspect` when `QVERIS_API_KEY` is set, and only execute `call` when `RUN_QVERIS_CALLS=1`.
+
+## Compatibility
+
+- Python `>=3.8`.
+- Public methods and Pydantic model fields follow additive compatibility where possible.
+- Deprecated aliases remain for at least one minor release after a canonical replacement ships.
+- Breaking changes require a major version bump and migration notes.
+
+## Links
+
+- Package: [`qveris` on PyPI](https://pypi.org/project/qveris/)
+- Source: [`packages/python-sdk`](https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk)
+- REST API: [rest-api.md](rest-api.md)
+- Get an API key: [qveris.ai](https://qveris.ai)

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -89,6 +89,8 @@ Python SDK 现在位于本单体仓库的 [`packages/python-sdk`](../../packages
 pip install qveris
 ```
 
+完整指南（client、agent、类型化模型、集成方式）见 [Python SDK](python-sdk.md)。
+
 设置环境变量：
 
 - `QVERIS_API_KEY`（从 [QVeris](https://qveris.ai) 获取）

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -1,0 +1,293 @@
+# QVeris Python SDK
+
+异步 Python SDK，让你在自己的智能体和应用中发现、检查、调用并审计 10,000+ 真实已验证的 API 能力。
+
+SDK 提供两种控制粒度：
+
+- **`QverisClient`** —— QVeris REST API 的轻量类型化封装（`discover`、`inspect`、`call`、`usage`、`ledger`）。
+- **`Agent`** —— 开箱即用的 LLM 工具循环，让模型自主发现并调用能力。
+
+需要完全控制时用 client；想几行代码就跑起来一个可用助手时用 agent。
+
+## 安装
+
+```bash
+pip install qveris
+```
+
+需要 Python 3.8+。运行时依赖：`httpx`、`pydantic`、`pydantic-settings`、`openai`。
+
+## 身份认证
+
+SDK 从环境变量 `QVERIS_API_KEY` 读取 API 密钥：
+
+```bash
+export QVERIS_API_KEY="sk-..."
+```
+
+在 [qveris.ai](https://qveris.ai) 获取密钥。也可以显式传入配置：
+
+```python
+from qveris import QverisClient, QverisConfig
+
+client = QverisClient(QverisConfig(api_key="sk-..."))
+```
+
+默认 API 基础地址为 `https://qveris.ai/api/v1/`。如需指向其他区域或自定义端点，用环境变量 `QVERIS_BASE_URL` 或 `QverisConfig(base_url=...)` 覆盖。
+
+## 快速开始
+
+核心流程是 **discover（发现）→ inspect（检查）→ call（调用）**，之后可选 **audit（审计）**。所有方法都是 `async`。
+
+```python
+import asyncio
+from qveris import QverisClient
+
+async def main():
+    client = QverisClient()
+    try:
+        # 1. 用自然语言发现能力（免费）
+        discovered = await client.discover("天气预报 API", limit=5)
+        tool = discovered.results[0]
+
+        # 2. 检查所选能力，获取完整参数
+        inspected = await client.inspect([tool.tool_id], search_id=discovered.search_id)
+        selected = inspected.results[0]
+
+        # 3. 调用（可能消耗积分）
+        params = (
+            selected.examples.sample_parameters
+            if selected.examples and selected.examples.sample_parameters
+            else {"city": "London"}
+        )
+        result = await client.call(
+            selected.tool_id,
+            params,
+            search_id=discovered.search_id,
+            max_response_size=20480,
+        )
+        print(result.success, result.result)
+
+        # 4. 审计最终扣费结果
+        usage = await client.usage(execution_id=result.execution_id, summary=True)
+        ledger = await client.ledger(summary=True, limit=5)
+        print(usage.total, ledger.total)
+    finally:
+        await client.close()
+
+asyncio.run(main())
+```
+
+> `QverisClient` 持有一个 HTTP 连接池。用完务必 `await client.close()`（建议放在 `finally` 中）。
+
+## Agent（智能体）
+
+`Agent` 把同一套流程封装成一个 LLM 工具循环。模型会拿到 `discover`、`inspect`、`call` 三个工具并自行决定何时调用。
+
+默认 agent 使用 OpenAI 兼容的 provider，因此需要设置：
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export OPENAI_BASE_URL="https://api.openai.com/v1"   # 可选；用于 OpenAI 兼容 provider
+```
+
+### 流式
+
+```python
+import asyncio
+from qveris import Agent, Message
+
+async def main():
+    async with Agent() as agent:
+        messages = [Message(role="user", content="查一下纽约现在的天气。")]
+        async for event in agent.run(messages):
+            if event.type == "content" and event.content:
+                print(event.content, end="", flush=True)
+
+asyncio.run(main())
+```
+
+`Agent` 是异步上下文管理器 —— `async with Agent() as agent:` 会自动释放网络资源。
+
+### 仅要最终文本
+
+只需要最终回答时：
+
+```python
+async with Agent() as agent:
+    answer = await agent.run_to_completion(
+        [Message(role="user", content="找一个股票报价能力并查询 AAPL。")]
+    )
+    print(answer)
+```
+
+### 事件类型
+
+`Agent.run(messages)` 产出 `StreamEvent` 对象。通过 `event.type` 区分：
+
+| `type` | 含义 |
+|--------|------|
+| `content` | 助手文本（流式时为增量分片，否则为完整消息） |
+| `reasoning` / `reasoning_details` | 部分 provider 的推理 token / 结构化推理 |
+| `tool_call` | 模型正在调用 `discover` / `inspect` / `call`（或你的额外工具） |
+| `tool_result` | 工具调用的执行结果（`event.tool_result` 含 `name`、`result`、`is_error`） |
+| `metrics` | provider 上报的 token 用量 / 耗时 |
+| `error` | 终止本次运行的致命错误 |
+
+给 `run(...)` 传 `stream=False` 可改为接收完整助手轮次而非增量分片。
+
+## 配置参考
+
+### `QverisConfig`
+
+| 字段 | 环境变量 | 默认值 | 说明 |
+|------|---------|--------|------|
+| `api_key` | `QVERIS_API_KEY` | `None` | API 密钥，以 `Authorization: Bearer ...` 发送 |
+| `base_url` | `QVERIS_BASE_URL` | `https://qveris.ai/api/v1/` | API 基础地址 |
+| `enable_history_pruning` | — | `True` | 裁剪/压缩旧的工具输出以节省 token（agent 循环） |
+| `max_iterations` | — | `50` | agent 工具循环的最大迭代次数 |
+
+### `AgentConfig`
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `model` | `gpt-4o` | 传给当前 LLM provider 的模型名 |
+| `additional_system_prompt` | `None` | 追加到默认工具使用系统提示词之后 |
+| `temperature` | `0.7` | 在 provider 支持时透传 |
+
+```python
+from qveris import Agent, QverisConfig, AgentConfig
+
+agent = Agent(
+    config=QverisConfig(max_iterations=20),
+    agent_config=AgentConfig(model="gpt-4o", temperature=0.2),
+)
+```
+
+## API 参考
+
+### `QverisClient`
+
+| 方法 | REST 端点 | 用途 |
+|------|-----------|------|
+| `discover(query, limit=20, session_id=None)` | `POST /search` | 用自然语言发现能力（免费） |
+| `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
+| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None)` | `POST /tools/execute` | 执行能力（可能消耗积分） |
+| `usage(**filters)` | `GET /auth/usage/history/v2` | 审计请求状态与扣费结果 |
+| `ledger(**filters)` | `GET /auth/credits/ledger` | 查看最终积分余额变动 |
+| `handle_tool_call(func_name, func_args, session_id=None)` | — | 把 LLM 工具调用桥接到对应的 QVeris 方法 |
+| `close()` | — | 关闭底层 HTTP 客户端 |
+
+`tool_ids` 接受单个字符串或可迭代对象。`usage(...)` 和 `ledger(...)` 接受仅关键字过滤参数，如 `start_date`、`end_date`、`summary`（默认 `True`）、`bucket`、`charge_outcome`、`execution_id`、`search_id`、`direction`、`entry_type`、`min_credits`、`max_credits`、`limit`、`page`、`page_size`。
+
+仍保留向后兼容别名：`search_tools` → `discover`，`get_tools_by_ids` → `inspect`，`execute_tool` → `call`。
+
+### `Agent`
+
+| 成员 | 说明 |
+|------|------|
+| `run(messages, stream=True)` | 产出 `StreamEvent` 的异步生成器；主集成 API |
+| `run_to_completion(messages)` | 非流式；返回最终助手文本 |
+| `get_last_messages()` | 上一次 `run(...)` 的对话历史，含工具调用/结果 |
+| `new_session()` | 重置关联/会话 id |
+| `close()` | 释放网络资源（或用 `async with`） |
+
+构造函数：`Agent(config=None, agent_config=None, llm_provider=None, extra_tools=None, extra_tool_handler=None, debug_callback=None)`。
+
+## 类型化模型
+
+SDK 返回 Pydantic v2 模型，因此你能获得自动补全与校验。未知的后端字段会被保留，因此较新的 API 元数据不会破坏较旧的 SDK 客户端。
+
+- 发现 / 检查：`SearchResponse` → `results: list[ToolInfo]`；`ToolInfo` 含 `tool_id`、`name`、`description`、`params: list[ToolParameter]`、`examples`、`stats`、`billing_rule`。
+- 调用：`ToolExecutionResponse`，含 `execution_id`、`success`、`result`、`error_message`、`billing`（`CompactBillingStatement`）、`cost`、`remaining_credits`。
+- 调用审计：`UsageHistoryResponse` → `items: list[UsageEventItem]`、`total`、`summary`。
+- 积分账本：`CreditsLedgerResponse` → `items: list[CreditsLedgerItem]`、`total`、`summary`。
+
+```python
+from qveris import ToolExecutionResponse
+
+def explain(result: ToolExecutionResponse) -> str:
+    if not result.success:
+        return f"失败：{result.error_message}"
+    charged = result.billing.summary if result.billing else "无计费信息"
+    return f"成功（{charged}）；剩余={result.remaining_credits}"
+```
+
+## 集成方式
+
+按你的应用选择合适的粒度：
+
+- **直接使用类型化 client** —— 在自己的代码里调用 `discover`/`inspect`/`call`/`usage`/`ledger`。
+- **内置流式 agent** —— `Agent.run(messages)` 并消费 `StreamEvent`。
+- **内置非流式 agent** —— `Agent.run(messages, stream=False)`，获取完整轮次与事件。
+- **仅要最终文本** —— `Agent.run_to_completion(messages)`。
+- **自带循环** —— 把 QVeris 工具 schema 暴露给你自己的 LLM provider，再把工具调用路由回 client：
+
+```python
+from qveris import QverisClient
+from qveris.client.tools import DISCOVER_TOOL_DEF, INSPECT_TOOL_DEF, CALL_TOOL_DEF
+
+tools = [DISCOVER_TOOL_DEF, INSPECT_TOOL_DEF, CALL_TOOL_DEF]
+client = QverisClient()
+
+# ... 你的 LLM 产出一个工具调用 (func_name, func_args) ...
+result, is_error, handled = await client.handle_tool_call(func_name, func_args)
+if handled and not is_error:
+    ...  # 把 result 回传给模型
+```
+
+### 自定义 LLM provider
+
+默认 `Agent()` 使用内置的 OpenAI 兼容 provider。如需对接其他模型 API，实现 `LLMProvider` 并传入：
+
+```python
+from typing import AsyncGenerator, List
+from openai.types.chat import ChatCompletionToolParam
+from qveris import Agent
+from qveris.config import AgentConfig
+from qveris.llm.base import LLMProvider
+from qveris.types import ChatResponse, Message, StreamEvent
+
+class MyProvider(LLMProvider):
+    async def chat_stream(self, messages: List[Message], tools: List[ChatCompletionToolParam], config: AgentConfig) -> AsyncGenerator[StreamEvent, None]:
+        ...
+
+    async def chat(self, messages: List[Message], tools: List[ChatCompletionToolParam], config: AgentConfig) -> ChatResponse:
+        ...
+
+agent = Agent(llm_provider=MyProvider())
+```
+
+## 错误处理
+
+- HTTP 错误抛出 `httpx.HTTPStatusError`；业务失败信封抛出 `RuntimeError`。
+- 在 agent 循环内部，provider/传输错误不会抛出 —— 它们以 `error` 类型的 `StreamEvent` 暴露并结束本次运行。`run_to_completion(...)` 会将其重新抛为 `RuntimeError`。
+- `result.success` 只反映能力调用本身。**不要**把它当作最终扣费结论 —— 用 `usage(...)` / `ledger(...)` 确认扣费。
+
+## 示例
+
+可运行示例位于 [`packages/python-sdk/examples/`](https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk/examples)：
+
+| 示例 | 场景 |
+|------|------|
+| `finance_research.py` | 股票报价 / 市场数据研究 |
+| `risk_compliance.py` | 制裁、负面舆情、合规筛查 |
+| `crypto_market.py` | 加密货币价格与成交量数据 |
+| `data_analysis.py` | 用外部能力数据丰富数据集 |
+| `agent_loop_integration.py` | LLM agent 循环集成 |
+
+设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。
+
+## 兼容性
+
+- Python `>=3.8`。
+- 公开方法与 Pydantic 模型字段尽量遵循增量兼容。
+- 规范方法替代上线后，弃用别名至少保留一个小版本。
+- 破坏性变更需要主版本号升级并附迁移说明。
+
+## 链接
+
+- 包：[PyPI 上的 `qveris`](https://pypi.org/project/qveris/)
+- 源码：[`packages/python-sdk`](https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk)
+- REST API：[rest-api.md](rest-api.md)
+- 获取 API 密钥：[qveris.ai](https://qveris.ai)


### PR DESCRIPTION
## Summary

Rebased onto `main` (after #42 website sync). Scope:

- **New Python SDK guide** — `docs/{en-US,zh-CN,cn/zh-CN}/python-sdk.md`, written from the actual `packages/python-sdk` code (client + agent workflow, config, typed models, integration patterns, error handling), OpenAI-doc style. Cross-linked from `getting-started.md` in all three locales. The cn/zh-CN variant prominently documents the China requirement to set `QVERIS_BASE_URL=https://qveris.cn/api/v1` (the SDK does **not** auto-switch region from the key prefix).
- **Completed the cn/zh-CN (China) doc set** — added `cli.md`, `mcp-server.md`, `ide-cli-setup.md`, `opencode-setup.md` localized with `qveris.cn` endpoints / `sk-cn-` key examples.
- **Removed all Claude Code AND Claude Desktop content from cn/zh-CN** — neither is available in the China region (configure targets, examples, env listings, the `### Claude Desktop 配置示例` section, dead `claude-code-setup.md` links).
- **`rest-api.md` (×3) intentionally left equal to base** — PR #42 (website sync) is authoritative, per instruction. My earlier response-JSON additions were dropped during the rebase.
- **Addressed all 4 Gemini review comments** — removed redundant spaces after full-width punctuation (`：`/`。`) across the cn/zh-CN docs; swept the same antipattern in sibling lines too (0 residual).

## Notes for reviewer

- The external `WonderfulValley/qveris-website/docs` copies are **older/leaner** than this repo's (no `qveris init`, stale SDK GitHub link, shorter rest-api). I did **not** downgrade our richer docs to those; "alignment" here means internal consistency + the new python-sdk cross-links. Flag if you want a different reconciliation.
- `cn/zh-CN/mcp-server.md` has one fewer heading than en-US — exactly the intentionally-removed `### Claude Desktop 配置示例` section (region differentiation).

## Test plan

- [x] All Python SDK examples reflect real `packages/python-sdk` API (`QverisClient`, `Agent`, `QverisConfig`, typed models, aliases)
- [x] Code-fence balance OK in every new/changed doc
- [x] `rest-api.md` ×3 byte-identical to base
- [x] No `Claude Code` / `Claude Desktop` strings remain in `docs/cn/zh-CN/`
- [x] No conflict markers; `en-US/getting-started.md` diff minimal (CRLF preserved)
- [ ] Reviewer: confirm `https://qveris.cn/cli/install` one-liner is hosted (region analogue)
- [ ] Reviewer: spot-check zh translation quality in the new China docs