### PR TITLE
test(mcp): fix entrypoint symlink test on macOS

### DIFF
--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -18,7 +18,10 @@ function payload(result: { content: Array<{ text: string }> }) {
 
 describe('MCP public tool interface', () => {
   it('detects the process entrypoint when npm launches the bin through a symlink', () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'qveris-mcp-entrypoint-'));
+    // Canonicalize: on macOS tmpdir() sits behind the /var -> /private/var
+    // symlink, but Node always reports canonical paths in import.meta.url,
+    // which is what the moduleUrl argument simulates.
+    const tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'qveris-mcp-entrypoint-')));
     try {
       const realEntrypoint = join(tempDir, 'dist-index.js');
       const symlinkEntrypoint = join(tempDir, 'qveris-mcp');


### PR DESCRIPTION
## Problem

`src/index.test.ts` "detects the process entrypoint when npm launches the bin through a symlink" fails on every macOS checkout (first assertion, line 27) while passing in CI. Contributors on macOS have to re-diagnose this known failure on every test run.

Root cause: the test builds `moduleUrl` from a path under `os.tmpdir()`. On macOS that path sits behind the `/var -> /private/var` symlink. `isEntrypoint` canonicalizes `argv` via `realpathSync` before comparing, so `file:///private/var/...` never equals the test's non-canonical `file:///var/...`. Linux `tmpdir()` is not a symlink, hence green CI.

## Fix

Canonicalize the temp dir with `realpathSync` right after `mkdtempSync`. This matches production reality: Node always reports canonical (symlink-resolved) paths in `import.meta.url`, which is exactly what the `moduleUrl` argument simulates — so the test premise, not the production code, was wrong.

## Test plan

- `npm test` on macOS: 68/68 passed (previously 67/68)
- `tsc --noEmit` clean
- No production code touched