### PR TITLE
docs: sync API docs from website

### DIFF
--- a/docs/openapi/qveris-public-api.openapi.json
+++ b/docs/openapi/qveris-public-api.openapi.json
@@ -2139,7 +2139,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/search.py",
-          "line": 4349
+          "line": 4352
         }
       }
     },
@@ -2174,7 +2174,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/search.py",
-          "line": 2639
+          "line": 2640
         }
       }
     },
@@ -2508,7 +2508,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/search.py",
-          "line": 4510
+          "line": 4513
         },
         "requestBody": {
           "required": true,


### PR DESCRIPTION
Mirrors website-owned REST API, Cookbook, and OpenAPI docs after qveris-website release/online OpenAPI documents changed. Source run: https://github.com/WonderfulValley/qveris-website/actions/runs/26578688984.