### PR TITLE
docs: region-neutral user-facing docs (no region machinery / cross-refs)

### DIFF
--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -264,7 +264,7 @@ qveris mcp validate --target cursor --probe
 
 ### `qveris login`
 
-使用 QVeris API 密钥认证。如果未预设区域，会先提示选择站点区域（全球 / 中国），然后打开对应的 API 密钥页面并掩码输入。
+使用 QVeris API 密钥认证。打开浏览器进入 API 密钥页面并掩码输入。
 
 ```bash
 qveris login [flags]
@@ -272,26 +272,15 @@ qveris login [flags]
 
 | 参数 | 说明 |
 |------|------|
-| `--token <key>` | 直接提供密钥（跳过浏览器和区域选择） |
+| `--token <key>` | 直接提供密钥（跳过浏览器） |
 | `--no-browser` | 不打开浏览器 |
 
 ```bash
-# 交互式（选择区域 → 打开浏览器 → 掩码输入）
+# 交互式（打开浏览器 → 掩码输入）
 qveris login
 
 # 非交互式
-qveris login --token "sk-cn-your-key-here"
-```
-
-交互式登录时，如果未设置 `QVERIS_REGION` 或 `--base-url`，会提示选择区域：
-
-```
-选择站点区域：
-
-  1) 全球   — qveris.ai  （国际用户）
-  2) 中国   — qveris.cn  （中国大陆用户）
-
-输入 1 或 2：
+qveris login --token "sk-1_your-key-here"
 ```
 
 密钥保存到 `~/.config/qveris/config.json`，权限为 `0600`（仅所有者可读写）。
@@ -302,7 +291,7 @@ qveris login --token "sk-cn-your-key-here"
 
 ### `qveris whoami`
 
-显示当前认证状态、密钥来源、所属区域，并验证密钥有效性。
+显示当前认证状态、密钥来源，并验证密钥有效性。
 
 ### `qveris credits`
 
@@ -371,7 +360,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-自检诊断：验证 Node.js 版本、API 密钥配置、区域和 API 地址、API 连通性。
+自检诊断：验证 Node.js 版本、API 密钥配置、API 地址、API 连通性。
 
 ### `qveris config`
 
@@ -442,8 +431,7 @@ qveris history [--clear]
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `QVERIS_API_KEY` | API 认证密钥 | — |
-| `QVERIS_REGION` | 强制区域：`global` 或 `cn` | 从密钥自动检测 |
-| `QVERIS_BASE_URL` | 覆盖 API 地址 | 从区域自动设置 |
+| `QVERIS_BASE_URL` | 覆盖 API 地址 | 从密钥自动设置 |
 | `QVERIS_DEFAULT_LIMIT` | 默认 discover 限制 | 5 |
 | `QVERIS_DEFAULT_MAX_SIZE` | 默认响应大小限制 | 4096 |
 | `XDG_CONFIG_HOME` | 配置目录基础路径 | `~/.config` |
@@ -454,43 +442,13 @@ qveris history [--clear]
 
 ---
 
-## 区域
-
-区域从 API 密钥前缀自动检测，无需额外配置。中国大陆用户使用 `sk-cn-` 前缀的密钥即可自动指向 `https://qveris.cn`。
-
-| 密钥前缀 | 区域 | API 地址 |
-|----------|------|----------|
-| `sk-xxx` | 全球 | `https://qveris.ai/api/v1` |
-| `sk-cn-xxx` | 中国 | `https://qveris.cn/api/v1` |
-
-**交互式登录：**运行 `qveris login` 时，如果未设置 `QVERIS_REGION` 或 `--base-url`，会提示选择区域。仅用于首次人工登录。
-
-**Agent / 脚本使用：**Agent 和脚本应跳过交互式提示。区域自动解析：
-
-```bash
-# 方式 1：密钥前缀自动检测（推荐）
-qveris login --token "sk-cn-xxx"    # 自动检测为中国区
-
-# 方式 2：环境变量
-export QVERIS_REGION=cn
-qveris login --token "sk-xxx"
-
-# 方式 3：显式 API 地址
-export QVERIS_BASE_URL=https://qveris.cn/api/v1
-
-# 方式 4：单次命令参数
-qveris discover "天气" --base-url https://qveris.cn/api/v1
-```
-
----
-
 ## 会话管理
 
 每次 `discover` 后，CLI 将会话状态保存到 `~/.config/qveris/.session.json`：
 
 - 发现 ID
 - 查询内容
