### PR TITLE
chore: drop provider_logo_url from type declarations and spec

### DIFF
--- a/docs/openapi/qveris-public-api.openapi.json
+++ b/docs/openapi/qveris-public-api.openapi.json
@@ -5585,9 +5585,6 @@
           "provider_description": {
             "type": "string"
           },
-          "provider_logo_url": {
-            "type": "string"
-          },
           "category": {
             "type": "string"
           },

--- a/packages/mcp/src/generated/openapi.d.ts
+++ b/packages/mcp/src/generated/openapi.d.ts
@@ -1204,7 +1204,6 @@ export interface components {
             provider_id?: string;
             provider_name?: string;
             provider_description?: string;
-            provider_logo_url?: string;
             category?: string;
             /** @description Categories/tags attached to the capability. Current responses return category objects; legacy responses returned plain strings. */
             categories?: (components["schemas"]["PublicToolCategory"] | string)[];

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -179,9 +179,6 @@ export interface ToolInfo {
   /** Provider website URL */
   provider_website_url?: string;
 
-  /** Provider logo URL */
-  provider_logo_url?: string;
-
   /**
    * Geographic availability of the tool.
    * - "global" - Available worldwide

--- a/packages/python-sdk/qveris/generated/openapi_models.py
+++ b/packages/python-sdk/qveris/generated/openapi_models.py
@@ -427,7 +427,6 @@ class PublicCapabilityResult(BaseModel):
     provider_id: Optional[str] = None
     provider_name: Optional[str] = None
     provider_description: Optional[str] = None
-    provider_logo_url: Optional[str] = None
     category: Optional[str] = None
     categories: Optional[List[Union[PublicToolCategory, str]]] = Field(
         None,

--- a/packages/python-sdk/qveris/types.py
+++ b/packages/python-sdk/qveris/types.py
@@ -115,7 +115,6 @@ class ToolInfo(QverisModel):
     provider_name: Optional[str] = None
     provider_description: Optional[Any] = None
     provider_website_url: Optional[str] = None
-    provider_logo_url: Optional[str] = None
     region: Optional[str] = None
     params: Optional[List[ToolParameter]] = None
     examples: Optional[ToolExamples] = None


### PR DESCRIPTION
## Why

Follow-up to #102: `provider_logo_url` carries no incremental information for agents, so it should not be part of the declared contract.

## Changes

- Python SDK: removed from `ToolInfo`
- MCP: removed from `ToolInfo`
- OpenAPI spec: removed from `PublicCapabilityResult`; artifacts regenerated
- CLI: nothing to change (never displayed it)

Runtime unaffected — responses containing the field are still tolerated (`extra="allow"` in the SDK, structural typing in TS); it's just no longer declared.

## Test plan

- MCP: `tsc --noEmit` clean; vitest 68/68
- Python SDK: `uv run --extra dev pytest` — 32/32
- `node scripts/validate-openapi-contract.mjs` passes
- `grep -r provider_logo_url` — zero occurrences left in the repo