### PR TITLE
feat(packages): 导入 OpenClaw QVeris 插件

### DIFF
--- a/packages/openclaw-qveris-plugin/.gitignore
+++ b/packages/openclaw-qveris-plugin/.gitignore
@@ -1,0 +1,77 @@
+.cursor/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage
+coverage
+*.lcov
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+web_modules/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Build output
+dist/
+build/Release
+
+# Optional caches
+.npm
+.eslintcache
+.stylelintcache
+.node_repl_history
+.yarn-integrity
+
+# dotenv
+.env
+.env.*
+!.env.example
+
+# Pack artifacts
+*.tgz
+
+# Framework caches/outputs
+.next
+out
+.nuxt
+.cache
+.parcel-cache
+.svelte-kit/
+**/.vitepress/dist
+**/.vitepress/cache
+.docusaurus
+.serverless/
+.fusebox/
+.dynamodb/
+.firebase/
+.tern-port
+.vscode-test
+
+# Yarn v3
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/packages/openclaw-qveris-plugin/.npmignore
+++ b/packages/openclaw-qveris-plugin/.npmignore
@@ -1,0 +1,3 @@
+# Test files
+src/**/*.test.ts
+src/**/*.test.js

--- a/packages/openclaw-qveris-plugin/LICENSE
+++ b/packages/openclaw-qveris-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 QVerisAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/openclaw-qveris-plugin/README.md
+++ b/packages/openclaw-qveris-plugin/README.md
@@ -1,0 +1,231 @@
+# QVeris Plugin for OpenClaw
+
+[![npm version](https://img.shields.io/npm/v/@qverisai/qveris?label=npm)](https://www.npmjs.com/package/@qverisai/qveris)
+[![OpenClaw](https://img.shields.io/badge/OpenClaw-%3E%3D2026.3.22-blue)](https://github.com/openclaw/openclaw)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+
+OpenClaw plugin that gives agents dynamic capability discovery and tool calling via the [QVeris](https://qveris.ai) API.
+
+## What it does
+
+Three tools are registered into the agent's context once the plugin is loaded:
+
+| Tool | Description |
+|------|-------------|
+| `qveris_discover` | Search for tools by natural language query (e.g. "weather", "currency exchange") |
+| `qveris_call` | Execute a discovered tool with parameters |
+| `qveris_inspect` | Look up detailed schema and examples for known tool IDs |
+
+The typical agent workflow is: `qveris_discover` → `qveris_inspect` (optional) → `qveris_call`.
+
+## Requirements
+
+- OpenClaw >= 2026.3.22
+- A QVeris API key — sign up at [qveris.ai](https://qveris.ai) (global) or [qveris.cn](https://qveris.cn) (China)
+
+---
+
+## Installation
+
+### From npm
+
+```bash
+openclaw plugins install @qverisai/qveris
+```
+
+### From local source (development)
+
+```bash
+# From the repo root
+openclaw plugins install -l ./extensions/qveris
+```
+
+---
+
+## Configuration
+
+Add the following to your `openclaw.json`:
+
+```json5
+{
+  // 1. Allow the plugin and make its tools visible to the agent
+  plugins: {
+    allow: ["qveris"],
+    entries: {
+      qveris: {
+        enabled: true,
+        config: {
+          apiKey: "qv-your-api-key-here",  // or use QVERIS_API_KEY env var
+          region: "cn"                      // "global" (qveris.ai) or "cn" (qveris.cn)
+        }
+      }
+    }
+  },
+
+  // 2. Add QVeris tools to the agent's tool allowlist
+  tools: {
+    alsoAllow: ["qveris"]
+  }
+}
+```
+
+> **Note**: `tools.alsoAllow` is required. Without it, plugin tools are not passed to the LLM even though the plugin is loaded.
+
+### API key via environment variable
+
+If you prefer not to store the key in the config file:
+
+```bash
+export QVERIS_API_KEY=qv-your-api-key-here
+```
+
+The plugin checks `plugins.entries.qveris.config.apiKey` first, then falls back to `QVERIS_API_KEY`.
+
+> **Security**: if no API key is found at startup, all three tools are silently omitted — no error is thrown.
+
+---
+
+## Full configuration reference
+
+All fields under `plugins.entries.qveris.config`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `string` | — | QVeris API key. Sensitive — use env var `QVERIS_API_KEY` as alternative. |
+| `region` | `"global"` \| `"cn"` | `"global"` | API region. `global` → `qveris.ai`, `cn` → `qveris.cn`. |
+| `baseUrl` | `string` | *(derived from region)* | Override API base URL. Use only when pointing at a private/staging endpoint. |
+| `searchTimeoutSeconds` | `number` | `5` | Timeout for `qveris_discover` calls. |
+| `executeTimeoutSeconds` | `number` | `60` | Default timeout for `qveris_call`. Can be overridden per-call via the `timeout_seconds` parameter. |
+| `searchLimit` | `number` | `10` | Max number of tools returned by `qveris_discover`. |
+| `maxResponseSize` | `number` | `20480` | Max response body size in bytes before truncation. |
+| `autoMaterializeFullContent` | `boolean` | `false` | When `true`, automatically download full-content files referenced in tool results to the agent workspace. |
+| `fullContentMaxBytes` | `number` | `10485760` (10 MB) | Max size for full-content downloads. |
+| `fullContentTimeoutSeconds` | `number` | `30` | Timeout for full-content downloads. |
+
+### Region and base URL
+
+| Region | API base URL | Full-content download domain |
+|--------|-------------|------------------------------|
+| `global` | `https://qveris.ai/api/v1` | `qveris.ai` |
+| `cn` | `https://qveris.cn/api/v1` | `qveris.cn` |
+
+---
+
+## Minimal vs full config examples
+
+### Minimal (global region, env var key)
+
+```bash
+export QVERIS_API_KEY=qv-...
+```
+
+```json5
+{
+  plugins: {
+    allow: ["qveris"],
+    entries: { qveris: { enabled: true } }
+  },
+  tools: { alsoAllow: ["qveris"] }
+}
+```
+
+### China region
+
+```json5
+{
+  plugins: {
+    allow: ["qveris"],
+    entries: {
+      qveris: {
+        enabled: true,
+        config: {
+          apiKey: "qv-...",
+          region: "cn"
+        }
+      }
+    }
+  },
+  tools: { alsoAllow: ["qveris"] }
+}
+```
+
+### With full-content materialization enabled
+
+```json5
+{
+  plugins: {
+    allow: ["qveris"],
+    entries: {
+      qveris: {
+        enabled: true,
+        config: {
+          apiKey: "qv-...",
+          region: "global",
+          autoMaterializeFullContent: true,
+          fullContentMaxBytes: 20971520,    // 20 MB
+          fullContentTimeoutSeconds: 60,
+          executeTimeoutSeconds: 120         // for slow image/video generation tools
+        }
+      }
+    }
+  },
+  tools: { alsoAllow: ["qveris"] }
+}
+```
+
+---
+
+## Verification
+
+After restarting the gateway, verify the plugin is loaded and tools are registered:
+
+```bash
+# Restart gateway
+openclaw gateway restart
+
+# Inspect plugin
+openclaw plugins inspect qveris
+```
+
+Expected output should include:
+
+```
+Status: loaded
+Tools:
+qveris_discover, qveris_call, qveris_inspect
+```
+
+---
+
+## Troubleshooting
+
+### Tools not visible to the agent
+
+Make sure `tools.alsoAllow: ["qveris"]` is set. Without this, plugin tools are excluded from the tool list sent to the LLM even if the plugin is loaded.
+
+### Plugin loaded but tools missing from `plugins inspect`
+
+The API key is not configured. Check:
+
+```bash
+openclaw config get plugins.entries.qveris
+# or
+echo $QVERIS_API_KEY
+```
+
+### `plugin id mismatch` warning on startup
+
+Your npm package name must unscopе to match the plugin id `qveris`. The correct package name is `@qverisai/qveris` (not `@qverisai/openclaw-qveris-plugin`).
+
+### `Cannot find module '@.../dist/plugin-sdk/root-alias.cjs/plugin-entry'`
+
+The OpenClaw host's `dist/` is not built. Either:
+- Use the official `openclaw` npm package as the host, or
+- Run `pnpm build` in the OpenClaw fork before loading the plugin.
+
+---
+
+## License
+
+MIT

--- a/packages/openclaw-qveris-plugin/index.ts
+++ b/packages/openclaw-qveris-plugin/index.ts
@@ -1,0 +1,15 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { createQverisTools } from "./src/qveris-tools.js";
+
+export default definePluginEntry({
+  id: "qveris",
+  name: "QVeris Plugin",
+  description: "QVeris capability discovery, tool inspection, and tool calling",
+  register(api: OpenClawPluginApi) {
+    api.registerTool(
+      (ctx) => createQverisTools({ api, ctx }),
+      { names: ["qveris_discover", "qveris_call", "qveris_inspect"] },
+    );
+  },
+});

--- a/packages/openclaw-qveris-plugin/openclaw.plugin.json
+++ b/packages/openclaw-qveris-plugin/openclaw.plugin.json
@@ -1,0 +1,34 @@
+{
+  "id": "qveris",
+  "providerAuthEnvVars": {
+    "qveris": ["QVERIS_API_KEY"]
+  },
+  "uiHints": {
+    "apiKey": {
+      "label": "QVeris API Key",
+      "help": "QVeris API key for capability discovery and tool calling (fallback: QVERIS_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "qv-..."
+    },
+    "region": {
+      "label": "QVeris Region",
+      "help": "API region: global (qveris.ai) or cn (qveris.cn)."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": { "type": ["string", "object"] },
+      "region": { "type": "string", "enum": ["global", "cn"] },
+      "baseUrl": { "type": "string" },
+      "autoMaterializeFullContent": { "type": "boolean" },
+      "fullContentMaxBytes": { "type": "number" },
+      "fullContentTimeoutSeconds": { "type": "number" },
+      "searchTimeoutSeconds": { "type": "number" },
+      "executeTimeoutSeconds": { "type": "number" },
+      "maxResponseSize": { "type": "number" },
+      "searchLimit": { "type": "number" }
+    }
+  }
+}

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@qverisai/qveris",
+  "version": "2026.3.23",
+  "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.22"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.3.22"
+    },
+    "build": {
+      "openclawVersion": "2026.3.24"
+    },
+    "install": {
+      "npmSpec": "@qverisai/qveris",
+      "minHostVersion": ">=2026.3.22"
+    },
+    "release": {
+      "publishToNpm": true
+    }
+  }
+}

--- a/packages/openclaw-qveris-plugin/src/config.ts
+++ b/packages/openclaw-qveris-plugin/src/config.ts
@@ -1,0 +1,112 @@
+import { normalizeSecretInput } from "openclaw/plugin-sdk/provider-auth";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+
+export type QverisRegion = "global" | "cn";
+
+export const QVERIS_REGION_DOMAINS: Record<QverisRegion, string> = {
+  global: "qveris.ai",
+  cn: "qveris.cn",
+};
+
+const DEFAULT_DISCOVER_TIMEOUT_SECONDS = 5;
+const DEFAULT_CALL_TIMEOUT_SECONDS = 60;
+const DEFAULT_MAX_RESPONSE_SIZE = 20480;
+const DEFAULT_DISCOVER_LIMIT = 10;
+const DEFAULT_FULL_CONTENT_MAX_BYTES = 10 * 1024 * 1024; // 10MB
+const DEFAULT_FULL_CONTENT_TIMEOUT_SECONDS = 30;
+
+function normalizeConfiguredSecret(value: unknown, path: string): string | undefined {
+  return normalizeSecretInput(
+    normalizeResolvedSecretInputString({
+      value,
+      path,
+    }),
+  );
+}
+
+export function resolveQverisApiKey(pluginConfig: Record<string, unknown> | undefined): string | undefined {
+  return (
+    normalizeConfiguredSecret(pluginConfig?.apiKey, "plugins.entries.qveris.config.apiKey") ||
+    normalizeSecretInput(process.env.QVERIS_API_KEY) ||
+    undefined
+  );
+}
+
+export function resolveQverisRegion(pluginConfig: Record<string, unknown> | undefined): QverisRegion {
+  return pluginConfig?.region === "cn" ? "cn" : "global";
+}
+
+export function resolveQverisBaseUrl(pluginConfig: Record<string, unknown> | undefined): string {
+  const explicit = typeof pluginConfig?.baseUrl === "string" ? pluginConfig.baseUrl.trim() : "";
+  if (explicit) {
+    return explicit;
+  }
+  const region = resolveQverisRegion(pluginConfig);
+  return `https://${QVERIS_REGION_DOMAINS[region]}/api/v1`;
+}
+
+/**
+ * Returns the allowed domains for full-content downloads.
+ * Includes the region domain plus the baseUrl domain if it resolves to a known QVeris domain.
+ */
+export function resolveFullContentAllowedDomains(pluginConfig: Record<string, unknown> | undefined): string[] {
+  const region = resolveQverisRegion(pluginConfig);
+  const domains = new Set<string>([QVERIS_REGION_DOMAINS[region]]);
+
+  const explicit = typeof pluginConfig?.baseUrl === "string" ? pluginConfig.baseUrl.trim() : "";
+  if (explicit) {
+    try {
+      const host = new URL(explicit).hostname.toLowerCase();
+      const allKnownDomains = Object.values(QVERIS_REGION_DOMAINS);
+      for (const d of allKnownDomains) {
+        if (host === d || host.endsWith(`.${d}`)) {
+          domains.add(d);
+        }
+      }
+    } catch {
+      // invalid baseUrl — ignore, region domain still in set
+    }
+  }
+
+  return [...domains];
+}
+
+export function resolveDiscoverTimeoutSeconds(pluginConfig: Record<string, unknown> | undefined): number {
+  const v = pluginConfig?.searchTimeoutSeconds;
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return Math.floor(v);
+  return DEFAULT_DISCOVER_TIMEOUT_SECONDS;
+}
+
+export function resolveCallTimeoutSeconds(pluginConfig: Record<string, unknown> | undefined): number {
+  const v = pluginConfig?.executeTimeoutSeconds;
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return Math.floor(v);
+  return DEFAULT_CALL_TIMEOUT_SECONDS;
+}
+
+export function resolveMaxResponseSize(pluginConfig: Record<string, unknown> | undefined): number {
+  const v = pluginConfig?.maxResponseSize;
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return Math.floor(v);
+  return DEFAULT_MAX_RESPONSE_SIZE;
+}
+
+export function resolveDiscoverLimit(pluginConfig: Record<string, unknown> | undefined): number {
+  const v = pluginConfig?.searchLimit;
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return Math.floor(v);
+  return DEFAULT_DISCOVER_LIMIT;
+}
+
+export function resolveAutoMaterialize(pluginConfig: Record<string, unknown> | undefined): boolean {
+  return pluginConfig?.autoMaterializeFullContent === true;
+}
+
+export function resolveFullContentMaxBytes(pluginConfig: Record<string, unknown> | undefined): number {
+  const v = pluginConfig?.fullContentMaxBytes;
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return Math.floor(v);
+  return DEFAULT_FULL_CONTENT_MAX_BYTES;
+}
+
+export function resolveFullContentTimeoutSeconds(pluginConfig: Record<string, unknown> | undefined): number {
+  const v = pluginConfig?.fullContentTimeoutSeconds;
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return Math.floor(v);
+  return DEFAULT_FULL_CONTENT_TIMEOUT_SECONDS;
+}

--- a/packages/openclaw-qveris-plugin/src/qveris-cache.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-cache.ts
@@ -1,0 +1,124 @@
+// Pure in-memory session-scoped state — no external dependencies.
+
+// ============================================================================
+// Discover Cache (short-TTL, avoids redundant API calls within a session)
+// ============================================================================
+
+const DEFAULT_DISCOVER_CACHE_TTL_MS = 90_000; // 90 seconds
+
+interface DiscoverCacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export function makeDiscoverCache<T>() {
+  const store = new Map<string, DiscoverCacheEntry<T>>();
+
+  function read(key: string): T | undefined {
+    const entry = store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  function write(key: string, value: T, ttlMs = DEFAULT_DISCOVER_CACHE_TTL_MS): void {
+    store.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  return { read, write };
+}
+
+// ============================================================================
+// Tool Rolodex — remembers successfully called tools for the session
+// ============================================================================
+
+interface RolodexEntry {
+  toolId: string;
+  name: string;
+  description: string;
+  successCount: number;
+  lastUsedAt: number;
+  discoveryQuery: string;
+  discoveryId?: string;
+}
+
+export function makeToolRolodex() {
+  const store = new Map<string, RolodexEntry>();
+
+  function record(
+    toolId: string,
+    meta: { name: string; description: string; discoveryQuery: string; discoveryId?: string },
+  ): void {
+    const existing = store.get(toolId);
+    if (existing) {
+      existing.successCount += 1;
+      existing.lastUsedAt = Date.now();
+      existing.discoveryId = meta.discoveryId ?? existing.discoveryId;
+    } else {
+      store.set(toolId, {
+        toolId,
+        name: meta.name,
+        description: meta.description,
+        successCount: 1,
+        lastUsedAt: Date.now(),
+        discoveryQuery: meta.discoveryQuery,
+        discoveryId: meta.discoveryId,
+      });
+    }
+  }
+
+  function lookup(toolId: string): RolodexEntry | undefined {
+    return store.get(toolId);
+  }
+
+  function getSummary(): Array<{ tool_id: string; name: string; uses: number }> {
+    return Array.from(store.values()).map((e) => ({
+      tool_id: e.toolId,
+      name: e.name,
+      uses: e.successCount,
+    }));
+  }
+
+  return { record, lookup, getSummary };
+}
+
+// ============================================================================
+// Discover Result Tracker — maps tool_id → discovery metadata (name, description, query, searchId)
+// ============================================================================
+
+interface DiscoverResultMeta {
+  name: string;
+  description: string;
+  query: string;
+  searchId?: string;
+}
+
+export function makeDiscoverResultTracker() {
+  const store = new Map<string, DiscoverResultMeta>();
+
+  function trackResults(
+    query: string,
+    tools: Array<{ tool_id: string; name: string; description: string }>,
+    searchId?: string,
+  ): void {
+    for (const tool of tools) {
+      const existing = store.get(tool.tool_id);
+      store.set(tool.tool_id, {
+        name: tool.name,
+        description: tool.description,
+        // Preserve original discovery query; "(inspect)" does not overwrite it
+        query: query === "(inspect)" ? (existing?.query ?? query) : query,
+        searchId: searchId ?? existing?.searchId,
+      });
+    }
+  }
+
+  function getMeta(toolId: string): DiscoverResultMeta | undefined {
+    return store.get(toolId);
+  }
+
+  return { trackResults, getMeta };
+}

--- a/packages/openclaw-qveris-plugin/src/qveris-client.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-client.ts
@@ -1,0 +1,197 @@
+// Pure HTTP client for the QVeris API. No SDK imports — only fetch + AbortController.
+
+/** Encode Retry-After into the error message so classifyQverisError can parse it */
+export function buildApiError(label: string, res: Response, detail: string): Error {
+  const retryAfter = res.headers.get("Retry-After");
+  const retryTag = retryAfter ? ` [retry-after:${retryAfter}]` : "";
+  return new Error(
+    `QVeris ${label} failed (${res.status}): ${detail || res.statusText}${retryTag}`,
+  );
+}
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+/** Parameter definition from QVeris discovery API */
+export interface QverisDiscoverResultParam {
+  name: string;
+  type: string;
+  required: boolean;
+  description?: {
+    en?: string;
+    [key: string]: string | undefined;
+  };
+}
+
+/** Example format from QVeris discovery API */
+export interface QverisDiscoverResultExamples {
+  sample_parameters?: Record<string, unknown>;
+}
+
+/** A single tool result from QVeris discovery */
+export interface QverisDiscoverResultTool {
+  tool_id: string;
+  name: string;
+  description: string;
+  params?: QverisDiscoverResultParam[];
+  provider_description?: string;
+  stats?: {
+    avg_execution_time_ms?: number;
+    success_rate?: number;
+  };
+  examples?: QverisDiscoverResultExamples;
+}
+
+/** QVeris /search response */
+export interface QverisDiscoverResponse {
+  query: string;
+  total: number;
+  results: QverisDiscoverResultTool[];
+  /** Backend session ID — resolved internally, never exposed to the model */
+  search_id: string;
+  elapsed_time_ms?: number;
+}
+
+/** QVeris /tools/execute response */
+export interface QverisCallResponse {
+  execution_id: string;
+  /** null when success is false */
+  result: {
+    data?: unknown;
+    status_code?: unknown;
+    message?: unknown;
+    full_content_file_url?: unknown;
+    truncated_content?: unknown;
+    content_schema?: unknown;
+  } | null;
+  success: boolean;
+  error_message: string | null;
+  elapsed_time_ms: number;
+  cost?: number;
+  credits_used?: number;
+}
+
+/** QVeris /tools/by-ids response */
+export interface QverisInspectResponse {
+  tools: QverisDiscoverResultTool[];
+}
+
+// ============================================================================
+// API Functions
+// ============================================================================
+
+export async function qverisDiscover(params: {
+  query: string;
+  sessionId: string;
+  limit: number;
+  apiKey: string;
+  baseUrl: string;
+  timeoutSeconds: number;
+}): Promise<QverisDiscoverResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), params.timeoutSeconds * 1000);
+
+  try {
+    const res = await fetch(`${params.baseUrl}/search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      body: JSON.stringify({
+        query: params.query,
+        limit: params.limit,
+        session_id: params.sessionId,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw buildApiError("discover", res, detail);
+    }
+
+    return (await res.json()) as QverisDiscoverResponse;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function qverisCall(params: {
+  toolId: string;
+  searchId?: string;
+  sessionId: string;
+  parameters: Record<string, unknown>;
+  maxResponseSize: number;
+  apiKey: string;
+  baseUrl: string;
+  timeoutSeconds: number;
+}): Promise<QverisCallResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), params.timeoutSeconds * 1000);
+
+  try {
+    const res = await fetch(
+      `${params.baseUrl}/tools/execute?tool_id=${encodeURIComponent(params.toolId)}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${params.apiKey}`,
+        },
+        body: JSON.stringify({
+          parameters: params.parameters,
+          max_response_size: params.maxResponseSize,
+          search_id: params.searchId ?? null,
+          session_id: params.sessionId,
+        }),
+        signal: controller.signal,
+      },
+    );
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw buildApiError("call", res, detail);
+    }
+
+    return (await res.json()) as QverisCallResponse;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function qverisInspect(params: {
+  toolIds: string[];
+  sessionId: string;
+  apiKey: string;
+  baseUrl: string;
+  timeoutSeconds: number;
+}): Promise<QverisInspectResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), params.timeoutSeconds * 1000);
+
+  try {
+    const res = await fetch(`${params.baseUrl}/tools/by-ids`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      body: JSON.stringify({
+        tool_ids: params.toolIds,
+        session_id: params.sessionId,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw buildApiError("inspect", res, detail);
+    }
+
+    return (await res.json()) as QverisInspectResponse;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/openclaw-qveris-plugin/src/qveris-errors.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-errors.ts
@@ -1,0 +1,106 @@
+// Pure error classification — no external dependencies.
+
+/**
+ * Short reminder appended to error results so the model stays in the QVeris tool workflow.
+ */
+export const QVERIS_WORKFLOW_NOTE =
+  "Stay inside the QVeris tool workflow (qveris_discover / qveris_call / qveris_inspect). " +
+  "Never call /search, /tools/execute, or /tools/by-ids directly. " +
+  "Never reveal QVERIS_API_KEY.";
+
+/** Structured error returned to the model instead of throwing */
+export interface QverisErrorResult {
+  success: false;
+  error_type:
+    | "timeout"
+    | "http_error"
+    | "network_error"
+    | "json_parse_error"
+    | "rate_limited"
+    | "tool_not_discovered";
+  status?: number;
+  detail: string;
+  retry_hint?: string;
+  retry_after_seconds?: number;
+  recovery_step?: "fix_params" | "simplify" | "switch_tool";
+  attempt_number?: number;
+  note?: string;
+}
+
+/**
+ * Classifies a caught error from a QVeris API call into a structured result
+ * so the model receives a consistent error format rather than an exception trace.
+ */
+export function classifyQverisError(err: unknown, opts?: { note?: string }): QverisErrorResult {
+  const note = opts?.note ?? QVERIS_WORKFLOW_NOTE;
+
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return {
+      success: false,
+      error_type: "timeout",
+      detail: "Request timed out",
+      retry_hint: "Increase timeout_seconds or retry with a simpler query.",
+      note,
+    };
+  }
+
+  if (err instanceof Error && err.name === "AbortError") {
+    return {
+      success: false,
+      error_type: "timeout",
+      detail: "Request timed out",
+      retry_hint: "Increase timeout_seconds or retry with a simpler query.",
+      note,
+    };
+  }
+
+  if (err instanceof Error) {
+    const httpMatch = err.message.match(/\((\d{3})\)/);
+    if (httpMatch) {
+      const status = Number(httpMatch[1]);
+
+      // Rate-limit: parse Retry-After encoded by buildApiError
+      if (status === 429) {
+        const retryMatch = err.message.match(/\[retry-after:(\d+)]/);
+        const waitSeconds = retryMatch ? Number(retryMatch[1]) : 10;
+        return {
+          success: false,
+          error_type: "rate_limited",
+          status: 429,
+          detail: err.message.replace(/\s*\[retry-after:\d+]/, ""),
+          retry_after_seconds: waitSeconds,
+          retry_hint: `Rate limited. Wait ${waitSeconds}s before retrying.`,
+          note,
+        };
+      }
+
+      const isClientError = status >= 400 && status < 500;
+      return {
+        success: false,
+        error_type: "http_error",
+        status,
+        detail: err.message,
+        retry_hint: isClientError
+          ? "Check tool_id and params_to_tool structure. Make sure tool_id came from qveris_discover."
+          : "QVeris service error — retry in a moment.",
+        note,
+      };
+    }
+
+    return {
+      success: false,
+      error_type: "network_error",
+      detail: err.message,
+      retry_hint: "Check network connectivity and retry.",
+      note,
+    };
+  }
+
+  return {
+    success: false,
+    error_type: "network_error",
+    detail: String(err),
+    retry_hint: "Check network connectivity and retry.",
+    note,
+  };
+}

--- a/packages/openclaw-qveris-plugin/src/qveris-materialization.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-materialization.ts
@@ -1,0 +1,448 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const QVERIS_DATA_DIR_NAME = "qveris-data";
+const MATERIALIZED_PREVIEW_MAX_CHARS = 800;
+
+const TEXT_MATERIALIZATION_CONTRACT =
+  "Use read or exec to process the materialized file. Do NOT base analysis on truncated transport data.";
+const MEDIA_MATERIALIZATION_CONTRACT =
+  "Binary file saved to disk. Report the file path and metadata to the user. Use the image tool to analyze images if applicable.";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ContentCategory = "json" | "csv" | "text" | "image" | "audio" | "video" | "binary";
+
+export interface ContentAnalysis {
+  root_type?: string;
+  record_count?: number;
+  line_count?: number;
+  column_names?: string[];
+  fields?: Record<string, string>;
+  preview_records?: number;
+}
+
+export interface MaterializedContentReady {
+  status: "ready";
+  path: string;
+  content_category: ContentCategory;
+  mime_type: string;
+  file_bytes: number;
+  analysis?: ContentAnalysis;
+  preview?: string;
+  consumption_contract: string;
+}
+
+export interface MaterializedContentFailed {
+  status: "failed";
+  reason: string;
+  detail?: string;
+}
+
+export type MaterializedContent = MaterializedContentReady | MaterializedContentFailed;
+
+interface DownloadResult {
+  raw: Uint8Array;
+  text?: string;
+  headerMime: string | null;
+  bytesRead: number;
+  truncatedOnDownload: boolean;
+}
+
+// ============================================================================
+// Local readResponseBuffer — reads a Response body into a Uint8Array with byte limit.
+// This utility does not exist in the upstream SDK so is implemented locally.
+// ============================================================================
+
+async function readResponseBuffer(
+  res: Response,
+  opts: { maxBytes: number },
+): Promise<{ buffer: Uint8Array; truncated: boolean; bytesRead: number }> {
+  const { maxBytes } = opts;
+
+  // Prefer arrayBuffer() when the body is not a stream (simpler path)
+  if (!res.body) {
+    const ab = await res.arrayBuffer();
+    const full = new Uint8Array(ab);
+    if (full.byteLength <= maxBytes) {
+      return { buffer: full, truncated: false, bytesRead: full.byteLength };
+    }
+    return { buffer: full.slice(0, maxBytes), truncated: true, bytesRead: full.byteLength };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  let truncated = false;
+  const reader = res.body.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remaining = maxBytes - totalBytes;
+      if (value.byteLength <= remaining) {
+        chunks.push(value);
+        totalBytes += value.byteLength;
+      } else {
+        // Byte limit reached — take only what fits
+        if (remaining > 0) {
+          chunks.push(value.slice(0, remaining));
+          totalBytes += remaining;
+        }
+        truncated = true;
+        break;
+      }
+    }
+  } finally {
+    reader.cancel().catch(() => undefined);
+  }
+
+  // Merge all chunks into one Uint8Array
+  const buffer = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { buffer, truncated, bytesRead: totalBytes };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function tryDecodeUtf8(buffer: Uint8Array): string | undefined {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+  } catch {
+    return undefined;
+  }
+}
+
+export function classifyContentCategory(mimeType: string | undefined): ContentCategory {
+  if (!mimeType) return "binary";
+  const lower = mimeType.toLowerCase().split(";")[0].trim();
+  if (lower === "application/json" || lower.endsWith("+json")) return "json";
+  if (lower === "text/csv" || lower === "application/csv") return "csv";
+  if (lower.startsWith("text/")) return "text";
+  if (lower.startsWith("image/")) return "image";
+  if (lower.startsWith("audio/")) return "audio";
+  if (lower.startsWith("video/")) return "video";
+  return "binary";
+}
+
+function resolveExtensionForMime(mime: string | undefined): string {
+  if (!mime) return ".bin";
+  const lower = mime.toLowerCase().split(";")[0].trim();
+  if (lower === "application/json" || lower.endsWith("+json")) return ".json";
+  if (lower === "text/csv" || lower === "application/csv") return ".csv";
+  if (lower === "text/plain") return ".txt";
+  if (lower === "text/html") return ".html";
+  if (lower === "text/xml" || lower === "application/xml") return ".xml";
+  if (lower.startsWith("image/png")) return ".png";
+  if (lower.startsWith("image/jpeg")) return ".jpg";
+  if (lower.startsWith("image/gif")) return ".gif";
+  if (lower.startsWith("image/webp")) return ".webp";
+  if (lower.startsWith("audio/mpeg")) return ".mp3";
+  if (lower.startsWith("audio/wav")) return ".wav";
+  if (lower.startsWith("video/mp4")) return ".mp4";
+  return ".bin";
+}
+
+function inferFieldType(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "array";
+    const first = value[0];
+    return `${typeof first === "object" && first !== null ? "object" : typeof first}[]`;
+  }
+  if (typeof value === "object") return "object";
+  return typeof value;
+}
+
+export function inferJsonAnalysis(
+  text: string,
+  maxPreviewChars: number,
+): ContentAnalysis & { preview?: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return {};
+  }
+
+  if (Array.isArray(parsed)) {
+    const fields: Record<string, string> = {};
+    const sample = parsed[0];
+    if (sample && typeof sample === "object" && sample !== null) {
+      for (const [key, val] of Object.entries(sample as Record<string, unknown>)) {
+        fields[key] = inferFieldType(val);
+      }
+    }
+    const previewSlice = parsed.slice(0, 2);
+    let preview = JSON.stringify(previewSlice);
+    if (preview.length > maxPreviewChars) preview = preview.slice(0, maxPreviewChars) + "...";
+    return {
+      root_type: "array",
+      record_count: parsed.length,
+      fields: Object.keys(fields).length > 0 ? fields : undefined,
+      preview_records: Math.min(2, parsed.length),
+      preview,
+    };
+  }
+
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const keys: Record<string, string> = {};
+    for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+      if (Array.isArray(val)) {
+        keys[key] = `array[${val.length}]`;
+      } else {
+        keys[key] = inferFieldType(val);
+      }
+    }
+    let preview = JSON.stringify(parsed, null, 2);
+    if (preview.length > maxPreviewChars) preview = preview.slice(0, maxPreviewChars) + "...";
+    return {
+      root_type: "object",
+      fields: Object.keys(keys).length > 0 ? keys : undefined,
+      preview,
+    };
+  }
+
+  return {};
+}
+
+function inferCsvAnalysis(
+  text: string,
+  maxPreviewChars: number,
+): ContentAnalysis & { preview?: string } {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return { line_count: 0 };
+
+  const firstLine = lines[0];
+  const delimiter = firstLine.includes("\t") ? "\t" : ",";
+  const columnNames = firstLine.split(delimiter).map((c) => c.trim().replace(/^["']|["']$/g, ""));
+
+  const previewLines = lines.slice(0, 5);
+  let preview = previewLines.join("\n");
+  if (preview.length > maxPreviewChars) preview = preview.slice(0, maxPreviewChars) + "...";
+
+  return { line_count: lines.length, column_names: columnNames, preview };
+}
+
+function inferTextAnalysis(
+  text: string,
+  maxPreviewChars: number,
+): ContentAnalysis & { preview?: string } {
+  const lines = text.split("\n");
+  let preview = text.slice(0, maxPreviewChars);
+  if (text.length > maxPreviewChars) preview += "...";
+  return { line_count: lines.length, preview };
+}
+
+function buildContentAnalysis(
+  text: string,
+  category: ContentCategory,
+  maxPreviewChars: number,
+): { analysis?: ContentAnalysis; preview?: string } {
+  let raw: ContentAnalysis & { preview?: string };
+  switch (category) {
+    case "json":
+      raw = inferJsonAnalysis(text, maxPreviewChars);
+      break;
+    case "csv":
+      raw = inferCsvAnalysis(text, maxPreviewChars);
+      break;
+    case "text":
+      raw = inferTextAnalysis(text, maxPreviewChars);
+      break;
+    default:
+      return {};
+  }
+  const { preview, ...rest } = raw;
+  const analysis = Object.keys(rest).length > 0 ? rest : undefined;
+  return { analysis, preview };
+}
+
+function isAllowedFullContentDomain(hostname: string, allowedDomains: string[]): boolean {
+  const lower = hostname.toLowerCase();
+  return allowedDomains.some((domain) => lower === domain || lower.endsWith(`.${domain}`));
+}
+
+// ============================================================================
+// Fetch full result data from a QVeris-provided URL
+// Security: HTTPS-only, domain-whitelisted, no redirects
+// ============================================================================
+
+async function fetchQverisResultData(params: {
+  url: string;
+  maxBytes: number;
+  timeoutSeconds: number;
+  allowedDomains: string[];
+}): Promise<DownloadResult> {
+  if (!params.url.startsWith("https://")) {
+    throw new Error("full_content_file_url must use HTTPS");
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(params.url);
+  } catch {
+    throw new Error(`full_content_file_url is not a valid URL: ${params.url}`);
+  }
+
+  if (!isAllowedFullContentDomain(parsedUrl.hostname, params.allowedDomains)) {
+    throw new Error(
+      `full_content_file_url domain "${parsedUrl.hostname}" is not in the allowed list ` +
+        `(${params.allowedDomains.join(", ")}). Download blocked.`,
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), params.timeoutSeconds * 1000);
+
+  try {
+    const res = await fetch(params.url, {
+      signal: controller.signal,
+      redirect: "error",
+    });
+
+    if (!res.ok) {
+      throw new Error(`Full-content download failed (${res.status}): ${res.statusText}`);
+    }
+
+    const headerMime = res.headers.get("content-type");
+    const category = classifyContentCategory(
+      headerMime ? headerMime.split(";")[0].trim() : undefined,
+    );
+    const { buffer, truncated, bytesRead } = await readResponseBuffer(res, {
+      maxBytes: params.maxBytes,
+    });
+
+    // Decode to text only for non-binary categories
+    const text =
+      category === "image" || category === "audio" || category === "video"
+        ? undefined
+        : tryDecodeUtf8(buffer);
+
+    return { raw: buffer, text, headerMime, bytesRead, truncatedOnDownload: truncated };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// ============================================================================
+// Save QVeris full result data to workspace — never throws
+// ============================================================================
+
+export async function saveQverisFullResult(params: {
+  url: string;
+  executionId: string;
+  workspaceDir: string;
+  maxBytes: number;
+  timeoutSeconds: number;
+  allowedDomains: string[];
+}): Promise<MaterializedContent> {
+  let downloaded: DownloadResult;
+  try {
+    downloaded = await fetchQverisResultData({
+      url: params.url,
+      maxBytes: params.maxBytes,
+      timeoutSeconds: params.timeoutSeconds,
+      allowedDomains: params.allowedDomains,
+    });
+  } catch (err) {
+    const isTimeout =
+      (err instanceof DOMException && err.name === "AbortError") ||
+      (err instanceof Error && err.name === "AbortError");
+    return {
+      status: "failed",
+      reason: isTimeout ? "download_timeout" : "download_error",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  let mimeType: string | undefined = downloaded.headerMime
+    ? downloaded.headerMime.split(";")[0].trim()
+    : undefined;
+
+  // Heuristic: reclassify application/octet-stream as JSON when content looks like JSON
+  if ((!mimeType || mimeType === "application/octet-stream") && downloaded.text) {
+    const trimmed = downloaded.text.trimStart();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        JSON.parse(downloaded.text);
+        mimeType = "application/json";
+      } catch {
+        mimeType = mimeType || "application/octet-stream";
+      }
+    }
+  }
+
+  const category = classifyContentCategory(mimeType);
+
+  if (downloaded.truncatedOnDownload) {
+    return {
+      status: "failed",
+      reason: "download_truncated",
+      detail:
+        `Downloaded content was truncated at ${downloaded.bytesRead} bytes (limit: ${params.maxBytes}). ` +
+        "The file is incomplete. Use web_fetch for text content, exec+curl for binary content, or increase fullContentMaxBytes.",
+    };
+  }
+
+  const buffer = Buffer.from(downloaded.raw);
+  const ext = resolveExtensionForMime(mimeType);
+
+  const safeDirName = params.executionId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const relDir = path.posix.join(".openclaw", QVERIS_DATA_DIR_NAME, safeDirName);
+  const absDir = path.join(params.workspaceDir, ".openclaw", QVERIS_DATA_DIR_NAME, safeDirName);
+  const dataFilename = `data${ext}`;
+  const relDataPath = path.posix.join(relDir, dataFilename);
+  const absDataPath = path.join(absDir, dataFilename);
+
+  try {
+    await fs.mkdir(absDir, { recursive: true });
+    await fs.writeFile(absDataPath, buffer, { flag: "w" });
+  } catch (err) {
+    return {
+      status: "failed",
+      reason: "write_error",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const isTextBased = category === "json" || category === "csv" || category === "text";
+  const { analysis, preview } =
+    isTextBased && downloaded.text
+      ? buildContentAnalysis(downloaded.text, category, MATERIALIZED_PREVIEW_MAX_CHARS)
+      : { analysis: undefined, preview: undefined };
+
+  const manifest: MaterializedContentReady = {
+    status: "ready",
+    path: relDataPath,
+    content_category: category,
+    mime_type: mimeType || "application/octet-stream",
+    file_bytes: buffer.byteLength,
+    ...(analysis ? { analysis } : {}),
+    ...(preview ? { preview } : {}),
+    consumption_contract: isTextBased ? TEXT_MATERIALIZATION_CONTRACT : MEDIA_MATERIALIZATION_CONTRACT,
+  };
+
+  try {
+    await fs.writeFile(
+      path.join(absDir, "manifest.json"),
+      JSON.stringify(manifest, null, 2) + "\n",
+      { flag: "w" },
+    );
+  } catch {
+    // Non-fatal: manifest.json is for debugging only
+  }
+
+  return manifest;
+}

--- a/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
@@ -1,0 +1,1182 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import plugin from "../index.js";
+import { classifyQverisError } from "./qveris-errors.js";
+import { inferJsonAnalysis } from "./qveris-materialization.js";
+import {
+  resolveQverisApiKey,
+  resolveQverisBaseUrl,
+  resolveQverisRegion,
+  resolveDiscoverTimeoutSeconds,
+  resolveCallTimeoutSeconds,
+  resolveFullContentAllowedDomains,
+  QVERIS_REGION_DOMAINS,
+} from "./config.js";
+import { createQverisTools } from "./qveris-tools.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePluginConfig(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    apiKey: "qv_test_key",
+    ...overrides,
+  };
+}
+
+function fakeApi(pluginConfig?: Record<string, unknown>): OpenClawPluginApi {
+  return {
+    pluginConfig: pluginConfig ?? makePluginConfig(),
+    config: {},
+  } as unknown as OpenClawPluginApi;
+}
+
+function fakeCtx(overrides?: Record<string, unknown>) {
+  return {
+    config: {},
+    workspaceDir: undefined,
+    sessionKey: "test-session-1",
+    ...overrides,
+  };
+}
+
+function mockFetchJson(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(),
+  });
+}
+
+/** Extract the JSON payload from an AgentToolResult */
+function parseToolResult(result: unknown): Record<string, unknown> {
+  if (result && typeof result === "object" && "details" in result) {
+    return (result as { details: Record<string, unknown> }).details;
+  }
+  if (result && typeof result === "object" && "content" in result) {
+    const content = (result as { content: Array<{ text: string }> }).content;
+    return JSON.parse(content[0].text) as Record<string, unknown>;
+  }
+  return JSON.parse(String(result)) as Record<string, unknown>;
+}
+
+function parseRequestBody(body: BodyInit | null | undefined): Record<string, unknown> {
+  if (typeof body === "string") return JSON.parse(body) as Record<string, unknown>;
+  if (body == null) return {};
+  throw new Error(`Unsupported mocked request body type: ${typeof body}`);
+}
+
+const SAMPLE_DISCOVER_RESPONSE = {
+  query: "weather forecast API",
+  total: 1,
+  search_id: "search-abc",
+  elapsed_time_ms: 42,
+  results: [
+    {
+      tool_id: "openweathermap.weather.execute.v1",
+      name: "OpenWeatherMap",
+      description: "Weather forecast API",
+      provider_description: "Weather data provider",
+      params: [{ name: "city", type: "string", required: true, description: { en: "City name" } }],
+      examples: { sample_parameters: { city: "London" } },
+      stats: { success_rate: 0.95, avg_execution_time_ms: 800 },
+    },
+  ],
+};
+
+const SAMPLE_INVOKE_RESPONSE = {
+  execution_id: "exec-123",
+  result: { data: { temp: 20, condition: "sunny" } },
+  success: true,
+  error_message: null,
+  elapsed_time_ms: 300,
+  cost: 0.01,
+};
+
+const SAMPLE_INSPECT_RESPONSE = {
+  tools: [
+    {
+      tool_id: "openweathermap.weather.execute.v1",
+      name: "OpenWeatherMap",
+      description: "Weather forecast API",
+      params: [{ name: "city", type: "string", required: true, description: { en: "City name" } }],
+      examples: { sample_parameters: { city: "London" } },
+      stats: { success_rate: 0.95, avg_execution_time_ms: 800 },
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Plugin registration
+// ---------------------------------------------------------------------------
+
+describe("plugin registration", () => {
+  it("registers tool factory with correct names", () => {
+    const registrations: {
+      factories: unknown[];
+      opts: unknown[];
+    } = { factories: [], opts: [] };
+
+    const mockApi = {
+      registerTool(factory: unknown, opts: unknown) {
+        registrations.factories.push(factory);
+        registrations.opts.push(opts);
+      },
+      pluginConfig: makePluginConfig(),
+      config: {},
+    };
+
+    plugin.register(mockApi as never);
+
+    expect(plugin.id).toBe("qveris");
+    expect(plugin.name).toBe("QVeris Plugin");
+    expect(registrations.factories).toHaveLength(1);
+    expect(typeof registrations.factories[0]).toBe("function");
+    expect(registrations.opts[0]).toEqual({
+      names: ["qveris_discover", "qveris_call", "qveris_inspect"],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+describe("config resolution", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves API key from plugin config", () => {
+    expect(resolveQverisApiKey({ apiKey: "from-config" })).toBe("from-config");
+  });
+
+  it("falls back to QVERIS_API_KEY env", () => {
+    vi.stubEnv("QVERIS_API_KEY", "env-key");
+    expect(resolveQverisApiKey(undefined)).toBe("env-key");
+  });
+
+  it("prefers plugin config over env var", () => {
+    vi.stubEnv("QVERIS_API_KEY", "env-key");
+    expect(resolveQverisApiKey({ apiKey: "config-key" })).toBe("config-key");
+  });
+
+  it("returns undefined when no key anywhere", () => {
+    const saved = process.env.QVERIS_API_KEY;
+    delete process.env.QVERIS_API_KEY;
+    try {
+      expect(resolveQverisApiKey(undefined)).toBeUndefined();
+    } finally {
+      if (saved !== undefined) process.env.QVERIS_API_KEY = saved;
+    }
+  });
+
+  it("resolves global region by default", () => {
+    expect(resolveQverisRegion(undefined)).toBe("global");
+    expect(resolveQverisRegion({})).toBe("global");
+  });
+
+  it("resolves cn region when configured", () => {
+    expect(resolveQverisRegion({ region: "cn" })).toBe("cn");
+  });
+
+  it("builds global base URL from region domain", () => {
+    expect(resolveQverisBaseUrl(undefined)).toBe(`https://${QVERIS_REGION_DOMAINS.global}/api/v1`);
+  });
+
+  it("builds cn base URL from region", () => {
+    expect(resolveQverisBaseUrl({ region: "cn" })).toBe(
+      `https://${QVERIS_REGION_DOMAINS.cn}/api/v1`,
+    );
+  });
+
+  it("uses explicit baseUrl when provided", () => {
+    expect(resolveQverisBaseUrl({ baseUrl: "https://proxy.example/qveris" })).toBe(
+      "https://proxy.example/qveris",
+    );
+  });
+
+  it("resolveDiscoverTimeoutSeconds returns default when not set", () => {
+    expect(resolveDiscoverTimeoutSeconds(undefined)).toBe(5);
+  });
+
+  it("resolveCallTimeoutSeconds returns default when not set", () => {
+    expect(resolveCallTimeoutSeconds(undefined)).toBe(60);
+  });
+
+  it("resolveDiscoverTimeoutSeconds uses searchTimeoutSeconds", () => {
+    expect(resolveDiscoverTimeoutSeconds({ searchTimeoutSeconds: 10 })).toBe(10);
+  });
+
+  it("resolveCallTimeoutSeconds uses executeTimeoutSeconds", () => {
+    expect(resolveCallTimeoutSeconds({ executeTimeoutSeconds: 120 })).toBe(120);
+  });
+
+  it("full-content allowed domains includes region domain", () => {
+    const domains = resolveFullContentAllowedDomains(undefined);
+    expect(domains).toContain(QVERIS_REGION_DOMAINS.global);
+  });
+
+  it("full-content allowed domains for cn region contains qveris.cn only", () => {
+    const domains = resolveFullContentAllowedDomains({ region: "cn" });
+    expect(domains).toContain(QVERIS_REGION_DOMAINS.cn);
+    expect(domains).not.toContain(QVERIS_REGION_DOMAINS.global);
+  });
+
+  it("full-content allowed domains extends to baseUrl qveris domain", () => {
+    const domains = resolveFullContentAllowedDomains({
+      region: "global",
+      baseUrl: "https://qveris.cn/api/v1",
+    });
+    expect(domains).toContain(QVERIS_REGION_DOMAINS.global);
+    expect(domains).toContain(QVERIS_REGION_DOMAINS.cn);
+  });
+
+  it("subdomain of region domain (e.g. oss.qveris.cn) is allowed for cn region", () => {
+    const domains = resolveFullContentAllowedDomains({ region: "cn" });
+    // oss.qveris.cn ends with .qveris.cn — must be whitelisted for materialization
+    const ossHostname = `oss.${QVERIS_REGION_DOMAINS.cn}`;
+    const allowed = domains.some(
+      (d) => ossHostname === d || ossHostname.endsWith(`.${d}`),
+    );
+    expect(allowed).toBe(true);
+  });
+
+  it("subdomain of region domain (e.g. oss.qveris.ai) is allowed for global region", () => {
+    const domains = resolveFullContentAllowedDomains(undefined);
+    const ossHostname = `oss.${QVERIS_REGION_DOMAINS.global}`;
+    const allowed = domains.some(
+      (d) => ossHostname === d || ossHostname.endsWith(`.${d}`),
+    );
+    expect(allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyQverisError
+// ---------------------------------------------------------------------------
+
+describe("classifyQverisError", () => {
+  it("classifies AbortError (DOMException) as timeout", () => {
+    const err = new DOMException("The operation was aborted", "AbortError");
+    const result = classifyQverisError(err);
+    expect(result.success).toBe(false);
+    expect(result.error_type).toBe("timeout");
+    expect(result.detail).toContain("timed out");
+    expect(result.retry_hint).toBeDefined();
+  });
+
+  it("classifies plain Error with name AbortError as timeout", () => {
+    const err = Object.assign(new Error("aborted"), { name: "AbortError" });
+    const result = classifyQverisError(err);
+    expect(result.success).toBe(false);
+    expect(result.error_type).toBe("timeout");
+  });
+
+  it("classifies HTTP 4xx errors correctly", () => {
+    const err = new Error("QVeris call failed (422): unprocessable entity");
+    const result = classifyQverisError(err);
+    expect(result.success).toBe(false);
+    expect(result.error_type).toBe("http_error");
+    expect(result.status).toBe(422);
+    expect(result.retry_hint).toContain("tool_id");
+  });
+
+  it("classifies HTTP 5xx errors correctly", () => {
+    const err = new Error("QVeris discover failed (503): service unavailable");
+    const result = classifyQverisError(err);
+    expect(result.success).toBe(false);
+    expect(result.error_type).toBe("http_error");
+    expect(result.status).toBe(503);
+    expect(result.retry_hint).toContain("retry");
+  });
+
+  it("classifies 429 rate-limit errors", () => {
+    const err = new Error("QVeris discover failed (429): too many requests [retry-after:30]");
+    const result = classifyQverisError(err);
+    expect(result.success).toBe(false);
+    expect(result.error_type).toBe("rate_limited");
+    expect(result.status).toBe(429);
+    expect(result.retry_after_seconds).toBe(30);
+    expect(result.retry_hint).toContain("30s");
+  });
+
+  it("classifies network errors", () => {
+    const err = new Error("fetch failed: ECONNREFUSED");
+    const result = classifyQverisError(err);
+    expect(result.success).toBe(false);
+    expect(result.error_type).toBe("network_error");
+    expect(result.detail).toContain("ECONNREFUSED");
+  });
+
+  it("classifies unknown thrown values", () => {
+    const result = classifyQverisError("something weird");
+    expect(result.success).toBe(false);
+    expect(result.error_type).toBe("network_error");
+    expect(result.detail).toBe("something weird");
+  });
+
+  it("includes default workflow note", () => {
+    const result = classifyQverisError(new Error("fail"));
+    expect(result.note).toContain("Stay inside the QVeris tool workflow");
+    expect(result.note).toContain("Never call /search");
+    expect(result.note).toContain("QVERIS_API_KEY");
+  });
+
+  it("uses caller-provided note when supplied", () => {
+    const result = classifyQverisError(new Error("fail"), { note: "custom note" });
+    expect(result.note).toBe("custom note");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createQverisTools — factory behavior
+// ---------------------------------------------------------------------------
+
+describe("createQverisTools", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns null when no API key", () => {
+    const saved = process.env.QVERIS_API_KEY;
+    delete process.env.QVERIS_API_KEY;
+    try {
+      const tools = createQverisTools({ api: fakeApi({ enabled: true }), ctx: fakeCtx() });
+      expect(tools).toBeNull();
+    } finally {
+      if (saved !== undefined) process.env.QVERIS_API_KEY = saved;
+    }
+  });
+
+  it("creates three tools when API key is configured", () => {
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    expect(tools).toHaveLength(3);
+    const names = tools!.map((t) => t.name);
+    expect(names).toContain("qveris_discover");
+    expect(names).toContain("qveris_call");
+    expect(names).toContain("qveris_inspect");
+  });
+
+  it("qveris_discover description includes negative boundaries", () => {
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const discover = tools!.find((t) => t.name === "qveris_discover");
+    expect(discover?.description).toContain("NOT for");
+    expect(discover?.description).toContain("local file operations");
+    expect(discover?.description).toContain("documentation");
+  });
+
+  it("qveris_call schema has tool_id and params_to_tool but not search_id", () => {
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const callTool = tools!.find((t) => t.name === "qveris_call");
+    const schema = callTool?.parameters as { properties?: Record<string, unknown> } | undefined;
+    expect(schema?.properties?.tool_id).toBeDefined();
+    expect(schema?.properties?.params_to_tool).toBeDefined();
+    expect(schema?.properties?.search_id).toBeUndefined();
+    expect(schema?.properties?.discovery_id).toBeUndefined();
+  });
+
+  it("qveris_discover query schema includes bilingual guidance", () => {
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const discover = tools!.find((t) => t.name === "qveris_discover");
+    const schema = discover?.parameters as { properties?: Record<string, unknown> };
+    const queryDescription = (schema.properties?.query as Record<string, unknown>)?.description ?? "";
+    expect(String(queryDescription)).toContain("腾讯最新股价");
+    expect(String(queryDescription)).toContain("stock quote real-time API");
+  });
+
+  it("qveris_inspect returns tool details", async () => {
+    globalThis.fetch = mockFetchJson(SAMPLE_INSPECT_RESPONSE);
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const inspect = tools!.find((t) => t.name === "qveris_inspect")!;
+
+    const result = await inspect.execute("call-1", { tool_ids: "openweathermap.weather.execute.v1" });
+    const parsed = parseToolResult(result);
+    expect(parsed.tools_found).toBe(1);
+    const toolsList = parsed.tools as Array<Record<string, unknown>>;
+    expect(toolsList[0].tool_id).toBe("openweathermap.weather.execute.v1");
+  });
+
+  it("qveris_inspect returns error for empty tool_ids", async () => {
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const inspect = tools!.find((t) => t.name === "qveris_inspect")!;
+
+    const result = await inspect.execute("call-1", { tool_ids: " , , " });
+    const parsed = parseToolResult(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error_type).toBe("json_parse_error");
+    expect(String(parsed.note)).toContain("Stay inside the QVeris tool workflow");
+  });
+
+  it("qveris_call proceeds with null search_id when tool not discovered", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ execution_id: "exec-1", success: true, result: { data: "ok" } }),
+      text: () => Promise.resolve(""),
+      headers: new Headers(),
+    });
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("call-1", {
+      tool_id: "unknown-tool-xyz",
+      params_to_tool: '{"city": "London"}',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/tools/execute");
+    const body = JSON.parse(init.body);
+    expect(body.search_id).toBeNull();
+  });
+
+  it("qveris_call auto-resolves search_id from discover tracker", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(SAMPLE_DISCOVER_RESPONSE),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      if (typeof url === "string" && url.includes("/tools/execute")) {
+        const body = parseRequestBody(init?.body);
+        expect(body.search_id).toBe("search-abc");
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(SAMPLE_INVOKE_RESPONSE),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+        headers: new Headers(),
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const discover = tools!.find((t) => t.name === "qveris_discover")!;
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    await discover.execute("d1", { query: "weather forecast API" });
+    const result = await callTool.execute("c1", {
+      tool_id: "openweathermap.weather.execute.v1",
+      params_to_tool: '{"city": "London"}',
+    });
+    const parsed = parseToolResult(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.execution_id).toBe("exec-123");
+  });
+
+  it("qveris_call returns recovery_step on body-level failure", async () => {
+    const failResponse = {
+      execution_id: "exec-fail",
+      result: null,
+      success: false,
+      error_message: "Invalid parameter: city not found",
+      elapsed_time_ms: 100,
+      cost: 0,
+    };
+    const discoverResponse = {
+      query: "tool x API",
+      total: 1,
+      search_id: "s1",
+      results: [{ tool_id: "tool-x", name: "ToolX", description: "test" }],
+    };
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(discoverResponse),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(failResponse),
+        text: () => Promise.resolve(""),
+        headers: new Headers(),
+      });
+    });
+
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const discover = tools!.find((t) => t.name === "qveris_discover")!;
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    await discover.execute("d1", { query: "tool x API" });
+    const result1 = await callTool.execute("c1", { tool_id: "tool-x", params_to_tool: '{"q":"a"}' });
+    const parsed1 = parseToolResult(result1);
+    expect(parsed1.success).toBe(false);
+    expect(parsed1.recovery_step).toBe("fix_params");
+    expect(parsed1.attempt_number).toBe(1);
+
+    const result2 = await callTool.execute("c2", { tool_id: "tool-x", params_to_tool: '{"q":"b"}' });
+    const parsed2 = parseToolResult(result2);
+    expect(parsed2.recovery_step).toBe("simplify");
+    expect(parsed2.attempt_number).toBe(2);
+  });
+
+  it("rolodex records successful invocations and annotates discover results", async () => {
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(SAMPLE_DISCOVER_RESPONSE),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      if (typeof url === "string" && url.includes("/tools/execute")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(SAMPLE_INVOKE_RESPONSE),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+        headers: new Headers(),
+      });
+    });
+
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const discover = tools!.find((t) => t.name === "qveris_discover")!;
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const r1 = await discover.execute("s1", { query: "weather forecast API" });
+    const p1 = parseToolResult(r1);
+    expect(p1.session_known_tools).toBeUndefined();
+    const results1 = p1.results as Array<Record<string, unknown>>;
+    expect(results1[0].previously_used).toBeUndefined();
+
+    await callTool.execute("e1", {
+      tool_id: "openweathermap.weather.execute.v1",
+      params_to_tool: '{"city": "London"}',
+    });
+
+    const r2 = await discover.execute("s2", { query: "weather data API", limit: 5 });
+    const p2 = parseToolResult(r2);
+    const knownTools = p2.session_known_tools as Array<Record<string, unknown>>;
+    expect(knownTools).toBeDefined();
+    expect(knownTools).toHaveLength(1);
+    expect(knownTools[0].tool_id).toBe("openweathermap.weather.execute.v1");
+    expect(knownTools[0].uses).toBe(1);
+    expect(knownTools[0].discovery_id).toBeUndefined();
+
+    const results2 = p2.results as Array<Record<string, unknown>>;
+    expect(results2[0].previously_used).toBe(true);
+    expect(results2[0].session_uses).toBe(1);
+    expect(results2[0].discovery_id).toBeUndefined();
+  });
+
+  it("qveris_call parses invalid JSON in params_to_tool gracefully", async () => {
+    globalThis.fetch = mockFetchJson(SAMPLE_DISCOVER_RESPONSE);
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const discover = tools!.find((t) => t.name === "qveris_discover")!;
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    await discover.execute("d1", { query: "weather forecast API" });
+    const result = await callTool.execute("c1", {
+      tool_id: "openweathermap.weather.execute.v1",
+      params_to_tool: "not-valid-json",
+    });
+    const parsed = parseToolResult(result);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error_type).toBe("json_parse_error");
+  });
+
+  it("session state is isolated per factory call — undiscovered call uses null search_id", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(SAMPLE_DISCOVER_RESPONSE),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      if (typeof url === "string" && url.includes("/tools/execute")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(SAMPLE_INVOKE_RESPONSE),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve(""), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools1 = createQverisTools({ api: fakeApi(), ctx: fakeCtx({ sessionKey: "s1" }) });
+    const tools2 = createQverisTools({ api: fakeApi(), ctx: fakeCtx({ sessionKey: "s2" }) });
+
+    const discover1 = tools1!.find((t) => t.name === "qveris_discover")!;
+    const callTool2 = tools2!.find((t) => t.name === "qveris_call")!;
+
+    await discover1.execute("d1", { query: "weather forecast API" });
+
+    // tools2 should not see tools1's discovery — call proceeds with null search_id
+    await callTool2.execute("c1", {
+      tool_id: "openweathermap.weather.execute.v1",
+      params_to_tool: '{"city": "London"}',
+    });
+    const executeCall = fetchMock.mock.calls.find(([u]: [string]) => u.includes("/tools/execute"));
+    expect(executeCall).toBeDefined();
+    const body = JSON.parse(executeCall![1].body);
+    expect(body.search_id).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferJsonAnalysis
+// ---------------------------------------------------------------------------
+
+describe("inferJsonAnalysis", () => {
+  it("infers JSON array schema from first record", () => {
+    const data = JSON.stringify([
+      { user_id: "abc", nickname: "test", fans_count: 123, tags: ["a", "b"] },
+      { user_id: "def", nickname: "test2", fans_count: 456, tags: ["c"] },
+    ]);
+    const result = inferJsonAnalysis(data, 800);
+    expect(result.root_type).toBe("array");
+    expect(result.record_count).toBe(2);
+    expect(result.fields).toBeDefined();
+    expect(result.fields!.user_id).toBe("string");
+    expect(result.fields!.fans_count).toBe("number");
+    expect(result.fields!.tags).toBe("string[]");
+    expect(result.preview_records).toBe(2);
+    expect(result.preview).toBeDefined();
+  });
+
+  it("infers JSON object schema", () => {
+    const data = JSON.stringify({ items: [1, 2, 3], total: 3, name: "test" });
+    const result = inferJsonAnalysis(data, 800);
+    expect(result.root_type).toBe("object");
+    expect(result.fields).toBeDefined();
+    expect(result.fields!.items).toBe("array[3]");
+    expect(result.fields!.total).toBe("number");
+    expect(result.fields!.name).toBe("string");
+  });
+
+  it("returns empty analysis for invalid JSON", () => {
+    const result = inferJsonAnalysis("not json", 800);
+    expect(result.root_type).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full-content materialization
+// ---------------------------------------------------------------------------
+
+describe("qveris_call materialization", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "qveris-materialize-test-"));
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  const TRUNCATED_CALL_RESPONSE = {
+    execution_id: "exec-trunc-1",
+    result: {
+      status_code: 200,
+      message: "Result content is too long (132707 bytes)",
+      truncated_content: '[{"user_id":"abc","nickname":"partial..."}]',
+      full_content_file_url: "https://oss.qveris.ai/full-content/exec-trunc-1.json",
+      content_schema: { type: "array" },
+    },
+    success: true,
+    error_message: null,
+    elapsed_time_ms: 500,
+    cost: 0.05,
+  };
+
+  const FULL_CONTENT_JSON = JSON.stringify([
+    { user_id: "abc", nickname: "KOL_A", fans_count: 52000, tags: ["beauty"] },
+    { user_id: "def", nickname: "KOL_B", fans_count: 31000, tags: ["fashion"] },
+  ]);
+
+  function makeDiscoverResponse(toolId: string, searchId = "search-mat") {
+    return {
+      query: "materialize test",
+      total: 1,
+      search_id: searchId,
+      results: [{ tool_id: toolId, name: toolId, description: "test tool" }],
+    };
+  }
+
+  async function registerToolViaDiscover(
+    tools: Array<{ name: string; execute: (id: string, args: Record<string, unknown>) => Promise<unknown> }>,
+    toolId: string,
+  ) {
+    const discover = tools.find((t) => t.name === "qveris_discover")!;
+    await discover.execute("pre-discover", { query: `find ${toolId}` });
+  }
+
+  /** Build a fake Response whose body can be read via arrayBuffer() */
+  function fakeTextResponse(text: string, contentType: string) {
+    const encoded = new TextEncoder().encode(text);
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(encoded.buffer.slice(0) as ArrayBuffer),
+      text: () => Promise.resolve(text),
+      headers: new Headers({ "content-type": contentType }),
+    };
+  }
+
+  function makeMaterializeFetchMock(opts?: {
+    toolId?: string;
+    callResponse?: typeof TRUNCATED_CALL_RESPONSE;
+    ossHandler?: (url: string) => Promise<unknown>;
+  }) {
+    const toolId = opts?.toolId ?? "test-tool";
+    const callResponse = opts?.callResponse ?? TRUNCATED_CALL_RESPONSE;
+    return vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(makeDiscoverResponse(toolId)),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      if (typeof url === "string" && url.includes("/tools/execute")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(callResponse),
+          text: () => Promise.resolve(JSON.stringify(callResponse)),
+          headers: new Headers(),
+        });
+      }
+      if (opts?.ossHandler && typeof url === "string" && url.includes("oss.qveris.ai")) {
+        return opts.ossHandler(url);
+      }
+      if (typeof url === "string" && url.includes("oss.qveris.ai")) {
+        return Promise.resolve(fakeTextResponse(FULL_CONTENT_JSON, "application/json"));
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+        headers: new Headers(),
+      });
+    });
+  }
+
+  it("materializes full content when full_content_file_url is present", async () => {
+    globalThis.fetch = makeMaterializeFetchMock({ toolId: "kol-search-tool" });
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "kol-search-tool");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", {
+      tool_id: "kol-search-tool",
+      params_to_tool: '{"keyword": "beauty"}',
+    });
+    const parsed = parseToolResult(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.materialized_content).toBeDefined();
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("ready");
+    expect(mc.content_category).toBe("json");
+    expect(typeof mc.path).toBe("string");
+    expect(mc.consumption_contract).toContain("read or exec");
+
+    const filePath = path.join(tmpDir, mc.path as string);
+    const content = await fsp.readFile(filePath, "utf-8");
+    expect(JSON.parse(content)).toHaveLength(2);
+  });
+
+  it("strips truncated transport fields on successful materialization", async () => {
+    globalThis.fetch = makeMaterializeFetchMock({ toolId: "kol-search-tool" });
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "kol-search-tool");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", {
+      tool_id: "kol-search-tool",
+      params_to_tool: '{"keyword": "beauty"}',
+    });
+    const parsed = parseToolResult(result);
+    const resultObj = parsed.result as Record<string, unknown>;
+    expect(resultObj.truncated_content).toBeUndefined();
+    expect(resultObj.full_content_file_url).toBeUndefined();
+    expect(resultObj.status_code).toBe(200);
+    expect(resultObj.message).toBeDefined();
+    expect(resultObj.content_schema).toBeDefined();
+  });
+
+  it("degrades gracefully when full content download times out", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: () => Promise.resolve(makeDiscoverResponse("tool-x")),
+          text: () => Promise.resolve(""),
+          headers: new Headers(),
+        });
+      }
+      if (typeof url === "string" && url.includes("/tools/execute")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: () => Promise.resolve(TRUNCATED_CALL_RESPONSE),
+          text: () => Promise.resolve(JSON.stringify(TRUNCATED_CALL_RESPONSE)),
+          headers: new Headers(),
+        });
+      }
+      if (typeof url === "string" && url.includes("oss.qveris.ai")) {
+        return Promise.reject(new DOMException("The operation was aborted", "AbortError"));
+      }
+      return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve("not found"), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "tool-x");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "tool-x", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.truncated).toBe(true);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("failed");
+    expect(mc.reason).toBe("download_timeout");
+  });
+
+  it("blocks download from non-whitelisted domain", async () => {
+    const blockedResponse = {
+      ...TRUNCATED_CALL_RESPONSE,
+      result: { ...TRUNCATED_CALL_RESPONSE.result, full_content_file_url: "https://evil-bucket.s3.amazonaws.com/data.json" },
+    };
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(makeDiscoverResponse("tool-x")), text: () => Promise.resolve(""), headers: new Headers() });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(blockedResponse), text: () => Promise.resolve(JSON.stringify(blockedResponse)), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "tool-x");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "tool-x", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("failed");
+    expect(mc.reason).toBe("download_error");
+    expect(String(mc.detail)).toContain("not in the allowed list");
+  });
+
+  it("blocks download from non-HTTPS URL", async () => {
+    const httpResponse = {
+      ...TRUNCATED_CALL_RESPONSE,
+      result: { ...TRUNCATED_CALL_RESPONSE.result, full_content_file_url: "http://insecure.example.com/data.json" },
+    };
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(makeDiscoverResponse("tool-x")), text: () => Promise.resolve(""), headers: new Headers() });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(httpResponse), text: () => Promise.resolve(JSON.stringify(httpResponse)), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "tool-x");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "tool-x", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("failed");
+    expect(mc.reason).toBe("download_error");
+    expect(String(mc.detail)).toContain("HTTPS");
+  });
+
+  it("skips materialization when autoMaterializeFullContent is false", async () => {
+    globalThis.fetch = makeMaterializeFetchMock({ toolId: "tool-x" });
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: false }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "tool-x");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "tool-x", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.materialized_content).toBeUndefined();
+    expect(parsed.truncation_hint).toContain("full_content_file_url");
+  });
+
+  it("skips materialization when no workspaceDir", async () => {
+    globalThis.fetch = makeMaterializeFetchMock({ toolId: "tool-x" });
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: undefined }),
+    });
+    await registerToolViaDiscover(tools!, "tool-x");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "tool-x", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    expect(parsed.success).toBe(true);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.materialized_content).toBeUndefined();
+  });
+
+  it("materializes binary content (image/png)", async () => {
+    const pngSignature = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00, 0x01]);
+    const binaryResponse = { ...TRUNCATED_CALL_RESPONSE, result: { ...TRUNCATED_CALL_RESPONSE.result, full_content_file_url: "https://oss.qveris.ai/images/chart.png" } };
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(makeDiscoverResponse("img-tool")), text: () => Promise.resolve(""), headers: new Headers() });
+      if (typeof url === "string" && url.includes("/tools/execute")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(binaryResponse), text: () => Promise.resolve(JSON.stringify(binaryResponse)), headers: new Headers() });
+      if (typeof url === "string" && url.includes("oss.qveris.ai")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          arrayBuffer: () => Promise.resolve(pngSignature.buffer.slice(0)),
+          headers: new Headers({ "content-type": "image/png" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve(""), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "img-tool");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "img-tool", params_to_tool: '{"q":"chart"}' });
+    const parsed = parseToolResult(result);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("ready");
+    expect(mc.content_category).toBe("image");
+    expect(mc.mime_type).toBe("image/png");
+    expect(String(mc.path)).toContain(".png");
+    expect(mc.consumption_contract).toContain("Binary file saved");
+    expect(mc.analysis).toBeUndefined();
+    expect(mc.preview).toBeUndefined();
+
+    const written = await fsp.readFile(path.join(tmpDir, mc.path as string));
+    expect(new Uint8Array(written)).toEqual(pngSignature);
+  });
+
+  it("rejects download when content is truncated by byte limit", async () => {
+    const largeContent = "x".repeat(200);
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(makeDiscoverResponse("big-tool")), text: () => Promise.resolve(""), headers: new Headers() });
+      if (typeof url === "string" && url.includes("/tools/execute")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(TRUNCATED_CALL_RESPONSE), text: () => Promise.resolve(JSON.stringify(TRUNCATED_CALL_RESPONSE)), headers: new Headers() });
+      if (typeof url === "string" && url.includes("oss.qveris.ai")) {
+        const encoder = new TextEncoder();
+        const fullBytes = encoder.encode(largeContent);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: new ReadableStream({
+            start(controller) {
+              controller.enqueue(fullBytes);
+              controller.close();
+            },
+          }),
+          headers: new Headers({ "content-type": "application/json" }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve(""), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true, fullContentMaxBytes: 50 }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "big-tool");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "big-tool", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("failed");
+    expect(mc.reason).toBe("download_truncated");
+    expect(String(mc.detail)).toContain("truncated");
+  });
+
+  it("reclassifies application/octet-stream as JSON when content looks like JSON", async () => {
+    const octetStreamResponse = { ...TRUNCATED_CALL_RESPONSE, result: { ...TRUNCATED_CALL_RESPONSE.result, full_content_file_url: "https://oss.qveris.ai/data/result.bin" } };
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(makeDiscoverResponse("generic-tool")), text: () => Promise.resolve(""), headers: new Headers() });
+      if (typeof url === "string" && url.includes("/tools/execute")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(octetStreamResponse), text: () => Promise.resolve(JSON.stringify(octetStreamResponse)), headers: new Headers() });
+      if (typeof url === "string" && url.includes("oss.qveris.ai")) {
+        const encoded = new TextEncoder().encode(FULL_CONTENT_JSON);
+        return Promise.resolve({ ok: true, status: 200, arrayBuffer: () => Promise.resolve(encoded.buffer.slice(0) as ArrayBuffer), text: () => Promise.resolve(FULL_CONTENT_JSON), headers: new Headers({ "content-type": "application/octet-stream" }) });
+      }
+      return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve("not found"), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "generic-tool");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "generic-tool", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("ready");
+    expect(mc.content_category).toBe("json");
+    expect(mc.mime_type).toBe("application/json");
+    expect(mc.analysis).toBeDefined();
+    expect(String(mc.path)).toContain(".json");
+  });
+
+  it("handles CSV content", async () => {
+    const csvContent = "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,SF";
+    const csvResponse = { ...TRUNCATED_CALL_RESPONSE, result: { ...TRUNCATED_CALL_RESPONSE.result, full_content_file_url: "https://oss.qveris.ai/data.csv" } };
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/search")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(makeDiscoverResponse("csv-tool")), text: () => Promise.resolve(""), headers: new Headers() });
+      if (typeof url === "string" && url.includes("/tools/execute")) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(csvResponse), text: () => Promise.resolve(JSON.stringify(csvResponse)), headers: new Headers() });
+      if (typeof url === "string" && url.includes("oss.qveris.ai")) {
+        const encoded = new TextEncoder().encode(csvContent);
+        return Promise.resolve({ ok: true, status: 200, arrayBuffer: () => Promise.resolve(encoded.buffer.slice(0) as ArrayBuffer), text: () => Promise.resolve(csvContent), headers: new Headers({ "content-type": "text/csv" }) });
+      }
+      return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve("not found"), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+    await registerToolViaDiscover(tools!, "csv-tool");
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    const result = await callTool.execute("c1", { tool_id: "csv-tool", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("ready");
+    expect(mc.content_category).toBe("csv");
+    const analysis = (mc as { analysis?: Record<string, unknown> }).analysis;
+    expect(analysis?.line_count).toBe(4);
+    expect(analysis?.column_names).toEqual(["name", "age", "city"]);
+  });
+
+  it("cn region routes API calls to qveris.cn and accepts oss.qveris.cn materialization URL", async () => {
+    const CN_OSS_URL = "https://oss.qveris.cn/full-content/exec-cn-1.json";
+    const cnInvokeResponse = {
+      execution_id: "exec-cn-1",
+      result: {
+        status_code: 200,
+        message: "truncated",
+        truncated_content: '[{"id":1}]',
+        full_content_file_url: CN_OSS_URL,
+      },
+      success: true,
+      error_message: null,
+      elapsed_time_ms: 200,
+      cost: 0.01,
+    };
+    const cnDiscoverResponse = {
+      query: "cn tool API",
+      total: 1,
+      search_id: "cn-search-1",
+      results: [{ tool_id: "cn-tool-x", name: "CnToolX", description: "CN tool" }],
+    };
+    const cnFullContent = JSON.stringify([{ id: 1, name: "cn result" }]);
+
+    const observedApiUrls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      observedApiUrls.push(url);
+      if (typeof url === "string" && url.includes("/search")) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(cnDiscoverResponse), text: () => Promise.resolve(""), headers: new Headers() });
+      }
+      if (typeof url === "string" && url.includes("/tools/execute")) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(cnInvokeResponse), text: () => Promise.resolve(JSON.stringify(cnInvokeResponse)), headers: new Headers() });
+      }
+      if (typeof url === "string" && url.includes("oss.qveris.cn")) {
+        const encoded = new TextEncoder().encode(cnFullContent);
+        return Promise.resolve({ ok: true, status: 200, arrayBuffer: () => Promise.resolve(encoded.buffer.slice(0) as ArrayBuffer), text: () => Promise.resolve(cnFullContent), headers: new Headers({ "content-type": "application/json" }) });
+      }
+      return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve("not found"), headers: new Headers() });
+    });
+    globalThis.fetch = fetchMock;
+
+    const tools = createQverisTools({
+      api: fakeApi({ apiKey: "qv_test_key", region: "cn", autoMaterializeFullContent: true }),
+      ctx: fakeCtx({ workspaceDir: tmpDir }),
+    });
+
+    const discover = tools!.find((t) => t.name === "qveris_discover")!;
+    const callTool = tools!.find((t) => t.name === "qveris_call")!;
+
+    await discover.execute("d1", { query: "cn tool API" });
+    const result = await callTool.execute("c1", { tool_id: "cn-tool-x", params_to_tool: '{"q":"test"}' });
+    const parsed = parseToolResult(result);
+
+    // All API calls must go to qveris.cn, not qveris.ai
+    const apiCalls = observedApiUrls.filter((u) => u.includes("/search") || u.includes("/tools/execute"));
+    for (const apiUrl of apiCalls) {
+      expect(apiUrl).toContain("qveris.cn");
+      expect(apiUrl).not.toContain("qveris.ai");
+    }
+
+    // Materialization from oss.qveris.cn must succeed
+    expect(parsed.success).toBe(true);
+    const mc = parsed.materialized_content as Record<string, unknown>;
+    expect(mc.status).toBe("ready");
+    expect(mc.content_category).toBe("json");
+  });
+});

