### PR TITLE
fix(cli,mcp): harden MCP probe and observability

### DIFF
--- a/packages/cli/src/commands/mcp.mjs
+++ b/packages/cli/src/commands/mcp.mjs
@@ -444,7 +444,7 @@ export function resolveProbeTimeoutMs(timeout) {
   return Math.max(1000, usableSeconds * 1000);
 }
 
-export function mcpSpawnOptions(env = {}, os = platform()) {
+export function mcpSpawnOptions(env = {}, _os = platform()) {
   return {
     env: { ...process.env, ...(env || {}) },
     stdio: ["pipe", "pipe", "pipe"],
@@ -468,11 +468,50 @@ function isWindowsExecutable(command) {
   return /\.(?:exe|com)$/i.test(command);
 }
 
+function isWindowsBatchCommand(command) {
+  const name = String(command).split(/[\\/]/).pop() || "";
+  return (
+    /\.(?:cmd|bat)$/i.test(name) ||
+    /^(?:corepack|npm|npx|pnpm|yarn)$/i.test(name)
+  );
+}
+
 function wrapWindowsCommandLine(parts) {
+  const escapePercent = isWindowsBatchCommand(parts[0]);
   const commandLine = parts
-    .map((part) => shellQuoteForPlatform(part, "win32"))
+    .map((part) => quoteWindowsCommandArgument(part, escapePercent))
     .join(" ");
   return `"${commandLine}"`;
+}
+
+function quoteWindowsCommandArgument(value, escapePercent = false) {
+  const raw = String(value);
+  if (/[\0\r\n]/.test(raw)) {
+    throw new Error("MCP command arguments cannot contain CR, LF, or NUL characters.");
+  }
+  const text = escapePercent ? raw.replaceAll("%", "%%") : raw;
+  let quoted = "\"";
+  let backslashes = 0;
+
+  for (const char of text) {
+    if (char === "\\") {
+      backslashes += 1;
+      continue;
+    }
+    if (char === "\"") {
+      quoted += "\\".repeat(backslashes * 2 + 1);
+      quoted += char;
+      backslashes = 0;
+      continue;
+    }
+    quoted += "\\".repeat(backslashes);
+    backslashes = 0;
+    quoted += char;
+  }
+
+  quoted += "\\".repeat(backslashes * 2);
+  quoted += "\"";
+  return quoted;
 }
 
 function extractServer(target, config) {

--- a/packages/cli/test/mcp.test.mjs
+++ b/packages/cli/test/mcp.test.mjs
@@ -100,6 +100,53 @@ test("mcp live probe wraps Windows command shims through cmd.exe without shell o
   ]);
 });
 
+test("mcp live probe safely quotes Windows command shim arguments", () => {
+  const spec = mcpSpawnCommand(
+    {
+      command: "C:\\Tools\\npm shim\\npx.cmd",
+      args: [
+        "--name=foo\"bar",
+        "C:\\temp\\tail\\",
+        "100% ready",
+        "safe&literal",
+      ],
+    },
+    "win32",
+  );
+
+  assert.equal(spec.command.endsWith("cmd.exe"), true);
+  assert.deepEqual(spec.args, [
+    "/d",
+    "/s",
+    "/c",
+    "\"\"C:\\Tools\\npm shim\\npx.cmd\" \"--name=foo\\\"bar\" \"C:\\temp\\tail\\\\\" \"100%% ready\" \"safe&literal\"\"",
+  ]);
+});
+
+test("mcp live probe preserves percent signs for non-batch Windows commands", () => {
+  const spec = mcpSpawnCommand(
+    {
+      command: "node",
+      args: ["100% ready"],
+    },
+    "win32",
+  );
+
+  assert.deepEqual(spec.args, [
+    "/d",
+    "/s",
+    "/c",
+    "\"\"node\" \"100% ready\"\"",
+  ]);
+});
+
+test("mcp live probe rejects Windows control characters before cmd.exe wrapping", () => {
+  assert.throws(
+    () => mcpSpawnCommand({ command: "npx", args: ["safe\nunsafe"] }, "win32"),
+    /cannot contain CR, LF, or NUL/
+  );
+});
+
 test("mcp command quoting follows the target shell platform", () => {
   assert.equal(shellQuoteForPlatform("L'Ondon", "darwin"), `'L'\\''Ondon'`);
   assert.equal(shellQuoteForPlatform('say "hi"', "win32"), `"say ""hi"""`);

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -106,7 +106,7 @@ describe('QverisClient', () => {
         json: async () => ({ message: 'Invalid API key' }),
       });
 
-      await expect(client.searchTools({ query: 'test' })).rejects.toEqual({
+      await expect(client.searchTools({ query: 'test' })).rejects.toMatchObject({
         status: 401,
         message: 'Invalid API key',
         details: { message: 'Invalid API key' },
@@ -123,10 +123,44 @@ describe('QverisClient', () => {
         },
       });
 
-      await expect(client.searchTools({ query: 'test' })).rejects.toEqual({
+      await expect(client.searchTools({ query: 'test' })).rejects.toMatchObject({
         status: 500,
         message: 'Internal Server Error',
-        details: undefined,
+      });
+    });
+
+    it('should convert fetch network failures to observable ApiError', async () => {
+      fetchMock.mockRejectedValueOnce(
+        new Error('fetch failed', { cause: new Error('ECONNRESET') })
+      );
+
+      await expect(client.searchTools({ query: 'test' })).rejects.toMatchObject({
+        status: 0,
+        message: 'fetch failed',
+        cause: 'ECONNRESET',
+        observability: {
+          operation: 'discover',
+          endpoint: '/search',
+          http_status: 0,
+          error_type: 'network_error',
+        },
+      });
+    });
+
+    it('should mark timeouts as transport failures in observability', async () => {
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      fetchMock.mockRejectedValueOnce(abortError);
+
+      await expect(client.searchTools({ query: 'test' })).rejects.toMatchObject({
+        status: 408,
+        message: 'Request timed out. Check connectivity or increase timeout.',
+        observability: {
+          operation: 'discover',
+          endpoint: '/search',
+          http_status: 0,
+          error_type: 'timeout',
+        },
       });
     });
   });
@@ -244,7 +278,7 @@ describe('QverisClient', () => {
 
       await expect(
         client.getToolsByIds({ tool_ids: [] })
-      ).rejects.toEqual({
+      ).rejects.toMatchObject({
         status: 400,
         message: 'Invalid tool_ids',
         details: { message: 'Invalid tool_ids' },
@@ -263,10 +297,9 @@ describe('QverisClient', () => {
 
       await expect(
         client.getToolsByIds({ tool_ids: ['tool-1'] })
-      ).rejects.toEqual({
+      ).rejects.toMatchObject({
         status: 500,
         message: 'Internal Server Error',
-        details: undefined,
       });
     });
   });

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -21,6 +21,8 @@ import type {
   ApiEnvelope,
   QverisClientConfig,
   ApiError,
+  ApiObservability,
+  ApiOperation,
 } from '../types.js';
 
 /** Region-specific API base URLs */
@@ -31,7 +33,7 @@ const REGION_URLS: Record<string, string> = {
 
 /**
  * Detect region from API key prefix.
- * sk-cn-xxx → cn, sk-xxx → global
+ * sk-cn-xxx -> cn, sk-xxx -> global
  */
 function detectRegionFromKey(apiKey: string): string {
   return apiKey.startsWith('sk-cn-') ? 'cn' : 'global';
@@ -95,6 +97,7 @@ export class QverisClient {
    * Makes an authenticated HTTP request to the Qveris API.
    */
   private async request<T>(
+    operation: ApiOperation,
     method: 'GET' | 'POST',
     endpoint: string,
     body?: unknown,
@@ -110,10 +113,18 @@ export class QverisClient {
       }
     }
     const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
-      timeoutMs ?? this.defaultTimeoutMs,
-    );
+    const resolvedTimeoutMs = timeoutMs ?? this.defaultTimeoutMs;
+    const queryParams = Object.fromEntries(url.searchParams.entries());
+    const requestContext: ApiObservability = {
+      source: 'qveris_api',
+      operation,
+      method,
+      endpoint,
+      url: url.toString(),
+      ...(Object.keys(queryParams).length > 0 && { query_params: queryParams }),
+      timeout_ms: resolvedTimeoutMs,
+    };
+    const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
 
     try {
       const response = await fetch(url.toString(), {
@@ -152,7 +163,13 @@ export class QverisClient {
         const error: ApiError = {
           status,
           message: errorMessage,
-          details: errorDetails,
+          ...(errorDetails !== undefined && { details: errorDetails }),
+          observability: withErrorContext(
+            requestContext,
+            'http_error',
+            status,
+            extractRequestId(response),
+          ),
         };
 
         throw error;
@@ -164,22 +181,37 @@ export class QverisClient {
         const error: ApiError = {
           status: response.status,
           message: 'Invalid or empty JSON response from API',
+          observability: withErrorContext(
+            requestContext,
+            'invalid_json',
+            response.status,
+            extractRequestId(response),
+          ),
         };
         throw error;
       }
     } catch (err: unknown) {
-      if (err && typeof err === 'object' && 'status' in err) {
-        // ApiError — rethrow as-is
+      if (isApiError(err)) {
         throw err;
       }
       if (err instanceof Error && err.name === 'AbortError') {
+        const cause = getErrorCause(err);
         const error: ApiError = {
           status: 408,
           message: 'Request timed out. Check connectivity or increase timeout.',
+          observability: withErrorContext(requestContext, 'timeout', 0),
+          ...(cause && { cause }),
         };
         throw error;
       }
-      throw err;
+      const cause = getErrorCause(err);
+      const error: ApiError = {
+        status: 0,
+        message: getErrorMessage(err, 'Network request failed'),
+        observability: withErrorContext(requestContext, 'network_error', 0),
+        ...(cause && { cause }),
+      };
+      throw error;
     } finally {
       clearTimeout(timeout);
     }
@@ -190,7 +222,7 @@ export class QverisClient {
    * This is the Discover action and is free.
    */
   async searchTools(request: SearchRequest): Promise<SearchResponse> {
-    return this.request<SearchResponse>('POST', '/search', request);
+    return this.request<SearchResponse>('discover', 'POST', '/search', request);
   }
 
   /**
@@ -198,7 +230,7 @@ export class QverisClient {
    * This is the Inspect action and is free.
    */
   async getToolsByIds(request: GetToolsByIdsRequest): Promise<SearchResponse> {
-    return this.request<SearchResponse>('POST', '/tools/by-ids', request);
+    return this.request<SearchResponse>('inspect', 'POST', '/tools/by-ids', request);
   }
 
   /**
@@ -212,6 +244,7 @@ export class QverisClient {
   ): Promise<ExecuteResponse> {
     const endpoint = `/tools/execute?tool_id=${encodeURIComponent(toolId)}`;
     return this.request<ExecuteResponse>(
+      'call',
       'POST',
       endpoint,
       request,
@@ -223,7 +256,7 @@ export class QverisClient {
    * Get current credit balance and bucket details.
    */
   async getCredits(): Promise<ApiEnvelope<CreditsResponse> | CreditsResponse> {
-    return this.request<ApiEnvelope<CreditsResponse> | CreditsResponse>('GET', '/auth/credits');
+    return this.request<ApiEnvelope<CreditsResponse> | CreditsResponse>('credits', 'GET', '/auth/credits');
   }
 
   /**
@@ -233,6 +266,7 @@ export class QverisClient {
     request: UsageHistoryRequest
   ): Promise<ApiEnvelope<UsageEventsResponse> | UsageEventsResponse> {
     return this.request<ApiEnvelope<UsageEventsResponse> | UsageEventsResponse>(
+      'usage_history',
       'GET',
       '/auth/usage/history/v2',
       undefined,
@@ -248,6 +282,7 @@ export class QverisClient {
     request: CreditsLedgerRequest
   ): Promise<ApiEnvelope<CreditsLedgerResponse> | CreditsLedgerResponse> {
     return this.request<ApiEnvelope<CreditsLedgerResponse> | CreditsLedgerResponse>(
+      'credits_ledger',
       'GET',
       '/auth/credits/ledger',
       undefined,
@@ -260,7 +295,7 @@ export class QverisClient {
 /**
  * Creates a Qveris client from environment variables.
  * Reads the API key from QVERIS_API_KEY. Region is auto-detected from key prefix
- * (sk-cn-xxx → cn, sk-xxx → global), or overridden via QVERIS_REGION or QVERIS_BASE_URL.
+ * (sk-cn-xxx -> cn, sk-xxx -> global), or overridden via QVERIS_REGION or QVERIS_BASE_URL.
  */
 export function createClientFromEnv(): QverisClient {
   const apiKey = process.env.QVERIS_API_KEY;
@@ -279,4 +314,51 @@ export function createClientFromEnv(): QverisClient {
   console.error(`Region: ${region} (${effectiveUrl})`);
 
   return client;
+}
+
+function withErrorContext(
+  context: ApiObservability,
+  errorType: NonNullable<ApiObservability['error_type']>,
+  httpStatus?: number,
+  requestId?: string,
+): ApiObservability {
+  return {
+    ...context,
+    error_type: errorType,
+    ...(httpStatus !== undefined && { http_status: httpStatus }),
+    ...(requestId && { request_id: requestId }),
+  };
+}
+
+function extractRequestId(response: Response): string | undefined {
+  const headers = response.headers;
+  return (
+    headers?.get('x-request-id') ??
+    headers?.get('x-qveris-request-id') ??
+    headers?.get('x-correlation-id') ??
+    undefined
+  );
+}
+
+function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    'message' in error
+  );
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error) return error;
+  return fallback;
+}
+
+function getErrorCause(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const cause = error.cause;
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === 'string' && cause) return cause;
+  return undefined;
 }

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -105,7 +105,17 @@ describe('MCP public tool interface', () => {
 
   it('returns MCP error payloads for validation, unknown tools, and API errors', async () => {
     const client = {
-      searchTools: vi.fn().mockRejectedValue({ status: 401, message: 'bad key', details: { code: 'auth' } }),
+      searchTools: vi.fn().mockRejectedValue({
+        status: 401,
+        message: 'bad key',
+        details: { code: 'auth' },
+        observability: {
+          operation: 'discover',
+          endpoint: '/search',
+          http_status: 401,
+          error_type: 'http_error',
+        },
+      }),
       getToolsByIds: vi.fn(),
       executeTool: vi.fn(),
       getUsageHistory: vi.fn(),
@@ -152,10 +162,76 @@ describe('MCP public tool interface', () => {
       'credits_ledger',
     ]);
     expect(apiError.isError).toBe(true);
-    expect(payload(apiError)).toEqual({
+    expect(payload(apiError)).toMatchObject({
       error: 'bad key',
       status: 401,
       details: { code: 'auth' },
+      observability: {
+        source: 'qveris_mcp',
+        requested_tool: 'discover',
+        mcp_tool: 'discover',
+        session_id: 'session-1',
+        query: 'weather',
+        api: {
+          operation: 'discover',
+          endpoint: '/search',
+          http_status: 401,
+          error_type: 'http_error',
+        },
+      },
+    });
+  });
+
+  it('adds tool and provider observability to failed call payloads', async () => {
+    const client = {
+      searchTools: vi.fn(),
+      getToolsByIds: vi.fn(),
+      executeTool: vi.fn().mockRejectedValue({
+        status: 0,
+        message: 'fetch failed',
+        cause: 'ECONNRESET',
+        observability: {
+          operation: 'call',
+          endpoint: '/tools/execute?tool_id=weather.forecast.v1',
+          http_status: 0,
+          error_type: 'network_error',
+        },
+      }),
+      getUsageHistory: vi.fn(),
+      getCreditsLedger: vi.fn(),
+    } as unknown as QverisClient;
+
+    const result = await executeQverisMcpTool(
+      client,
+      'session-1',
+      'call',
+      {
+        tool_id: 'weather.forecast.v1',
+        search_id: 'search-1',
+        params_to_tool: { city: 'London' },
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(payload(result)).toMatchObject({
+      error: 'fetch failed',
+      status: 0,
+      cause: 'ECONNRESET',
+      observability: {
+        source: 'qveris_mcp',
+        requested_tool: 'call',
+        mcp_tool: 'call',
+        session_id: 'session-1',
+        search_id: 'search-1',
+        tool_id: 'weather.forecast.v1',
+        provider_id: 'weather',
+        api: {
+          operation: 'call',
+          endpoint: '/tools/execute?tool_id=weather.forecast.v1',
+          http_status: 0,
+          error_type: 'network_error',
+        },
+      },
     });
   });
 });

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -145,6 +145,47 @@ export const DEPRECATED_ALIASES: Record<string, string> = {
   execute_tool: 'call',
 };
 
+function buildMcpObservability(
+  requestedTool: string,
+  mcpTool: string,
+  args: unknown,
+  defaultSessionId: string,
+): Record<string, unknown> {
+  const input = isRecord(args) ? args : {};
+  const toolId = readString(input.tool_id);
+
+  return compactObject({
+    source: 'qveris_mcp',
+    requested_tool: requestedTool,
+    mcp_tool: mcpTool,
+    session_id: readString(input.session_id) ?? defaultSessionId,
+    search_id: readString(input.search_id),
+    tool_id: toolId,
+    provider_id: inferProviderId(toolId),
+    query: readString(input.query),
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function inferProviderId(toolId: string | undefined): string | undefined {
+  if (!toolId) return undefined;
+  const [providerId] = toolId.split('.');
+  return providerId || undefined;
+}
+
+function compactObject(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined),
+  );
+}
+
 /**
  * Route one MCP tool call to the matching Qveris operation.
  */
@@ -161,6 +202,7 @@ export async function executeQverisMcpTool(
     name = DEPRECATED_ALIASES[rawName];
     warn(`[qveris] Deprecated: "${rawName}" -> use "${name}" instead\n`);
   }
+  const mcpObservability = buildMcpObservability(rawName, name, args, defaultSessionId);
 
   try {
     if (name === 'discover') {
@@ -312,7 +354,12 @@ export async function executeQverisMcpTool(
             text: JSON.stringify({
               error: error.message,
               status: error.status,
-              details: error.details,
+              ...(error.details !== undefined && { details: error.details }),
+              ...(error.cause && { cause: error.cause }),
+              observability: compactObject({
+                ...mcpObservability,
+                api: error.observability,
+              }),
             }),
           },
         ],

--- a/packages/mcp/src/tools/execute.test.ts
+++ b/packages/mcp/src/tools/execute.test.ts
@@ -141,7 +141,7 @@ describe('call (execute_tool)', () => {
       });
     });
 
-    it.each(['not valid json', null, ['city']])(
+    it.each(['not valid json', null, ['city'], new Date('2026-01-01'), new Map([['city', 'London']])])(
       'should reject non-object params_to_tool: %s',
       async (paramsToTool) => {
         await expect(
@@ -157,6 +157,28 @@ describe('call (execute_tool)', () => {
         ).rejects.toThrow('params_to_tool must be a JSON object');
       }
     );
+
+    it('should allow null-prototype params_to_tool objects', async () => {
+      const params = Object.create(null) as Record<string, unknown>;
+      params.city = 'London';
+
+      await executeExecuteTool(
+        mockClient,
+        {
+          tool_id: 'tool-1',
+          search_id: 'search-123',
+          params_to_tool: params,
+        },
+        'default-session'
+      );
+
+      expect(mockClient.executeTool).toHaveBeenCalledWith('tool-1', {
+        search_id: 'search-123',
+        session_id: 'default-session',
+        parameters: params,
+        max_response_size: undefined,
+      });
+    });
 
     it('should handle complex nested parameters', async () => {
       const complexParams = {

--- a/packages/mcp/src/tools/execute.ts
+++ b/packages/mcp/src/tools/execute.ts
@@ -124,6 +124,10 @@ export async function executeExecuteTool(
 }
 
 function isParamsObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -496,6 +496,22 @@ export interface QverisClientConfig {
 /**
  * Error response from the Qveris API.
  */
+export type ApiOperation = 'discover' | 'inspect' | 'call' | 'credits' | 'usage_history' | 'credits_ledger';
+export type ApiErrorType = 'http_error' | 'invalid_json' | 'timeout' | 'network_error';
+
+export interface ApiObservability {
+  source: 'qveris_api';
+  operation: ApiOperation;
+  method: 'GET' | 'POST';
+  endpoint: string;
+  url: string;
+  query_params?: Record<string, string>;
+  timeout_ms: number;
+  http_status?: number;
+  request_id?: string;
+  error_type?: ApiErrorType;
+}
+
 export interface ApiError {
   /** HTTP status code */
   status: number;
@@ -505,4 +521,10 @@ export interface ApiError {
 
   /** Original error details if available */
   details?: unknown;
+
+  /** Request metadata for diagnosing API/provider/tool-chain failures. */
+  observability?: ApiObservability;
+
+  /** Lower-level transport or runtime cause when available. */
+  cause?: string;
 }


### PR DESCRIPTION
## Summary
- harden Windows MCP probe command shim quoting without shell execution
- reject non-plain params_to_tool values while preserving null-prototype objects
- add MCP/API observability metadata for network/API failures such as fetch failed

## Verification
- packages/cli: npm test (45 passed)
- packages/mcp: npm test (65 passed), npm run typecheck, npm run build in a clean temp install