### PR TITLE
ci: enable PyPI trusted publishing

### DIFF
--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -6,7 +6,7 @@ on:
       - "python-sdk-v*" # Trigger on tags like python-sdk-v0.1.0, python-sdk-v1.0.0
 
 permissions:
-  contents: write # For creating GitHub Releases
+  contents: read
 
 jobs:
   test:
@@ -43,6 +43,9 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # For creating GitHub Releases
+      id-token: write # For PyPI trusted publishing
     defaults:
       run:
         working-directory: packages/python-sdk


### PR DESCRIPTION
## Summary
- grant the Python SDK publish job OIDC token permission for PyPI trusted publishing
- reduce default workflow permissions to read-only and keep GitHub Release write permission on the publish job

## Verification
- git diff --check