--- a/packages/openclaw-qveris-plugin/src/qveris-tools.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-tools.ts
@@ -1,0 +1,437 @@
+import { randomUUID } from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import { jsonResult, readNumberParam, readStringParam } from "openclaw/plugin-sdk/agent-runtime";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  makeDiscoverCache,
+  makeDiscoverResultTracker,
+  makeToolRolodex,
+} from "./qveris-cache.js";
+import {
+  resolveAutoMaterialize,
+  resolveCallTimeoutSeconds,
+  resolveDiscoverLimit,
+  resolveDiscoverTimeoutSeconds,
+  resolveFullContentAllowedDomains,
+  resolveFullContentMaxBytes,
+  resolveFullContentTimeoutSeconds,
+  resolveMaxResponseSize,
+  resolveQverisApiKey,
+  resolveQverisBaseUrl,
+} from "./config.js";
+import { qverisCall, qverisDiscover, qverisInspect } from "./qveris-client.js";
+import type { QverisDiscoverResultTool } from "./qveris-client.js";
+import { classifyQverisError, QVERIS_WORKFLOW_NOTE } from "./qveris-errors.js";
+import type { QverisErrorResult } from "./qveris-errors.js";
+import { saveQverisFullResult } from "./qveris-materialization.js";
+
+// ============================================================================
+// Tool Schemas
+// ============================================================================
+
+const QverisDiscoverSchema = Type.Object(
+  {
+    query: Type.String({
+      description:
+        "English API capability description. Describe the type of tool, not your task or question. " +
+        "GOOD: 'stock quote real-time API', 'stock historical price time series API', 'web page content extraction API'. " +
+        "BAD: 'what is the weather in Beijing' (question), 'AAPL stock price today' (task). " +
+        "Chinese input should also produce English capability: '腾讯最新股价' -> 'stock quote real-time API'.",
+    }),
+    limit: Type.Optional(
+      Type.Number({
+        description: "Maximum number of results to return (1-100). Default: 10.",
+        minimum: 1,
+        maximum: 100,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const QverisCallSchema = Type.Object(
+  {
+    tool_id: Type.String({
+      description: "The tool_id from qveris_discover or qveris_inspect results.",
+    }),
+    params_to_tool: Type.String({
+      description:
+        "JSON dictionary of parameters to pass to the tool. " +
+        "IMPORTANT: Use sample_parameters from the qveris_discover results as your template. " +
+        "Common mistakes to avoid: " +
+        "(1) numbers must be unquoted (limit: 10, not \"10\"); " +
+        "(2) dates must be ISO 8601 (2025-01-15, not 01/15/2025); " +
+        '(3) use identifiers not natural language (symbol: "AAPL", not "Apple stock price"); ' +
+        "(4) never omit required params listed in the discovery results. " +
+        'Example: \'{"city": "London", "units": "metric"}\'.',
+    }),
+    max_response_size: Type.Optional(
+      Type.Number({
+        description:
+          "Maximum size of response data in bytes. If tool generates data longer than this, it will be truncated. Default: 20480 (20KB).",
+      }),
+    ),
+    timeout_seconds: Type.Optional(
+      Type.Number({
+        description:
+          "Override timeout in seconds for this invocation. Default: 60s. For long-running tasks (image/video generation, multimodal processing) set 60-120s; only lower if you are certain the tool is fast.",
+        minimum: 1,
+        maximum: 300,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const QverisInspectSchema = Type.Object(
+  {
+    tool_ids: Type.String({
+      description:
+        "Comma-separated list of QVeris tool IDs to inspect (e.g. 'jina_ai.reader.execute.v1.b2ef8fda,openweathermap.weather.execute.v1'). " +
+        "Use tool IDs from a previous qveris_discover or from session context to verify availability and get current parameter schemas.",
+    }),
+  },
+  { additionalProperties: false },
+);
+
+// ============================================================================
+// Tool Factory
+// ============================================================================
+
+/**
+ * Creates the three QVeris agent tools (discover, call, inspect).
+ * Returns null when QVeris is disabled (no API key configured).
+ * All session-scoped state is contained in the returned closures.
+ */
+export function createQverisTools(options: {
+  api: OpenClawPluginApi;
+  ctx: OpenClawPluginToolContext;
+}): AnyAgentTool[] | null {
+  const { api, ctx } = options;
+  const pluginConfig = api.pluginConfig as Record<string, unknown> | undefined;
+
+  const apiKey = resolveQverisApiKey(pluginConfig);
+  if (!apiKey) {
+    return null;
+  }
+
+  const baseUrl = resolveQverisBaseUrl(pluginConfig);
+  const discoverTimeoutSeconds = resolveDiscoverTimeoutSeconds(pluginConfig);
+  const callTimeoutSeconds = resolveCallTimeoutSeconds(pluginConfig);
+  const maxResponseSize = resolveMaxResponseSize(pluginConfig);
+  const discoverLimit = resolveDiscoverLimit(pluginConfig);
+  const autoMaterialize = resolveAutoMaterialize(pluginConfig);
+  const fullContentMaxBytes = resolveFullContentMaxBytes(pluginConfig);
+  const fullContentTimeoutSeconds = resolveFullContentTimeoutSeconds(pluginConfig);
+  const workspaceDir = ctx.workspaceDir?.trim() || undefined;
+
+  // Session-scoped state — shared across all 3 tools since they are created together
+  const discoverCache = makeDiscoverCache<ReturnType<typeof jsonResult>>();
+  const rolodex = makeToolRolodex();
+  const discoverTracker = makeDiscoverResultTracker();
+  const callFailureCount = new Map<string, number>();
+
+  const sessionId = ctx.sessionKey ?? `qveris-${Date.now()}-${randomUUID()}`;
+
+  const DEFAULT_DISCOVER_CACHE_TTL_MS = 90_000;
+
+  // Auto-resolve the backend search_id so the model never has to manage it
+  function resolveKnownSearchId(toolId: string): string | undefined {
+    return rolodex.lookup(toolId)?.discoveryId ?? discoverTracker.getMeta(toolId)?.searchId;
+  }
+
+  function formatToolForModel(tool: QverisDiscoverResultTool) {
+    const entry = rolodex.lookup(tool.tool_id);
+    return {
+      tool_id: tool.tool_id,
+      name: tool.name,
+      description: tool.description,
+      provider_description: tool.provider_description,
+      params: tool.params?.map((p) => ({
+        name: p.name,
+        type: p.type,
+        required: p.required,
+        description: p.description?.en ?? Object.values(p.description ?? {})[0],
+      })),
+      examples: tool.examples?.sample_parameters
+        ? { sample_parameters: tool.examples.sample_parameters }
+        : undefined,
+      stats: tool.stats,
+      ...(entry ? { previously_used: true, session_uses: entry.successCount } : {}),
+    };
+  }
+
+  // ---- qveris_discover ----
+
+  const discoverTool: AnyAgentTool = {
+    label: "QVeris Discover",
+    name: "qveris_discover",
+    description:
+      "Find specialized API tools for exact current values, historical sequence data, structured reports, " +
+      "web extraction/crawling, PDF workflows, or external service capabilities " +
+      "(OCR, speech, image/video understanding or generation, translation, geocoding). " +
+      "Preferred over web_search when a specialized provider can return the answer or perform the work directly. " +
+      "NOT for: local file operations, software documentation. " +
+      "Query must describe the API capability in English.",
+    parameters: QverisDiscoverSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const query = readStringParam(params, "query", { required: true });
+      const limit = readNumberParam(params, "limit", { integer: true }) ?? discoverLimit;
+      const normalizedLimit = Math.min(Math.max(1, limit), 100);
+
+      const cacheKey = `${query}:${normalizedLimit}`;
+      const cached = discoverCache.read(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      let result: Awaited<ReturnType<typeof qverisDiscover>>;
+      try {
+        result = await qverisDiscover({
+          query,
+          sessionId,
+          limit: normalizedLimit,
+          apiKey,
+          baseUrl,
+          timeoutSeconds: discoverTimeoutSeconds,
+        });
+      } catch (err) {
+        return jsonResult(classifyQverisError(err));
+      }
+
+      discoverTracker.trackResults(
+        query,
+        result.results.map((t) => ({ tool_id: t.tool_id, name: t.name, description: t.description })),
+        result.search_id,
+      );
+
+      const knownTools = rolodex.getSummary();
+      const payload = jsonResult({
+        query: result.query,
+        total: result.total,
+        elapsed_time_ms: result.elapsed_time_ms,
+        results: result.results.map(formatToolForModel),
+        ...(knownTools.length > 0 ? { session_known_tools: knownTools } : {}),
+      });
+
+      discoverCache.write(cacheKey, payload, DEFAULT_DISCOVER_CACHE_TTL_MS);
+      return payload;
+    },
+  };
+
+  // ---- qveris_call ----
+
+  const callTool: AnyAgentTool = {
+    label: "QVeris Call",
+    name: "qveris_call",
+    description:
+      "Call a discovered third-party API/service. " +
+      "Provide the tool_id from qveris_discover results and parameters as a JSON string in params_to_tool.",
+    parameters: QverisCallSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const toolId = readStringParam(params, "tool_id", { required: true });
+      const searchId = resolveKnownSearchId(toolId);
+      const paramsToToolRaw = readStringParam(params, "params_to_tool", { required: true });
+      const maxSize =
+        readNumberParam(params, "max_response_size", { integer: true }) ?? maxResponseSize;
+      const timeoutOverride = readNumberParam(params, "timeout_seconds");
+
+      let toolParams: Record<string, unknown>;
+      try {
+        toolParams = JSON.parse(paramsToToolRaw) as Record<string, unknown>;
+      } catch (parseError) {
+        return jsonResult({
+          success: false,
+          error_type: "json_parse_error",
+          detail: `Invalid JSON in params_to_tool: ${parseError instanceof Error ? parseError.message : "Unknown parse error"}`,
+          retry_hint:
+            "Use sample_parameters from the qveris_discover result as a template and ensure valid JSON.",
+          note: QVERIS_WORKFLOW_NOTE,
+        } satisfies QverisErrorResult);
+      }
+
+      let result: Awaited<ReturnType<typeof qverisCall>>;
+      try {
+        result = await qverisCall({
+          toolId,
+          searchId,
+          sessionId,
+          parameters: toolParams,
+          maxResponseSize: maxSize,
+          apiKey,
+          baseUrl,
+          timeoutSeconds: timeoutOverride ?? callTimeoutSeconds,
+        });
+      } catch (err) {
+        const failCount = (callFailureCount.get(toolId) ?? 0) + 1;
+        callFailureCount.set(toolId, failCount);
+        const recoveryStep =
+          failCount === 1 ? "fix_params" : failCount === 2 ? "simplify" : "switch_tool";
+        const classified = classifyQverisError(err);
+        return jsonResult({ ...classified, recovery_step: recoveryStep, attempt_number: failCount });
+      }
+
+      if (result.success) {
+        callFailureCount.delete(toolId);
+        const meta = discoverTracker.getMeta(toolId);
+        if (meta) {
+          rolodex.record(toolId, {
+            name: meta.name,
+            description: meta.description,
+            discoveryQuery: meta.query,
+            discoveryId: searchId,
+          });
+        }
+      } else {
+        const failCount = (callFailureCount.get(toolId) ?? 0) + 1;
+        callFailureCount.set(toolId, failCount);
+        const recoveryStep =
+          failCount === 1 ? "fix_params" : failCount === 2 ? "simplify" : "switch_tool";
+        return jsonResult({
+          execution_id: result.execution_id,
+          success: false,
+          elapsed_time_ms: result.elapsed_time_ms,
+          error_message: result.error_message,
+          cost: result.cost ?? result.credits_used,
+          recovery_step: recoveryStep,
+          attempt_number: failCount,
+          note: QVERIS_WORKFLOW_NOTE,
+        });
+      }
+
+      // result.result is always non-null when success === true (API contract)
+      const resultData = result.result ?? {};
+      const fullContentUrl =
+        typeof resultData?.full_content_file_url === "string" && resultData.full_content_file_url
+          ? resultData.full_content_file_url
+          : null;
+      const isTruncated = Boolean(resultData?.truncated_content || fullContentUrl);
+
+      if (isTruncated && fullContentUrl && autoMaterialize && workspaceDir) {
+        const materialized = await saveQverisFullResult({
+          url: fullContentUrl,
+          executionId: result.execution_id,
+          workspaceDir,
+          maxBytes: fullContentMaxBytes,
+          timeoutSeconds: fullContentTimeoutSeconds,
+          allowedDomains: resolveFullContentAllowedDomains(pluginConfig),
+        });
+
+        if (materialized.status === "ready") {
+          const {
+            truncated_content: _tc,
+            full_content_file_url: _url,
+            ...cleanResult
+          } = resultData as Record<string, unknown>;
+          return jsonResult({
+            execution_id: result.execution_id,
+            success: true,
+            elapsed_time_ms: result.elapsed_time_ms,
+            result: cleanResult,
+            cost: result.cost ?? result.credits_used,
+            materialized_content: materialized,
+          });
+        }
+
+        return jsonResult({
+          execution_id: result.execution_id,
+          success: true,
+          elapsed_time_ms: result.elapsed_time_ms,
+          result: resultData,
+          cost: result.cost ?? result.credits_used,
+          truncated: true,
+          truncation_hint:
+            "Auto-materialization failed. Use web_fetch on full_content_file_url to download manually.",
+          materialized_content: materialized,
+        });
+      }
+
+      return jsonResult({
+        execution_id: result.execution_id,
+        success: true,
+        elapsed_time_ms: result.elapsed_time_ms,
+        result: resultData,
+        cost: result.cost ?? result.credits_used,
+        ...(isTruncated
+          ? {
+              truncated: true,
+              truncation_hint:
+                "Response was truncated. Increase max_response_size for full data, " +
+                "or use full_content_file_url if available.",
+            }
+          : {}),
+      });
+    },
+  };
+
+  // ---- qveris_inspect ----
+
+  const inspectTool: AnyAgentTool = {
+    label: "QVeris Inspect",
+    name: "qveris_inspect",
+    description:
+      "Inspect known QVeris tools by their IDs without a full discovery. " +
+      "Use when you already have a tool_id from a previous qveris_discover or session context " +
+      "and want to verify availability and get current parameter schemas before reusing the tool.",
+    parameters: QverisInspectSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const toolIdsRaw = readStringParam(params, "tool_ids", { required: true });
+      const toolIds = toolIdsRaw
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean);
+
+      if (toolIds.length === 0) {
+        return jsonResult({
+          success: false,
+          error_type: "json_parse_error" as const,
+          detail: "No valid tool IDs provided. Pass comma-separated tool IDs.",
+          retry_hint: "Example: 'jina_ai.reader.execute.v1.b2ef8fda'",
+          note: QVERIS_WORKFLOW_NOTE,
+        } satisfies QverisErrorResult);
+      }
+
+      let result: Awaited<ReturnType<typeof qverisInspect>>;
+      try {
+        result = await qverisInspect({
+          toolIds,
+          sessionId,
+          apiKey,
+          baseUrl,
+          timeoutSeconds: discoverTimeoutSeconds,
+        });
+      } catch (err) {
+        return jsonResult(classifyQverisError(err));
+      }
+
+      discoverTracker.trackResults(
+        "(inspect)",
+        result.tools.map((t) => ({ tool_id: t.tool_id, name: t.name, description: t.description })),
+      );
+
+      const tools = result.tools.map(formatToolForModel);
+      const hasSessionContext = tools.some(
+        (t) => resolveKnownSearchId((t as { tool_id: string }).tool_id) !== undefined,
+      );
+
+      return jsonResult({
+        tool_ids_requested: toolIds,
+        tools_found: result.tools.length,
+        tools,
+        ...(!hasSessionContext
+          ? {
+              call_hint:
+                "These tools have not been discovered in this session yet. " +
+                "Run qveris_discover first before calling them with qveris_call.",
+            }
+          : {}),
+      });
+    },
+  };
+
+  return [discoverTool, callTool, inspectTool];
+}

--- a/packages/openclaw-qveris-plugin/tsconfig.json
+++ b/packages/openclaw-qveris-plugin/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2023",
+    "paths": {
+      "openclaw/plugin-sdk": ["../openclaw/src/plugin-sdk/index.ts"],
+      "openclaw/plugin-sdk/*": ["../openclaw/src/plugin-sdk/*.ts"]
+    }
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- 将 `QVerisAI/openclaw-qveris-plugin` 仓库内容完整导入到 `packages/openclaw-qveris-plugin/`
- 保留插件源码、测试、配置、README、LICENSE、package metadata 等文件
- 排除源仓库 `.git` 目录，避免嵌套 Git 仓库

## Test Plan

- 已对比源仓与目标目录文件列表，确认除 `.git` 外文件数量和路径一致
- 本次为纯导入改动；目标仓库根目录没有 workspace/package 配置，未运行包级安装或测试
