### PR TITLE
ci: compose release notes from annotated tag message

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -47,26 +47,34 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Release body = Install section + Highlights from the annotated tag
+      # message (git tag -a cli-vX.Y.Z -m "- bullet"), if any, + auto-generated
+      # notes. Lightweight tags simply get no Highlights section.
+      - name: Compose release notes
+        run: |
+          NOTES="$RUNNER_TEMP/release-notes.md"
+          {
+            echo '## Install'
+            echo ''
+            echo '```bash'
+            echo '# One-liner'
+            echo 'curl -fsSL https://qveris.ai/cli/install | bash'
+            echo ''
+            echo '# Or via npm'
+            echo "npm install -g @qverisai/cli@${VERSION}"
+            echo '```'
+          } > "$NOTES"
+          if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}" 2>/dev/null)" = "tag" ]; then
+            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")"
+            if [ -n "$HIGHLIGHTS" ]; then
+              printf '\n## Highlights\n\n%s\n' "$HIGHLIGHTS" >> "$NOTES"
+            fi
+          fi
+          printf '\nSee [README](packages/cli/README.md) for usage.\n' >> "$NOTES"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: "QVeris CLI v${{ env.VERSION }}"
-          body: |
-            ## Install
-
-            ```bash
-            # One-liner
-            curl -fsSL https://qveris.ai/cli/install | bash
-
-            # Or via npm
-            npm install -g @qverisai/cli@${{ env.VERSION }}
-            ```
-
-            ## Highlights
-
-            - Adds `qveris usage` for context-safe usage audit summaries, filtered searches, and local JSONL exports.
-            - Adds `qveris ledger` for final credit balance movement summaries, filtered searches, and local JSONL exports.
-            - Labels call billing as pre-settlement and points final charge checks to usage history and the credits ledger.
-
-            See [README](packages/cli/README.md) for usage.
+          body_path: ${{ runner.temp }}/release-notes.md
           generate_release_notes: true

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -64,8 +64,13 @@ jobs:
             echo "npm install -g @qverisai/cli@${VERSION}"
             echo '```'
           } > "$NOTES"
+          # actions/checkout maps the tag ref to the bare commit, dropping the
+          # annotation (actions/checkout#882) — re-fetch the real tag object.
+          git fetch --force --depth=1 origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" \
+            || echo "::warning::Could not re-fetch tag ${GITHUB_REF_NAME}; Highlights may be omitted"
           if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}" 2>/dev/null)" = "tag" ]; then
-            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")"
+            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME" \
+              | sed -e '/^-----BEGIN PGP SIGNATURE-----$/,$d' -e '/^-----BEGIN SSH SIGNATURE-----$/,$d')"
             if [ -n "$HIGHLIGHTS" ]; then
               printf '\n## Highlights\n\n%s\n' "$HIGHLIGHTS" >> "$NOTES"
             fi

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -93,8 +93,13 @@ jobs:
             echo "npx -y @qverisai/mcp@${VERSION}"
             echo '```'
           } > "$NOTES"
+          # actions/checkout maps the tag ref to the bare commit, dropping the
+          # annotation (actions/checkout#882) — re-fetch the real tag object.
+          git fetch --force --depth=1 origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" \
+            || echo "::warning::Could not re-fetch tag ${GITHUB_REF_NAME}; Highlights may be omitted"
           if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}" 2>/dev/null)" = "tag" ]; then
