### PR TITLE
fix(packages): 发布 QVeris 插件编译产物

### DIFF
--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -1,0 +1,64 @@
+name: Publish QVeris OpenClaw plugin to npm
+
+on:
+  push:
+    tags:
+      - "qveris-plugin-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/openclaw-qveris-plugin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify package version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#qveris-plugin-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
+
+      - name: Verify npm package contents
+        run: npm run check:pack
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "QVeris OpenClaw Plugin v${{ env.VERSION }}"
+          body: |
+            ## Install
+
+            ```bash
+            openclaw plugins install @qverisai/qveris@${{ env.VERSION }}
+            ```
+
+            ## Highlights
+
+            - Publishes compiled JavaScript runtime files under `dist/`.
+            - Points `openclaw.extensions` at `./dist/index.js` for current OpenClaw package-install compatibility.
+            - Keeps TypeScript source in the package for inspection, but no longer depends on TypeScript runtime loading.
+
+            See [README](packages/openclaw-qveris-plugin/README.md) for usage.
+          generate_release_notes: true

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.3.23",
+  "version": "2026.6.4",
   "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
   "type": "module",
   "files": [
@@ -38,7 +38,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "compat": {
       "pluginApi": ">=2026.3.22"

--- a/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
@@ -1,6 +1,17 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+const extensions = packageJson.openclaw?.extensions;
+if (!Array.isArray(extensions) || !extensions.includes("./dist/index.js")) {
+  fail("package.json openclaw.extensions must include the compiled runtime entry:", [
+    'expected "./dist/index.js"',
+  ]);
+}
+if (extensions.some((entry) => typeof entry === "string" && /\.tsx?$/.test(entry))) {
+  fail("package.json openclaw.extensions must not point at TypeScript source entries for npm packages:", extensions);
+}
+
 const requiredFiles = new Set([
   "README.md",
   "dist/index.js",


### PR DESCRIPTION
## Summary

- 将 `@qverisai/qveris` 的 OpenClaw 插件入口从 TypeScript 源码 `./index.ts` 改为编译后的 `./dist/index.js`，适配当前 OpenClaw 对 npm 包运行产物的校验。
- 将插件版本更新为 `2026.6.4`，并在打包校验中增加 `openclaw.extensions` 检查，避免后续再次发布 TS-only 入口。
- 新增根目录发布工作流 `qveris-plugin-publish.yml`，参考 `cli-publish.yml`，通过 `qveris-plugin-v*` tag 使用仓库 `NPM_TOKEN` 发布 npm 包并创建 GitHub Release。

## Test Plan

- `npm run check:pack`
- `npm pack --json`
- 使用生成的 tarball 验证当前 OpenClaw 安装成功：
  `npx --yes openclaw@2026.6.1 plugins install ./qverisai-qveris-2026.6.4.tgz`

## Reviewer notes

- 当前 npm 版本 `2026.3.23` 只包含 TypeScript 入口，OpenClaw 2026.6.1 安装时会明确拒绝 TS-only npm 包；本 PR 改为发布编译产物入口。
- `dist/` 仍由 `prepack` 自动生成，不提交到仓库。
