### PR TITLE
release: bump client package versions

### DIFF
--- a/ecosystem/compatibility.md
+++ b/ecosystem/compatibility.md
@@ -5,9 +5,9 @@ The ecosystem manifest is designed to keep recipes, skills, plugins, and marketp
 | Surface | Minimum version | Used for |
 |---------|-----------------|----------|
 | Manifest schema | `2026-05-13` | Shared metadata, permissions, docs, examples, and marketplace listing fields |
-| QVeris CLI | `>=0.5.0` | `discover`, `inspect`, `call`, `usage`, `ledger`, and `init` recipe commands |
-| QVeris MCP server | `>=0.6.0` | Canonical MCP tools plus usage and credits ledger audit tools |
-| QVeris Python SDK | `>=0.1.0` | Typed `QverisClient`, `Agent`, and audit methods |
+| QVeris CLI | `>=0.6.0` | `discover`, `inspect`, `call`, `usage`, `ledger`, and `init` recipe commands |
+| QVeris MCP server | `>=0.7.0` | Canonical MCP tools plus usage and credits ledger audit tools |
+| QVeris Python SDK | `>=0.2.0` | Typed `QverisClient`, `Agent`, and audit methods |
 | QVeris agent skill | `>=0.1.0` | Agent-facing discover, inspect, call, and audit workflow guidance |
 
 ## Compatibility Policy

--- a/ecosystem/templates/plugin-manifest.template.json
+++ b/ecosystem/templates/plugin-manifest.template.json
@@ -31,8 +31,8 @@
     ]
   },
   "compatibility": {
-    "cli": ">=0.5.0",
-    "python_sdk": ">=0.1.0"
+    "cli": ">=0.6.0",
+    "python_sdk": ">=0.2.0"
   },
   "marketplace": {
     "listing_slug": "replace-with-plugin-slug",

--- a/ecosystem/templates/skill-manifest.template.json
+++ b/ecosystem/templates/skill-manifest.template.json
@@ -32,7 +32,7 @@
   },
   "compatibility": {
     "agent_skill": ">=0.1.0",
-    "mcp": ">=0.6.0"
+    "mcp": ">=0.7.0"
   },
   "marketplace": {
     "listing_slug": "replace-with-skill-slug",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "QVeris CLI for agent capability discovery, inspection, calling, and audit",
   "type": "module",
   "bin": {

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qveris"
-version = "0.1.0"
+version = "0.2.0"
 description = "QVeris Python SDK for agent capability discovery, calling, and audit"
 requires-python = ">=3.8"
 license = "MIT"

--- a/packages/python-sdk/uv.lock
+++ b/packages/python-sdk/uv.lock
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "qveris"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump CLI to 0.6.0, MCP server to 0.7.0, and Python SDK to 0.2.0
- Update ecosystem compatibility defaults for the new client versions

## Validation
- git diff --check
- npm --prefix packages/cli test
- npm --prefix packages/mcp run typecheck
- npm --prefix packages/mcp test
- npm --prefix packages/mcp run build
- uv run --project packages/python-sdk --extra dev pytest
- uv run --project packages/python-sdk python -m compileall packages/python-sdk/qveris packages/python-sdk/examples