### PR TITLE
ci(cli): gate npm publish on the CLI test suite

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -9,7 +9,30 @@ permissions:
   contents: write # For creating GitHub Releases
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/cli
+
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run tests
+        run: node --test
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Why

Closes #114. `cli-publish.yml` ran only `node --check` syntax validation before publishing to npm, while `mcp-publish.yml` has a full test matrix. The CLI now carries 61 tests (formatter suite etc.) that were not part of the publish gate — a failing test could ship.

## Changes

- New `test` job: node 18/20/22 matrix, runs `node --test` in `packages/cli` (no dependencies to install — the CLI is dependency-free, so no `npm ci`/cache step needed)
- `publish` job now `needs: test`
- Same structure as `mcp-publish.yml`

## Test plan

- YAML parses cleanly
- Gate takes effect on the next `cli-v*` tag push; a failing test aborts before `npm publish`