-            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")"
+            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME" \
+              | sed -e '/^-----BEGIN PGP SIGNATURE-----$/,$d' -e '/^-----BEGIN SSH SIGNATURE-----$/,$d')"
             if [ -n "$HIGHLIGHTS" ]; then
               printf '\n## Highlights\n\n%s\n' "$HIGHLIGHTS" >> "$NOTES"
             fi

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -80,22 +80,30 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Release body = Install section + Highlights from the annotated tag
+      # message (git tag -a mcp-vX.Y.Z -m "- bullet"), if any, + auto-generated
+      # notes. Lightweight tags simply get no Highlights section.
+      - name: Compose release notes
+        run: |
+          NOTES="$RUNNER_TEMP/release-notes.md"
+          {
+            echo '## Install'
+            echo ''
+            echo '```bash'
+            echo "npx -y @qverisai/mcp@${VERSION}"
+            echo '```'
+          } > "$NOTES"
+          if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}" 2>/dev/null)" = "tag" ]; then
+            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")"
+            if [ -n "$HIGHLIGHTS" ]; then
+              printf '\n## Highlights\n\n%s\n' "$HIGHLIGHTS" >> "$NOTES"
+            fi
+          fi
+          printf '\nSee [README](packages/mcp/README.md) for configuration.\n' >> "$NOTES"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: "QVeris MCP Server v${{ env.VERSION }}"
-          body: |
-            ## Install
-
-            ```bash
-            npx -y @qverisai/mcp@${{ env.VERSION }}
-            ```
-
-            ## Highlights
-
-            - Adds `usage_history` for context-safe request charge outcome summaries, filtered searches, and local JSONL exports.
-            - Adds `credits_ledger` for final credit balance movement summaries, filtered searches, and local JSONL exports.
-            - Updates tool descriptions and response guidance to separate pricing rules, pre-settlement billing, and final settlement.
-
-            See [README](packages/mcp/README.md) for configuration.
+          body_path: ${{ runner.temp }}/release-notes.md
           generate_release_notes: true

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -84,22 +84,30 @@ jobs:
           packages-dir: packages/python-sdk/dist
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+      # Release body = Install section + Highlights from the annotated tag
+      # message (git tag -a python-sdk-vX.Y.Z -m "- bullet"), if any, +
+      # auto-generated notes. Lightweight tags simply get no Highlights section.
+      - name: Compose release notes
+        run: |
+          NOTES="$RUNNER_TEMP/release-notes.md"
+          {
+            echo '## Install'
+            echo ''
+            echo '```bash'
+            echo "pip install qveris==${VERSION}"
+            echo '```'
+          } > "$NOTES"
+          if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}" 2>/dev/null)" = "tag" ]; then
+            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")"
+            if [ -n "$HIGHLIGHTS" ]; then
+              printf '\n## Highlights\n\n%s\n' "$HIGHLIGHTS" >> "$NOTES"
+            fi
+          fi
+          printf '\nSee [README](packages/python-sdk/README.md) for usage.\n' >> "$NOTES"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: "QVeris Python SDK v${{ env.VERSION }}"
-          body: |
-            ## Install
-
-            ```bash
-            pip install qveris==${{ env.VERSION }}
-            ```
-
-            ## Highlights
-
-            - Publishes the typed Python SDK for the QVeris Agent External Data & Tool Harness.
-            - Includes discover, inspect, call, usage, and ledger client methods.
-            - Includes the built-in agent runtime and OpenAI-compatible provider support.
-
-            See [README](packages/python-sdk/README.md) for usage.
+          body_path: ${{ runner.temp }}/release-notes.md
           generate_release_notes: true

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -97,8 +97,13 @@ jobs:
             echo "pip install qveris==${VERSION}"
             echo '```'
           } > "$NOTES"
+          # actions/checkout maps the tag ref to the bare commit, dropping the
+          # annotation (actions/checkout#882) — re-fetch the real tag object.
+          git fetch --force --depth=1 origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" \
+            || echo "::warning::Could not re-fetch tag ${GITHUB_REF_NAME}; Highlights may be omitted"
           if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}" 2>/dev/null)" = "tag" ]; then
-            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")"
+            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME" \
+              | sed -e '/^-----BEGIN PGP SIGNATURE-----$/,$d' -e '/^-----BEGIN SSH SIGNATURE-----$/,$d')"
             if [ -n "$HIGHLIGHTS" ]; then
               printf '\n## Highlights\n\n%s\n' "$HIGHLIGHTS" >> "$NOTES"
             fi


### PR DESCRIPTION
## Problem

`cli-publish.yml` / `mcp-publish.yml` / `python-sdk-publish.yml` hardcode a `## Highlights` section in the GitHub Release body. It was written for past releases, so every new release ships stale notes (e.g. the v0.6.1/0.7.2/0.2.1 releases published today initially described the old usage/ledger features and had to be edited by hand).

## Change

Each publish workflow now composes the release body at publish time via a `Compose release notes` step + `body_path`:

1. **Install** — templated with the released version (never stale)
2. **Highlights** — taken from the annotated tag message when the release tag is annotated (`git tag -a cli-vX.Y.Z -m "- bullet"`); lightweight tags simply omit the section
3. Auto-generated notes (`generate_release_notes: true`) — unchanged

## Release flow going forward

- Curated highlights: `git tag -a mcp-vX.Y.Z -m "- Fixes …" <sha> && git push origin mcp-vX.Y.Z`
- No highlights needed: plain lightweight tag as before; body is Install + auto-generated PR list

## Test plan

- All three YAML files parse cleanly
- Compose script executed locally against a real annotated tag (Highlights rendered from tag message) and a real lightweight tag (`mcp-v0.7.2`, section omitted) — output verified in both cases