### PR TITLE
fix(mcp): resolve symlink entrypoint

### DIFF
--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -23,13 +23,26 @@ describe('MCP public tool interface', () => {
       const realEntrypoint = join(tempDir, 'dist-index.js');
       const symlinkEntrypoint = join(tempDir, 'qveris-mcp');
       writeFileSync(realEntrypoint, '#!/usr/bin/env node\n');
-      symlinkSync(realEntrypoint, symlinkEntrypoint);
 
       expect(isEntrypoint(realEntrypoint, pathToFileURL(realEntrypoint).href)).toBe(true);
-      expect(isEntrypoint(symlinkEntrypoint, pathToFileURL(realEntrypoint).href)).toBe(true);
+
+      try {
+        symlinkSync(realEntrypoint, symlinkEntrypoint);
+        expect(isEntrypoint(symlinkEntrypoint, pathToFileURL(realEntrypoint).href)).toBe(true);
+      } catch (error) {
+        if (hasErrorCode(error, 'EPERM')) return;
+
+        throw error;
+      }
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it('falls back to the original entrypoint path when realpath resolution fails', () => {
+    const missingEntrypoint = join(tmpdir(), 'qveris-mcp-missing-entrypoint.js');
+
+    expect(isEntrypoint(missingEntrypoint, pathToFileURL(missingEntrypoint).href)).toBe(true);
   });
 
   it('exposes canonical tools and deprecated aliases with matching schemas', () => {
@@ -254,3 +267,11 @@ describe('MCP public tool interface', () => {
     });
   });
 });
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -1,6 +1,10 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 
-import { executeQverisMcpTool, listQverisMcpTools } from './index.js';
+import { executeQverisMcpTool, isEntrypoint, listQverisMcpTools } from './index.js';
 import type { QverisClient } from './api/client.js';
 import { creditsLedgerSchema } from './tools/credits-ledger.js';
 import { executeToolSchema } from './tools/execute.js';
@@ -13,6 +17,21 @@ function payload(result: { content: Array<{ text: string }> }) {
 }
 
 describe('MCP public tool interface', () => {
+  it('detects the process entrypoint when npm launches the bin through a symlink', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'qveris-mcp-entrypoint-'));
+    try {
+      const realEntrypoint = join(tempDir, 'dist-index.js');
+      const symlinkEntrypoint = join(tempDir, 'qveris-mcp');
+      writeFileSync(realEntrypoint, '#!/usr/bin/env node\n');
+      symlinkSync(realEntrypoint, symlinkEntrypoint);
+
+      expect(isEntrypoint(realEntrypoint, pathToFileURL(realEntrypoint).href)).toBe(true);
+      expect(isEntrypoint(symlinkEntrypoint, pathToFileURL(realEntrypoint).href)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('exposes canonical tools and deprecated aliases with matching schemas', () => {
     const tools = listQverisMcpTools();
     const byName = new Map(tools.map((tool) => [tool.name, tool]));

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -474,7 +474,15 @@ function isApiError(error: unknown): error is ApiError {
 export function isEntrypoint(argvEntry: string | undefined, moduleUrl = import.meta.url): boolean {
   if (!argvEntry) return false;
 
-  return pathToFileURL(realpathSync(argvEntry)).href === moduleUrl;
+  try {
+    return pathToFileURL(realpathSync(argvEntry)).href === moduleUrl;
+  } catch {
+    try {
+      return pathToFileURL(argvEntry).href === moduleUrl;
+    } catch {
+      return false;
+    }
+  }
 }
 
 // Run the server only when this file is the process entrypoint.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -31,6 +31,7 @@ import {
   ListToolsRequestSchema,
   type CallToolResult,
 } from '@modelcontextprotocol/sdk/types.js';
+import { realpathSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -470,9 +471,14 @@ function isApiError(error: unknown): error is ApiError {
   );
 }
 
+export function isEntrypoint(argvEntry: string | undefined, moduleUrl = import.meta.url): boolean {
+  if (!argvEntry) return false;
+
+  return pathToFileURL(realpathSync(argvEntry)).href === moduleUrl;
+}
+
 // Run the server only when this file is the process entrypoint.
-const entrypoint = process.argv[1] ? pathToFileURL(process.argv[1]).href : undefined;
-if (entrypoint === import.meta.url) {
+if (isEntrypoint(process.argv[1])) {
   main().catch((error) => {
     console.error('Fatal error:', error);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Fix `@qverisai/mcp` entrypoint detection when npm or npx launches the bin through a symlink.
- Resolve `process.argv[1]` with `realpathSync` before comparing it with `import.meta.url`, with a safe fallback to the original path if realpath resolution fails.
- Add regression coverage for symlink-based bin startup and the fallback path, while keeping the symlink test portable on Windows environments where symlink creation may require elevated permissions.

## Root Cause
Global npm installs and npx can launch the package through a symlink such as `qveris-mcp -> dist/index.js`. The previous check converted `process.argv[1]` directly with `pathToFileURL`, which does not resolve symlinks. As a result, the symlink URL did not match Node's resolved `import.meta.url`, `main()` was not called, and the process exited silently with code 0.

## Test Plan
- `npm test`
- `npm run typecheck`
- `npm run build`
- Manual symlink smoke test: create `qveris-mcp -> packages/mcp/dist/index.js` and execute it. The process now enters `main()` and, when `QVERIS_API_KEY` is missing, prints the expected error and exits with code 1 instead of silently exiting with code 0.

## Related
- Fixes QVerisAI/mcp#7 in the migrated package location: `packages/mcp`
