### PR TITLE
feat(openclaw-plugin): project why_recommended and expected_cost to the model

### DIFF
--- a/packages/openclaw-qveris-plugin/src/qveris-client.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-client.ts
@@ -41,6 +41,10 @@ export interface QverisDiscoverResultTool {
     success_rate?: number;
   };
   examples?: QverisDiscoverResultExamples;
+  /** Backend explanation of why this tool was recommended for the query */
+  why_recommended?: string;
+  /** Pre-call cost estimate in credits */
+  expected_cost?: string | number;
 }
 
 /** QVeris /search response */

--- a/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
@@ -81,6 +81,8 @@ const SAMPLE_DISCOVER_RESPONSE = {
       params: [{ name: "city", type: "string", required: true, description: { en: "City name" } }],
       examples: { sample_parameters: { city: "London" } },
       stats: { success_rate: 0.95, avg_execution_time_ms: 800 },
+      why_recommended: "Matched both semantic and keyword relevance signals.",
+      expected_cost: "3.0",
     },
   ],
 };
@@ -388,6 +390,29 @@ describe("createQverisTools", () => {
     expect(results2[0].previously_used).toBe(true);
     expect(results2[0].session_uses).toBe(1);
     expect(results2[0].discovery_id).toBeUndefined();
+  });
+
+  it("qveris_discover projects why_recommended and expected_cost, omitting them when absent", async () => {
+    const response = {
+      query: "weather forecast API",
+      total: 2,
+      search_id: "search-abc",
+      results: [
+        SAMPLE_DISCOVER_RESPONSE.results[0],
+        { tool_id: "bare.tool.v1", name: "Bare Tool", description: "No extras" },
+      ],
+    };
+    globalThis.fetch = mockFetchJson(response);
+    const tools = createQverisTools({ api: fakeApi(), ctx: fakeCtx() });
+    const discover = tools!.find((t) => t.name === "qveris_discover")!;
+
+    const parsed = parseToolResult(await discover.execute("d1", { query: "weather forecast API" }));
+    const results = parsed.results as Array<Record<string, unknown>>;
+
+    expect(results[0].why_recommended).toBe("Matched both semantic and keyword relevance signals.");
+    expect(results[0].expected_cost).toBe("3.0");
+    expect(results[1].why_recommended).toBeUndefined();
+    expect(results[1].expected_cost).toBeUndefined();
   });
 
   it("qveris_call parses invalid JSON in params_to_tool gracefully", async () => {

--- a/packages/openclaw-qveris-plugin/src/qveris-tools.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-tools.ts
@@ -158,6 +158,8 @@ export function createQverisTools(options: {
         ? { sample_parameters: tool.examples.sample_parameters }
         : undefined,
       stats: tool.stats,
+      why_recommended: tool.why_recommended,
+      expected_cost: tool.expected_cost,
       ...(entry ? { previously_used: true, session_uses: entry.successCount } : {}),
     };
   }


### PR DESCRIPTION
## Problem

QVeris Discover responses include `why_recommended` (backend ranking rationale) and `expected_cost` (pre-call credit estimate), but the plugin's `formatToolForModel` projection dropped both — the agent model chose between tools without seeing why each was recommended or what it would cost.

Companion to #102 (CLI/SDK/MCP surfacing of the same fields), scoped to the OpenClaw plugin.

## Changes

- `QverisDiscoverResultTool` declares `why_recommended?: string` and `expected_cost?: string | number`
- `formatToolForModel` projects both fields into the model-facing discover payload; absent fields serialize to nothing (same pattern as `provider_description`)

## Test plan

- `vitest run` — 63/63 passed (new test: both fields projected when present, undefined when absent)
- `npm run build` clean
- `npm run check:pack` OK (18 files, no test sources in package)