### PR TITLE
feat(mcp): add registry metadata for MCP directory listings

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "linfangw"
+  ]
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@qverisai/mcp",
+  "mcpName": "io.github.qverisai/mcp",
   "version": "0.7.2",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.qverisai/mcp",
+  "description": "Discover, inspect and call ranked external data & tool APIs with unified billing and usage audit",
+  "repository": {
+    "url": "https://github.com/QVerisAI/qveris-agent-toolkit",
+    "source": "github",
+    "subfolder": "packages/mcp"
+  },
+  "websiteUrl": "https://qveris.ai",
+  "version": "0.7.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@qverisai/mcp",
+      "version": "0.7.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "QVERIS_API_KEY",
+          "description": "QVeris API key (create one at https://qveris.ai)",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "QVERIS_REGION",
+          "description": "Force region: 'global' or 'cn' (auto-detected from key prefix if not set)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "QVERIS_BASE_URL",
+          "description": "Override API base URL (highest priority, for custom endpoints)",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,27 @@
+# Smithery registry configuration (https://smithery.ai/docs)
+# Runs the published @qverisai/mcp npm package over stdio.
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - qverisApiKey
+    properties:
+      qverisApiKey:
+        type: string
+        description: QVeris API key (create one at https://qveris.ai)
+      qverisRegion:
+        type: string
+        enum:
+          - global
+          - cn
+        description: Optional region override (auto-detected from key prefix if not set)
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', '@qverisai/mcp'],
+      env: {
+        QVERIS_API_KEY: config.qverisApiKey,
+        ...(config.qverisRegion ? { QVERIS_REGION: config.qverisRegion } : {})
+      }
+    })


### PR DESCRIPTION
## Why

Part of #108 — MCP registries are the main discovery channel for agent users (mcp.so indexes 20k+ servers; Smithery/Glama/PulseMCP are the other major directories). This PR adds the in-repo metadata those registries consume; the actual submissions are the follow-up step tracked in #108.

## Changes

- `packages/mcp/server.json` — official MCP registry manifest (npm package `@qverisai/mcp`, stdio transport, `QVERIS_API_KEY`/`QVERIS_REGION`/`QVERIS_BASE_URL` declarations). **Validated against the official `2025-12-11` server.schema.json** (the validation caught and fixed an over-length description).
- `packages/mcp/package.json` — adds `mcpName: io.github.qverisai/mcp`, required by the official registry's npm ownership validation. No other fields touched (CRLF line endings preserved).
- `smithery.yaml` (repo root) — stdio start command running the published npm package with a config schema for the API key and optional region.
- `glama.json` (repo root) — maintainer metadata.

## Not in this PR

- Registry submissions themselves (`mcp-publisher login github && mcp-publisher publish`, Smithery claim, awesome-mcp-servers PR) — they need interactive auth; exact steps will be posted on #108.
- The `mcpName` only takes effect on the next npm publish (0.7.3+).

## Test plan

- `server.json` validates against the official schema (jsonschema)
- `smithery.yaml` / `glama.json` parse cleanly
- No runtime code touched