### PR TITLE
ci: centralize OpenAPI artifact regeneration

### DIFF
--- a/.github/workflows/openapi-types.yml
+++ b/.github/workflows/openapi-types.yml
@@ -12,6 +12,7 @@ on:
       - "packages/python-sdk/qveris/generated/**"
       - "packages/mcp/package.json"
       - "packages/python-sdk/pyproject.toml"
+      - "scripts/regenerate-openapi-artifacts.sh"
       - ".github/workflows/openapi-types.yml"
   push:
     branches:
@@ -22,6 +23,7 @@ on:
       - "packages/python-sdk/qveris/generated/**"
       - "packages/mcp/package.json"
       - "packages/python-sdk/pyproject.toml"
+      - "scripts/regenerate-openapi-artifacts.sh"
       - ".github/workflows/openapi-types.yml"
 
 permissions:
@@ -44,26 +46,14 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Regenerate MCP TypeScript types
-        run: npx --yes openapi-typescript@7.4.4 docs/openapi/qveris-public-api.openapi.json -o packages/mcp/src/generated/openapi.d.ts
-
-      - name: Regenerate Python SDK models
-        run: |
-          python -m pip install --quiet "datamodel-code-generator==0.26.3"
-          python -m datamodel_code_generator \
-            --input docs/openapi/qveris-public-api.openapi.json \
-            --input-file-type openapi \
-            --output packages/python-sdk/qveris/generated/openapi_models.py \
-            --output-model-type pydantic_v2.BaseModel \
-            --target-python-version 3.8 \
-            --use-schema-description \
-            --disable-timestamp
+      - name: Regenerate OpenAPI artifacts
+        run: bash scripts/regenerate-openapi-artifacts.sh
 
       - name: Fail on drift
         run: |
           if ! git diff --exit-code -- \
               packages/mcp/src/generated/openapi.d.ts \
               packages/python-sdk/qveris/generated/openapi_models.py; then
-            echo "::error::Generated OpenAPI artifacts are out of date. Run 'npm --prefix packages/mcp run gen:openapi' and regenerate the Python models, then commit."
+            echo "::error::Generated OpenAPI artifacts are out of date. Run 'bash scripts/regenerate-openapi-artifacts.sh' or 'npm --prefix packages/mcp run gen:openapi', then commit."
             exit 1
           fi

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,7 +39,7 @@
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit",
-    "gen:openapi": "openapi-typescript ../../docs/openapi/qveris-public-api.openapi.json -o src/generated/openapi.d.ts && npx prettier --write src/generated/openapi.d.ts"
+    "gen:openapi": "bash ../../scripts/regenerate-openapi-artifacts.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/scripts/regenerate-openapi-artifacts.sh
+++ b/scripts/regenerate-openapi-artifacts.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+SPEC_PATH="docs/openapi/qveris-public-api.openapi.json"
+MCP_TYPES_PATH="packages/mcp/src/generated/openapi.d.ts"
+PYTHON_MODELS_PATH="packages/python-sdk/qveris/generated/openapi_models.py"
+
+npx --yes openapi-typescript@7.4.4 "${SPEC_PATH}" -o "${MCP_TYPES_PATH}"
+
+python -m pip install --quiet "datamodel-code-generator==0.26.3"
+python -m datamodel_code_generator \
+  --input "${SPEC_PATH}" \
+  --input-file-type openapi \
+  --output "${PYTHON_MODELS_PATH}" \
+  --output-model-type pydantic_v2.BaseModel \
+  --target-python-version 3.8 \
+  --use-schema-description \
+  --disable-timestamp


### PR DESCRIPTION
## Summary
- add a shared script that regenerates MCP TypeScript OpenAPI types and Python SDK models with the pinned generators
- update the OpenAPI drift check and MCP npm script to use the shared regeneration path
- refresh the drift error message so contributors run one command

## Verification
- bash scripts/regenerate-openapi-artifacts.sh
- npm --prefix packages/mcp run gen:openapi
- git diff --exit-code -- packages/mcp/src/generated/openapi.d.ts packages/python-sdk/qveris/generated/openapi_models.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openapi-types.yml")'
- git diff --check

This is the toolkit-side prerequisite for making website-driven OpenAPI spec sync PRs include generated artifacts before CI runs.