### PR TITLE
docs: sync API docs from website

### DIFF
--- a/docs/openapi/qveris-public-api.openapi.json
+++ b/docs/openapi/qveris-public-api.openapi.json
@@ -2139,7 +2139,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/search.py",
-          "line": 3691
+          "line": 4164
         }
       }
     },
@@ -2149,7 +2149,7 @@
           "Discovery"
         ],
         "summary": "Get Provider Categories",
-        "description": "Get provider categories from the shared provider catalog snapshot.",
+        "description": "Get provider category slugs from Quaestio category facets.",
         "operationId": "get_provider_categories_api_v1_providers_categories_get",
         "responses": {
           "200": {
@@ -2174,7 +2174,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/search.py",
-          "line": 2552
+          "line": 2617
         }
       }
     },
@@ -2508,7 +2508,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/search.py",
-          "line": 3851
+          "line": 4325
         },
         "requestBody": {
           "required": true,

--- a/packages/mcp/src/generated/openapi.d.ts
+++ b/packages/mcp/src/generated/openapi.d.ts
@@ -305,7 +305,7 @@ export interface paths {
         };
         /**
          * Get Provider Categories
-         * @description Get provider categories from the shared provider catalog snapshot.
+         * @description Get provider category slugs from Quaestio category facets.
          */
         get: operations["get_provider_categories_api_v1_providers_categories_get"];
         put?: never;


### PR DESCRIPTION
Mirrors website-owned REST API, Cookbook, and OpenAPI docs after qveris-website release/test changed. Source run: https://github.com/WonderfulValley/qveris-website/actions/runs/26452470240.