### PR TITLE
chore(release): cli 0.6.1, mcp 0.7.2, python-sdk 0.2.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "QVeris CLI for agent capability discovery, inspection, calling, and audit",
   "type": "module",
   "bin": {

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qveris"
-version = "0.2.0"
+version = "0.2.1"
 description = "QVeris Python SDK for agent capability discovery, calling, and audit"
 requires-python = ">=3.8"
 license = "MIT"

--- a/packages/python-sdk/uv.lock
+++ b/packages/python-sdk/uv.lock
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "qveris"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Patch releases for all three packages, shipping the object-shaped `categories` fixes from #97:

| Package | Version | Change |
|---|---|---|
| `@qverisai/cli` | 0.6.0 → **0.6.1** | Fix `discover`/`inspect` rendering `[object Object]` for category tags; handles `{slug, name, description}` objects and i18n names |
| `@qverisai/mcp` | 0.7.1 → **0.7.2** | Updated `ToolInfo.categories` type declarations (`Array<string \| ToolCategory>`); runtime unaffected |
| `qveris` (PyPI) | 0.2.0 → **0.2.1** | Fix `ValidationError` crash in `discover()`/`inspect()` on object-shaped categories; adds `ToolCategory` model |

Version-field-only bumps in `package.json` / `package-lock.json` / `pyproject.toml` / `uv.lock`, matching the release convention from #92.

## Test plan

- CLI: `node --test` — 53/53 passed
- MCP: `tsc --noEmit` clean; `vitest` 67/68 (the 1 failure is the pre-existing local-only symlink entrypoint test, passes in CI)
- Python SDK: `uv run --extra dev pytest` — 32/32 passed

After merge, tags `cli-v0.6.1`, `mcp-v0.7.2`, `python-sdk-v0.2.1` on the merge commit will trigger the npm/PyPI publish workflows.