-- 区域和 API 地址
+- API 地址
 - 结果列表（tool_id、名称、提供商）
 
 后续 `inspect` 和 `call` 自动读取会话，支持数字索引快捷方式：
@@ -577,7 +535,7 @@ qveris call "$TOOL" --discovery-id "$SEARCH_ID" --params '{"city":"London"}' --j
 │   ├── commands/              # 12 个命令处理器
 │   ├── client/api.mjs         # HTTP 客户端（原生 fetch）
 │   ├── client/auth.mjs        # API 密钥解析
-│   ├── config/region.mjs      # 区域自动检测
+│   ├── config/endpoint.mjs    # API 地址解析
 │   ├── config/store.mjs       # 配置文件读写（0600 权限）
 │   ├── session/session.mjs    # 会话持久化
 │   ├── output/formatter.mjs   # 人类友好格式化
@@ -592,9 +550,9 @@ qveris call "$TOOL" --discovery-id "$SEARCH_ID" --params '{"city":"London"}' --j
 
 ## 链接
 
-- 官网：[qveris.cn](https://qveris.cn)（中国）/ [qveris.ai](https://qveris.ai)（全球）
+- 官网：[qveris.cn](https://qveris.cn)
 - GitHub：[QVerisAI/qveris-agent-toolkit](https://github.com/QVerisAI/qveris-agent-toolkit)
 - npm：[@qverisai/cli](https://www.npmjs.com/package/@qverisai/cli)
 - REST API：[docs/cn/zh-CN/rest-api.md](rest-api.md)
 - MCP 服务器：[docs/cn/zh-CN/mcp-server.md](mcp-server.md)
-- 获取 API 密钥：[qveris.cn/account](https://qveris.cn/account?page=api-keys) / [qveris.ai/account](https://qveris.ai/account?page=api-keys)
+- 获取 API 密钥：[qveris.cn/account](https://qveris.cn/account?page=api-keys)

--- a/docs/cn/zh-CN/ide-cli-setup.md
+++ b/docs/cn/zh-CN/ide-cli-setup.md
@@ -24,5 +24,5 @@ QVeris 已集成到多种 IDE 和 CLI 编程工具中。通过自动配置 QVeri
 
 OpenCode：
 ```
-请按照 https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/cn/zh-CN/opencode-setup.md 帮我完成配置。API 密钥是 sk-cn-xxxxxxxxxxxxx
+请按照 https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/cn/zh-CN/opencode-setup.md 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
 ```

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -63,12 +63,9 @@ npx -y @qverisai/mcp
 MCP 服务器从以下环境变量读取配置：
 
 ```bash
-QVERIS_API_KEY=sk-cn-your-api-key    # 必填
-QVERIS_REGION=cn                      # 可选：强制区域（global | cn）
+QVERIS_API_KEY=your-api-key          # 必填
 QVERIS_BASE_URL=https://...          # 可选：覆盖 API 地址
 ```
-
-区域从 API 密钥前缀自动检测（`sk-cn-xxx` → 中国区，`sk-xxx` → 全球）。中国大陆用户使用 `sk-cn-` 前缀的密钥即可自动指向 `https://qveris.cn`，仅在需要覆盖时设置 `QVERIS_REGION`。
 
 ### 使用 QVeris CLI 配置
 
@@ -105,26 +102,7 @@ qveris mcp validate --target cursor --probe
       "command": "npx",
       "args": ["-y", "@qverisai/mcp"],
       "env": {
-        "QVERIS_API_KEY": "sk-cn-your-api-key-here"
-      }
-    }
-  }
-}
-```
-
-### 中国区配置示例
-
-中国大陆用户使用 `sk-cn-` 前缀的密钥即可自动指向中国区；也可显式添加 `QVERIS_REGION`：
-
-```json
-{
-  "mcpServers": {
-    "qveris": {
-      "command": "npx",
-      "args": ["-y", "@qverisai/mcp"],
-      "env": {
-        "QVERIS_API_KEY": "sk-cn-your-api-key-here",
-        "QVERIS_REGION": "cn"
+        "QVERIS_API_KEY": "your-api-key-here"
       }
     }
   }

--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -17,27 +17,25 @@ pip install qveris
 
 需要 Python 3.8+。运行时依赖：`httpx`、`pydantic`、`pydantic-settings`、`openai`。
 
-## 身份认证（中国区）
+## 身份认证
 
-SDK 从环境变量 `QVERIS_API_KEY` 读取 API 密钥。**SDK 默认指向全球区 `https://qveris.ai/api/v1/`，中国区用户必须显式指向 `https://qveris.cn`**：
+SDK 从环境变量 `QVERIS_API_KEY` 读取 API 密钥，并通过 `QVERIS_BASE_URL` 指向 API 地址。请设置：
 
 ```bash
-export QVERIS_API_KEY="sk-cn-..."
+export QVERIS_API_KEY="your-api-key"
 export QVERIS_BASE_URL="https://qveris.cn/api/v1"
 ```
 
-在 [qveris.cn](https://qveris.cn) 获取密钥（中国区密钥为 `sk-cn-` 前缀）。也可以显式传入配置：
+在 [qveris.cn](https://qveris.cn) 获取密钥。也可以显式传入配置：
 
 ```python
 from qveris import QverisClient, QverisConfig
 
 client = QverisClient(QverisConfig(
-    api_key="sk-cn-...",
+    api_key="your-api-key",
     base_url="https://qveris.cn/api/v1",
 ))
 ```
-
-> 注意：与 CLI / MCP 服务器不同，Python SDK **不会**根据 `sk-cn-` 前缀自动切换区域。中国区必须通过 `QVERIS_BASE_URL` 环境变量或 `QverisConfig(base_url=...)` 显式设置 `https://qveris.cn/api/v1`。
 
 ## 快速开始
 
@@ -97,7 +95,7 @@ export OPENAI_API_KEY="..."
 export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"   # 你的 OpenAI 兼容服务地址
 ```
 
-QVeris 区域仍由 `QVERIS_BASE_URL` 控制，与 LLM provider 相互独立。
+QVeris API 地址仍由 `QVERIS_BASE_URL` 控制，与 LLM provider 相互独立。
 
 ### 流式
 
@@ -151,7 +149,7 @@ async with Agent(config=QverisConfig(base_url="https://qveris.cn/api/v1")) as ag
 | 字段 | 环境变量 | 默认值 | 说明 |
 |------|---------|--------|------|
 | `api_key` | `QVERIS_API_KEY` | `None` | API 密钥，以 `Authorization: Bearer ...` 发送 |
-| `base_url` | `QVERIS_BASE_URL` | `https://qveris.ai/api/v1/` | API 基础地址；**中国区须设为 `https://qveris.cn/api/v1`** |
+| `base_url` | `QVERIS_BASE_URL` | `https://qveris.cn/api/v1` | API 基础地址 |
 | `enable_history_pruning` | — | `True` | 裁剪/压缩旧的工具输出以节省 token（agent 循环） |
 | `max_iterations` | — | `50` | agent 工具循环的最大迭代次数 |
 

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -268,7 +268,7 @@ qveris mcp validate --target cursor --probe
 
 ### `qveris login`
 
-Authenticate with your QVeris API key. If no region is pre-configured, prompts you to select your region (Global or China), then opens the browser to the corresponding API key page and prompts for masked input.
+Authenticate with your QVeris API key. Opens the browser to the API key page and prompts for masked input.
 
 ```bash
 qveris login [flags]
@@ -276,26 +276,15 @@ qveris login [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--token <key>` | Provide key directly (skip browser and region prompt) |
+| `--token <key>` | Provide key directly (skip browser prompt) |
 | `--no-browser` | Don't open browser |
 
 ```bash
-# Interactive (select region → opens browser → masked input)
+# Interactive (opens browser → masked input)
 qveris login
 
 # Non-interactive
 qveris login --token "sk-1_your-key-here"
-```
-
-During interactive login, if `QVERIS_REGION` or `--base-url` is not set, you will be prompted:
-
-```
-Select your region / 选择站点区域:
-
-  1) Global  — qveris.ai  (International users)
-  2) China   — qveris.cn  (中国大陆用户)
-
-Enter 1 or 2:
 ```
 
 The key is saved to `~/.config/qveris/config.json` with `0600` permissions (owner-only).
@@ -310,7 +299,7 @@ qveris logout
 
 ### `qveris whoami`
 
-Show current auth status, key source, resolved region, and validate against the API.
+Show current auth status and key source, and validate against the API.
 
 ```bash
 qveris whoami
@@ -422,7 +411,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-Self-check diagnostics: verifies Node.js version, API key configuration, resolved region and base URL, and API connectivity.
+Self-check diagnostics: verifies Node.js version, API key configuration, base URL, and API connectivity.
 
 ```bash
 qveris doctor
@@ -497,8 +486,7 @@ Use `--` to end option parsing: `qveris discover -- --literal-query`.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `QVERIS_API_KEY` | API authentication key | — |
-| `QVERIS_REGION` | Force region: `global` or `cn` | auto from key |
-| `QVERIS_BASE_URL` | Override API base URL | auto from region |
+| `QVERIS_BASE_URL` | Override API base URL | auto from key |
 | `QVERIS_DEFAULT_LIMIT` | Default discover limit | 5 |
 | `QVERIS_DEFAULT_MAX_SIZE` | Default response size limit | 4096 |
 | `XDG_CONFIG_HOME` | Config directory base | `~/.config` |
@@ -509,43 +497,13 @@ Use `--` to end option parsing: `qveris discover -- --literal-query`.
 
 ---
 
-## Region
-
-Region is auto-detected from your API key prefix. No extra configuration needed.
-
-| Key prefix | Region | Base URL |
-|------------|--------|----------|
-| `sk-xxx` | Global | `https://qveris.ai/api/v1` |
-| `sk-cn-xxx` | China | `https://qveris.cn/api/v1` |
-
-**Interactive login:** When running `qveris login` without `QVERIS_REGION` or `--base-url`, you'll be prompted to choose a region. This is for first-time human users only.
-
-**Agent / script usage:** Agents and scripts should skip the interactive prompt. Region is resolved automatically:
-
-```bash
-# Option 1: Key prefix auto-detection (recommended)
-qveris login --token "sk-cn-xxx"    # auto-detects China region
-
-# Option 2: Environment variable
-export QVERIS_REGION=cn
-qveris login --token "sk-xxx"
-
-# Option 3: Explicit base URL
-export QVERIS_BASE_URL=https://qveris.cn/api/v1
-
-# Option 4: Per-command flag
-qveris discover "weather" --base-url https://qveris.cn/api/v1
-```
-
----
-
 ## Session Management
 
 After each `discover`, the CLI saves session state to `~/.config/qveris/.session.json`:
 
 - Discovery ID
 - Query
-- Region and base URL
+- Base URL
 - Result list (tool_id, name, provider)
 
 Subsequent `inspect` and `call` commands auto-read this session, enabling numeric index shortcuts:
@@ -632,7 +590,7 @@ For backward compatibility, the following aliases are supported with deprecation
 │   ├── commands/              # 12 command handlers
 │   ├── client/api.mjs         # HTTP client (native fetch)
 │   ├── client/auth.mjs        # API key resolution
-│   ├── config/region.mjs      # Region auto-detection
+│   ├── config/endpoint.mjs    # API endpoint resolution
 │   ├── config/store.mjs       # Config file R/W (0600 perms)
 │   ├── session/session.mjs    # Session persistence
 │   ├── output/formatter.mjs   # Human-readable formatting
@@ -647,9 +605,9 @@ For backward compatibility, the following aliases are supported with deprecation
 
 ## Links
 
-- Website: [qveris.ai](https://qveris.ai) (Global) / [qveris.cn](https://qveris.cn) (China)
+- Website: [qveris.ai](https://qveris.ai)
 - GitHub: [QVerisAI/qveris-agent-toolkit](https://github.com/QVerisAI/qveris-agent-toolkit)
 - npm: [@qverisai/cli](https://www.npmjs.com/package/@qverisai/cli)
 - REST API: [docs/en-US/rest-api.md](rest-api.md)
 - MCP Server: [docs/en-US/mcp-server.md](mcp-server.md)
-- Get API Key: [qveris.ai/account](https://qveris.ai/account?page=api-keys) / [qveris.cn/account](https://qveris.cn/account?page=api-keys)
+- Get API Key: [qveris.ai/account](https://qveris.ai/account?page=api-keys)

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -64,11 +64,8 @@ The MCP server reads configuration from environment variables:
 
 ```bash
 QVERIS_API_KEY=your-api-key          # Required
-QVERIS_REGION=cn                      # Optional: force region (global | cn)
 QVERIS_BASE_URL=https://...          # Optional: override API base URL
 ```
-
-Region is auto-detected from your API key prefix (`sk-cn-xxx` → China, `sk-xxx` → Global). Set `QVERIS_REGION` only if you need to override.
 
 ### Configure with QVeris CLI
 
@@ -126,25 +123,6 @@ qveris mcp validate --target cursor --probe
       "args": ["-y", "@qverisai/mcp"],
       "env": {
         "QVERIS_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
-
-### China region example
-
-For users in mainland China, add `QVERIS_REGION` or use a `sk-cn-` prefixed key:
-
-```json
-{
-  "mcpServers": {
-    "qveris": {
-      "command": "npx",
-      "args": ["-y", "@qverisai/mcp"],
-      "env": {
-        "QVERIS_API_KEY": "sk-cn-your-api-key-here",
-        "QVERIS_REGION": "cn"
       }
     }
   }

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -33,7 +33,7 @@ from qveris import QverisClient, QverisConfig
 client = QverisClient(QverisConfig(api_key="sk-..."))
 ```
 
-The default API base URL is `https://qveris.ai/api/v1/`. Override it with the `QVERIS_BASE_URL` environment variable or `QverisConfig(base_url=...)` when targeting another region or a custom endpoint.
+The default API base URL is `https://qveris.ai/api/v1/`. Override it with the `QVERIS_BASE_URL` environment variable or `QverisConfig(base_url=...)` when targeting a custom endpoint.
 
 ## Quickstart
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -268,7 +268,7 @@ qveris mcp validate --target cursor --probe
 
 ### `qveris login`
 
-使用 QVeris API 密钥认证。如果未预设区域，会先提示选择站点区域（全球 / 中国），然后打开对应的 API 密钥页面并掩码输入。
+使用 QVeris API 密钥认证。打开浏览器进入 API 密钥页面并掩码输入。
 
 ```bash
 qveris login [flags]
@@ -276,26 +276,15 @@ qveris login [flags]
 
 | 参数 | 说明 |
 |------|------|
-| `--token <key>` | 直接提供密钥（跳过浏览器和区域选择） |
+| `--token <key>` | 直接提供密钥（跳过浏览器） |
 | `--no-browser` | 不打开浏览器 |
 
 ```bash
-# 交互式（选择区域 → 打开浏览器 → 掩码输入）
+# 交互式（打开浏览器 → 掩码输入）
 qveris login
 
 # 非交互式
 qveris login --token "sk-1_your-key-here"
-```
-
-交互式登录时，如果未设置 `QVERIS_REGION` 或 `--base-url`，会提示选择区域：
-
-```
-选择站点区域：
-
-  1) 全球   — qveris.ai  （国际用户）
-  2) 中国   — qveris.cn  （中国大陆用户）
-
-输入 1 或 2：
 ```
 
 密钥保存到 `~/.config/qveris/config.json`，权限为 `0600`（仅所有者可读写）。
@@ -306,7 +295,7 @@ qveris login --token "sk-1_your-key-here"
 
 ### `qveris whoami`
 
-显示当前认证状态、密钥来源、所属区域，并验证密钥有效性。
+显示当前认证状态、密钥来源，并验证密钥有效性。
 
 ### `qveris credits`
 
@@ -375,7 +364,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-自检诊断：验证 Node.js 版本、API 密钥配置、区域和 API 地址、API 连通性。
+自检诊断：验证 Node.js 版本、API 密钥配置、API 地址、API 连通性。
 
 ### `qveris config`
 
@@ -446,8 +435,7 @@ qveris history [--clear]
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `QVERIS_API_KEY` | API 认证密钥 | — |
-| `QVERIS_REGION` | 强制区域：`global` 或 `cn` | 从密钥自动检测 |
-| `QVERIS_BASE_URL` | 覆盖 API 地址 | 从区域自动设置 |
+| `QVERIS_BASE_URL` | 覆盖 API 地址 | 从密钥自动设置 |
 | `QVERIS_DEFAULT_LIMIT` | 默认 discover 限制 | 5 |
 | `QVERIS_DEFAULT_MAX_SIZE` | 默认响应大小限制 | 4096 |
 | `XDG_CONFIG_HOME` | 配置目录基础路径 | `~/.config` |
@@ -458,34 +446,6 @@ qveris history [--clear]
 
 ---
 
-## 区域
-
-区域从 API 密钥前缀自动检测，无需额外配置。
-
-| 密钥前缀 | 区域 | API 地址 |
-|----------|------|----------|
-| `sk-xxx` | 全球 | `https://qveris.ai/api/v1` |
-| `sk-cn-xxx` | 中国 | `https://qveris.cn/api/v1` |
-
-**交互式登录：** 运行 `qveris login` 时，如果未设置 `QVERIS_REGION` 或 `--base-url`，会提示选择区域。仅用于首次人工登录。
-
-**智能体 / 脚本使用：** 智能体和脚本应跳过交互式提示。区域自动解析：
-
-```bash
-# 方式 1：密钥前缀自动检测（推荐）
-qveris login --token "sk-cn-xxx"    # 自动检测为中国区
-
-# 方式 2：环境变量
-export QVERIS_REGION=cn
-qveris login --token "sk-xxx"
-
-# 方式 3：显式 API 地址
-export QVERIS_BASE_URL=https://qveris.cn/api/v1
-
-# 方式 4：单次命令参数
-qveris discover "天气" --base-url https://qveris.cn/api/v1
-```
-
 ---
 
 ## 会话管理
@@ -494,7 +454,7 @@ qveris discover "天气" --base-url https://qveris.cn/api/v1
 
 - 发现 ID
 - 查询内容
-- 区域和 API 地址
+- API 地址
 - 结果列表（tool_id、名称、提供商）
 
 后续 `inspect` 和 `call` 自动读取会话，支持数字索引快捷方式：
@@ -581,7 +541,7 @@ qveris call "$TOOL" --discovery-id "$SEARCH_ID" --params '{"city":"London"}' --j
 │   ├── commands/              # 12 个命令处理器
 │   ├── client/api.mjs         # HTTP 客户端（原生 fetch）
 │   ├── client/auth.mjs        # API 密钥解析
-│   ├── config/region.mjs      # 区域自动检测
+│   ├── config/endpoint.mjs    # API 地址解析
 │   ├── config/store.mjs       # 配置文件读写（0600 权限）
 │   ├── session/session.mjs    # 会话持久化
 │   ├── output/formatter.mjs   # 人类友好格式化
@@ -596,9 +556,9 @@ qveris call "$TOOL" --discovery-id "$SEARCH_ID" --params '{"city":"London"}' --j
 
 ## 链接
 
-- 官网：[qveris.ai](https://qveris.ai)（全球）/ [qveris.cn](https://qveris.cn)（中国）
+- 官网：[qveris.ai](https://qveris.ai)
 - GitHub：[QVerisAI/qveris-agent-toolkit](https://github.com/QVerisAI/qveris-agent-toolkit)
 - npm：[@qverisai/cli](https://www.npmjs.com/package/@qverisai/cli)
 - REST API：[docs/zh-CN/rest-api.md](rest-api.md)
 - MCP 服务器：[docs/zh-CN/mcp-server.md](mcp-server.md)
-- 获取 API 密钥：[qveris.ai/account](https://qveris.ai/account?page=api-keys) / [qveris.cn/account](https://qveris.cn/account?page=api-keys)
+- 获取 API 密钥：[qveris.ai/account](https://qveris.ai/account?page=api-keys)

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -64,11 +64,8 @@ MCP 服务器从以下环境变量读取配置：
 
 ```bash
 QVERIS_API_KEY=your-api-key          # 必填
-QVERIS_REGION=cn                      # 可选：强制区域（global | cn）
 QVERIS_BASE_URL=https://...          # 可选：覆盖 API 地址
 ```
-
-区域从 API 密钥前缀自动检测（`sk-cn-xxx` → 中国区，`sk-xxx` → 全球）。仅在需要覆盖时设置 `QVERIS_REGION`。
 
 ### 使用 QVeris CLI 配置
 
@@ -126,25 +123,6 @@ qveris mcp validate --target cursor --probe
       "args": ["-y", "@qverisai/mcp"],
       "env": {
         "QVERIS_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
-
-### 中国区配置示例
-
-中国大陆用户可添加 `QVERIS_REGION` 或使用 `sk-cn-` 前缀的密钥：
-
-```json
-{
-  "mcpServers": {
-    "qveris": {
-      "command": "npx",
-      "args": ["-y", "@qverisai/mcp"],
-      "env": {
-        "QVERIS_API_KEY": "sk-cn-your-api-key-here",
-        "QVERIS_REGION": "cn"
       }
     }
   }

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -33,7 +33,7 @@ from qveris import QverisClient, QverisConfig
 client = QverisClient(QverisConfig(api_key="sk-..."))
 ```
 
-默认 API 基础地址为 `https://qveris.ai/api/v1/`。如需指向其他区域或自定义端点，用环境变量 `QVERIS_BASE_URL` 或 `QverisConfig(base_url=...)` 覆盖。
+默认 API 基础地址为 `https://qveris.ai/api/v1/`。如需指向自定义端点，用环境变量 `QVERIS_BASE_URL` 或 `QverisConfig(base_url=...)` 覆盖。
 
 ## 快速开始
 


### PR DESCRIPTION
Aligns the toolkit-owned user-facing docs with the website doc policy:

1. **No internal region setup wording** — removed `QVERIS_REGION`, the `sk-xxx`→qveris.ai / `sk-cn-xxx`→qveris.cn region table, the interactive region-selection prompt, the `## Region` section, `config/region.mjs` ("Region auto-detection"), "region auto-detected from key prefix", "resolved region".
2. **No cross-region references** — Global docs (`docs/en-US`, `docs/zh-CN`) now present only the `qveris.ai` world; CN docs (`docs/cn/zh-CN`) only the `qveris.cn` world. Removed dual-site footers (`qveris.ai (Global) / qveris.cn (China)`), `### China region example`, the python-sdk "SDK defaults to global qveris.ai, China users must…" framing, and `sk-cn-` key prefixes.
3. **Kept** the provider-level `region` capability attribute (listed beside `success_rate` / latency / `billing_rule`) — confirmed product field, not site region.

Files: `cli.md`, `mcp-server.md`, `python-sdk.md`, `ide-cli-setup.md` across `docs/en-US`, `docs/zh-CN`, `docs/cn/zh-CN`.

Verification: `grep` sweep confirms Global docs contain no CN/region machinery and CN docs contain no qveris.ai/global/region machinery (only the neutral `sk-xxxxxxxxxxxxx` placeholder remains, matching the existing en-US style).

These mirror to `qveris-website` via the docs-sync workflow (toolkit-owned). Companion website-owned docs (`cookbook.md`, `rest-api.md`, `getting-started.md`) handled in a separate qveris-website PR.