### PR TITLE
feat(js-sdk): add @qverisai/sdk TypeScript client

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -13,6 +13,7 @@ on:
       - "packages/cli/test/openapi-contract.test.mjs"
       - "packages/python-sdk/qveris/**"
       - "packages/python-sdk/tests/test_openapi_contract.py"
+      - "packages/js-sdk/src/**"
       - ".github/workflows/contract-tests.yml"
   push:
     branches:
@@ -23,6 +24,7 @@ on:
       - "packages/cli/test/openapi-contract.test.mjs"
       - "packages/python-sdk/qveris/**"
       - "packages/python-sdk/tests/test_openapi_contract.py"
+      - "packages/js-sdk/src/**"
       - ".github/workflows/contract-tests.yml"
 
 permissions:
@@ -52,3 +54,22 @@ jobs:
         run: |
           python -m pip install --quiet pytest "pydantic>=2.0.0"
           PYTHONPATH=. python -m pytest tests/test_openapi_contract.py -q
+
+  js-sdk-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/js-sdk
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: packages/js-sdk/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npm run typecheck
+      - name: JS SDK client tests
+        run: npm test

--- a/.github/workflows/js-sdk-publish.yml
+++ b/.github/workflows/js-sdk-publish.yml
@@ -1,0 +1,114 @@
+name: Publish JS SDK to npm
+
+on:
+  push:
+    tags:
+      - "js-sdk-v*" # Trigger on tags like js-sdk-v0.1.0, js-sdk-v1.0.0
+
+permissions:
+  contents: write # For creating GitHub Releases
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/js-sdk
+
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: packages/js-sdk/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/js-sdk
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify package version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#js-sdk-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Release body = Install section + Highlights from the annotated tag
+      # message (git tag -a js-sdk-vX.Y.Z -m "- bullet"), if any, +
+      # auto-generated notes. Lightweight tags simply get no Highlights section.
+      - name: Compose release notes
+        run: |
+          NOTES="$RUNNER_TEMP/release-notes.md"
+          {
+            echo '## Install'
+            echo ''
+            echo '```bash'
+            echo "npm install @qverisai/sdk@${VERSION}"
+            echo '```'
+          } > "$NOTES"
+          # actions/checkout maps the tag ref to the bare commit, dropping the
+          # annotation (actions/checkout#882) — re-fetch the real tag object.
+          git fetch --force --depth=1 origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" \
+            || echo "::warning::Could not re-fetch tag ${GITHUB_REF_NAME}; Highlights may be omitted"
+          if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}" 2>/dev/null)" = "tag" ]; then
+            HIGHLIGHTS="$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME" \
+              | sed -e '/^-----BEGIN PGP SIGNATURE-----$/,$d' -e '/^-----BEGIN SSH SIGNATURE-----$/,$d')"
+            if [ -n "$HIGHLIGHTS" ]; then
+              printf '\n## Highlights\n\n%s\n' "$HIGHLIGHTS" >> "$NOTES"
+            fi
+          fi
+          printf '\nSee [README](packages/js-sdk/README.md) for usage.\n' >> "$NOTES"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "QVeris JS SDK v${{ env.VERSION }}"
+          body_path: ${{ runner.temp }}/release-notes.md
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Full CLI documentation: [packages/cli/README.md](packages/cli/README.md)
 | **CLI** (recommended) | Claude Code / OpenClaw / any agent with exec | [CLI docs](packages/cli/README.md) |
 | MCP Server | Cursor / Claude Desktop / MCP-only clients | [MCP docs](docs/mcp-server.md) |
 | Python SDK | Python projects, agent frameworks | [Python SDK docs](packages/python-sdk/README.md) |
+| TypeScript SDK | Node.js / TypeScript projects | [JS SDK docs](packages/js-sdk/README.md) |
 | REST API | Any language, custom integrations | [REST API docs](docs/rest-api.md) |
 
 ### Core protocol
@@ -263,6 +264,7 @@ This repository (`QVerisAI/qveris-agent-toolkit`) is the primary monorepo for QV
 | MCP Server | [`packages/mcp`](packages/mcp) | [@qverisai/mcp](https://www.npmjs.com/package/@qverisai/mcp) |
 | CLI | [`packages/cli`](packages/cli) | [@qverisai/cli](https://www.npmjs.com/package/@qverisai/cli) |
 | Python SDK | [`packages/python-sdk`](packages/python-sdk) | [qveris](https://pypi.org/project/qveris/) |
+| TypeScript SDK | [`packages/js-sdk`](packages/js-sdk) | [@qverisai/sdk](https://www.npmjs.com/package/@qverisai/sdk) |
 | Agent docs | [`agent/`](agent) | — |
 | Skills | [`skills/`](skills) | — |
 

--- a/packages/js-sdk/.gitignore
+++ b/packages/js-sdk/.gitignore
@@ -1,0 +1,32 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# Test coverage
+coverage/
+
+# Misc
+*.tgz
+

--- a/packages/js-sdk/LICENSE
+++ b/packages/js-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 QVerisAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -1,0 +1,89 @@
+# @qverisai/sdk
+
+TypeScript SDK for [QVeris](https://qveris.ai) — the Agent External Data & Tool Harness. Discover, inspect and call 1000+ ranked external data & tool capabilities with unified billing and usage audit. No per-provider API keys required.
+
+- **Typed end to end** — response types aligned with the public OpenAPI contract (categories, capabilities, `why_recommended`, `expected_cost`, billing)
+- **Zero dependencies** — native `fetch`, Node.js 18+
+- **Same wire semantics** as the [Python SDK](https://pypi.org/project/qveris/) and the [MCP server](https://www.npmjs.com/package/@qverisai/mcp)
+
+## Install
+
+```bash
+npm install @qverisai/sdk
+```
+
+## Quickstart
+
+```typescript
+import { Qveris } from '@qverisai/sdk';
+
+const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+// or: const qveris = Qveris.fromEnv();
+
+// 1. Discover — free, returns ranked capabilities
+const found = await qveris.discover('stock price market data API', { limit: 5 });
+for (const tool of found.results) {
+  console.log(tool.tool_id, '—', tool.why_recommended);
+}
+
+// 2. Inspect — free, current parameter schemas
+const detail = await qveris.inspect(found.results[0].tool_id, {
+  searchId: found.search_id,
+});
+
+// 3. Call — billed in credits; response includes pre-settlement billing
+const outcome = await qveris.call(found.results[0].tool_id, {
+  searchId: found.search_id,
+  parameters: { symbol: 'AAPL' },
+});
+console.log(outcome.success, outcome.result);
+```
+
+## Audit
+
+```typescript
+// Final charge status for an execution
+const usage = await qveris.usage({ execution_id: outcome.execution_id });
+
+// Credit balance movements
+const ledger = await qveris.ledger({ direction: 'consume', summary: true });
+
+// Current balance
+const credits = await qveris.credits();
+```
+
+## Configuration
+
+| Option / env var | Description |
+| --- | --- |
+| `apiKey` / `QVERIS_API_KEY` | Required. Create one at [qveris.ai](https://qveris.ai/account?page=api-keys) (global) or [qveris.cn](https://qveris.cn/account?page=api-keys) (China) |
+| `baseUrl` / `QVERIS_BASE_URL` | Override API base URL (highest priority) |
+| `QVERIS_REGION` | Force region: `global` or `cn`. Otherwise auto-detected from the key prefix (`sk-cn-…` → China) |
+| `timeoutMs` | Default request timeout (30s; `call` defaults to 120s) |
+
+## Errors
+
+All failures throw `QverisApiError` (an `Error` subclass) with `status`, `details`, and an `observability` object (operation, endpoint, request id) for diagnostics:
+
+```typescript
+import { QverisApiError } from '@qverisai/sdk';
+
+try {
+  await qveris.call('some.tool.v1', { parameters: {} });
+} catch (err) {
+  if (err instanceof QverisApiError && err.status === 402) {
+    // insufficient credits — err.message includes the purchase link
+  }
+}
+```
+
+## Related
+
+- [QVeris CLI](https://www.npmjs.com/package/@qverisai/cli) — `qveris discover / inspect / call / usage / ledger`
+- [QVeris MCP server](https://www.npmjs.com/package/@qverisai/mcp) — for Claude, Cursor and other MCP clients
+- [Python SDK](https://pypi.org/project/qveris/)
+- [REST API docs](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/rest-api.md)
+
+## License
+
+MIT

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,0 +1,1458 @@
+{
+  "name": "@qverisai/sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@qverisai/sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.10.1",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@qverisai/sdk",
+  "version": "0.1.0",
+  "description": "QVeris TypeScript SDK for agent capability discovery, inspection, calling, and audit",
+  "keywords": [
+    "qveris",
+    "ai",
+    "agent",
+    "tools",
+    "sdk",
+    "typescript",
+    "function-calling"
+  ],
+  "author": "QVerisAI",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QVerisAI/qveris-agent-toolkit",
+    "directory": "packages/js-sdk"
+  },
+  "homepage": "https://qveris.ai",
+  "bugs": {
+    "url": "https://github.com/QVerisAI/qveris-agent-toolkit/issues"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Qveris } from './client.js';
+import { QverisApiError } from './errors.js';
+import type { ToolCategory, ToolCapability } from './types.js';
+
+const API_KEY = 'sk-test-key';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+function mockFetch(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue(jsonResponse(body, status));
+}
+
+const SAMPLE_DISCOVER_RESPONSE = {
+  search_id: 'search-123',
+  total: 1,
+  results: [
+    {
+      tool_id: 'weather.forecast.v1',
+      name: 'Weather Forecast',
+      description: 'Forecast by location',
+      provider_name: 'Weather',
+      categories: [
+        { slug: 'weather', name: 'Weather', description: 'Weather related tools.' },
+        'legacy-string-tag',
+      ],
+      capabilities: [
+        {
+          id: 'WX.FORECAST.DAILY',
+          tag: [{ id: 'US', name: 'United States', type: 'market' }],
+        },
+      ],
+      params: [{ name: 'city', type: 'string', required: true, description: 'City name' }],
+      stats: { avg_execution_time_ms: 42.5, success_rate: 0.99 },
+      billing_rule: {
+        metering_mode: 'per_request',
+        price: { amount_credits: 3, unit: 'request' },
+      },
+      expected_cost: '3.0',
+      why_recommended: 'Matched both semantic and keyword relevance signals.',
+    },
+  ],
+  elapsed_time_ms: 12.5,
+};
+
+describe('Qveris client', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('requires an API key', () => {
+    expect(() => new Qveris({ apiKey: '' })).toThrow(/API key is required/);
+  });
+
+  it('resolves base URL from key prefix (sk-cn- -> qveris.cn)', async () => {
+    const fetchMock = mockFetch(SAMPLE_DISCOVER_RESPONSE);
+    globalThis.fetch = fetchMock;
+
+    await new Qveris({ apiKey: 'sk-cn-test' }).discover('weather');
+    expect(fetchMock.mock.calls[0][0]).toContain('https://qveris.cn/api/v1/search');
+
+    await new Qveris({ apiKey: API_KEY }).discover('weather');
+    expect(fetchMock.mock.calls[1][0]).toContain('https://qveris.ai/api/v1/search');
+  });
+
+  it('explicit baseUrl overrides key-prefix detection and strips trailing slashes', async () => {
+    const fetchMock = mockFetch(SAMPLE_DISCOVER_RESPONSE);
+    globalThis.fetch = fetchMock;
+
+    const client = new Qveris({ apiKey: 'sk-cn-test', baseUrl: 'https://example.test/api/v1///' });
+    await client.discover('weather');
+    expect(fetchMock.mock.calls[0][0]).toBe('https://example.test/api/v1/search');
+  });
+
+  it('discover posts query/limit/session_id and parses the modern result shape', async () => {
+    const fetchMock = mockFetch(SAMPLE_DISCOVER_RESPONSE);
+    globalThis.fetch = fetchMock;
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const response = await client.discover('weather forecast API', {
+      limit: 3,
+      sessionId: 'session-1',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://qveris.ai/api/v1/search');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Authorization']).toBe(`Bearer ${API_KEY}`);
+    expect(JSON.parse(init.body)).toEqual({
+      query: 'weather forecast API',
+      limit: 3,
+      session_id: 'session-1',
+    });
+
+    expect(response.search_id).toBe('search-123');
+    const tool = response.results[0];
+    const categories = tool.categories as Array<string | ToolCategory>;
+    expect((categories[0] as ToolCategory).slug).toBe('weather');
+    expect(categories[1]).toBe('legacy-string-tag');
+    const capabilities = tool.capabilities as ToolCapability[];
+    expect(capabilities[0].id).toBe('WX.FORECAST.DAILY');
+    expect(capabilities[0].tag?.[0].id).toBe('US');
+    expect(tool.expected_cost).toBe('3.0');
+    expect(tool.why_recommended).toContain('semantic and keyword');
+  });
+
+  it('inspect posts tool_ids and search_id, coercing a single string id', async () => {
+    const fetchMock = mockFetch({
+      search_id: 'search-123',
+      results: [{ tool_id: 'weather.forecast.v1', description: 'Forecast' }],
+    });
+    globalThis.fetch = fetchMock;
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const response = await client.inspect('weather.forecast.v1', { searchId: 'search-123' });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://qveris.ai/api/v1/tools/by-ids');
+    expect(JSON.parse(init.body)).toEqual({
+      tool_ids: ['weather.forecast.v1'],
+      search_id: 'search-123',
+    });
+    expect(response.results[0].tool_id).toBe('weather.forecast.v1');
+  });
+
+  it('inspect with an empty id list returns an empty response without a request', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const response = await client.inspect([], { searchId: 'search-123' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.search_id).toBe('search-123');
+    expect(response.total).toBe(0);
+    expect(response.results).toEqual([]);
+  });
+
+  it('call sends tool_id as query param and parameters/search_id/max_response_size in the body', async () => {
+    const fetchMock = mockFetch({
+      execution_id: 'exec-123',
+      tool_id: 'weather.forecast.v1',
+      parameters: { city: 'London' },
+      success: true,
+      result: { data: { temperature: 18 } },
+      billing: {
+        summary: '3 credits per successful request',
+        list_amount_credits: 3,
+        charge_lines: [{ component_key: 'request', amount_credits: 3, unit: 'request' }],
+      },
+      remaining_credits: 997,
+    });
+    globalThis.fetch = fetchMock;
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const response = await client.call('weather.forecast.v1', {
+      parameters: { city: 'London' },
+      searchId: 'search-123',
+      maxResponseSize: 20480,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      'https://qveris.ai/api/v1/tools/execute?tool_id=weather.forecast.v1',
+    );
+    expect(JSON.parse(init.body)).toEqual({
+      parameters: { city: 'London' },
+      search_id: 'search-123',
+      max_response_size: 20480,
+    });
+    expect(response.execution_id).toBe('exec-123');
+    expect(response.billing?.list_amount_credits).toBe(3);
+    expect(response.billing?.charge_lines?.[0].component_key).toBe('request');
+  });
+
+  it('unwraps {status: "success", data: ...} envelopes', async () => {
+    globalThis.fetch = mockFetch({
+      status: 'success',
+      data: { search_id: 'search-123', results: [], total: 0 },
+    });
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const response = await client.discover('weather forecast API');
+    expect(response.search_id).toBe('search-123');
+    expect(response.results).toEqual([]);
+  });
+
+  it('throws QverisApiError on a failure envelope before result parsing', async () => {
+    globalThis.fetch = mockFetch({
+      status: 'failure',
+      message: 'quota exhausted',
+      data: { unexpected: 'shape' },
+    });
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const error = await client.discover('weather').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(QverisApiError);
+    expect((error as QverisApiError).message).toContain('quota exhausted');
+  });
+
+  it('throws QverisApiError with parsed message and details on HTTP errors', async () => {
+    globalThis.fetch = mockFetch({ error_message: 'bad key' }, 401);
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const error = await client.discover('weather').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(QverisApiError);
+    const apiError = error as QverisApiError;
+    expect(apiError.status).toBe(401);
+    expect(apiError.message).toBe('bad key');
+    expect(apiError.observability?.operation).toBe('discover');
+    expect(apiError.observability?.error_type).toBe('http_error');
+  });
+
+  it('adds a purchase hint on 402 responses', async () => {
+    globalThis.fetch = mockFetch({ message: 'balance too low' }, 402);
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const error = await client.call('t.v1', { parameters: {} }).catch((e: unknown) => e);
+    expect((error as QverisApiError).message).toContain('Insufficient credits');
+    expect((error as QverisApiError).message).toContain('https://qveris.ai/pricing');
+  });
+
+  it('usage() issues a GET with query filters and unwraps the envelope', async () => {
+    const fetchMock = mockFetch({
+      status: 'success',
+      data: {
+        items: [
+          {
+            id: 'usage-1',
+            event_type: 'tool_execute',
+            source_system: 'qveris',
+            success: true,
+            charge_outcome: 'charged',
+            execution_id: 'exec-123',
+            actual_amount_credits: 3,
+            created_at: '2026-05-10T00:00:00Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        page_size: 1,
+        summary: { total_credits: 3 },
+      },
+    });
+    globalThis.fetch = fetchMock;
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const response = await client.usage({ execution_id: 'exec-123', summary: true });
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(url.pathname).toBe('/api/v1/auth/usage/history/v2');
+    expect(url.searchParams.get('execution_id')).toBe('exec-123');
+    expect(url.searchParams.get('summary')).toBe('true');
+    expect(fetchMock.mock.calls[0][1].method).toBe('GET');
+
+    expect(response.total).toBe(1);
+    expect(response.items[0].charge_outcome).toBe('charged');
+    expect(response.summary).toEqual({ total_credits: 3 });
+  });
+
+  it('ledger() issues a GET with query filters and unwraps the envelope', async () => {
+    const fetchMock = mockFetch({
+      status: 'success',
+      data: {
+        items: [
+          {
+            id: 'ledger-1',
+            entry_type: 'consume_tool_execute',
+            amount_credits: -3,
+            source_system: 'qveris',
+            source_ref_type: 'execution',
+            source_ref_id: 'exec-123',
+            created_at: '2026-05-10T00:00:00Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        page_size: 1,
+        summary: { net_credits: -3 },
+      },
+    });
+    globalThis.fetch = fetchMock;
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const response = await client.ledger({ direction: 'consume', min_credits: 1.5 });
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(url.pathname).toBe('/api/v1/auth/credits/ledger');
+    expect(url.searchParams.get('direction')).toBe('consume');
+    expect(url.searchParams.get('min_credits')).toBe('1.5');
+
+    expect(response.items[0].entry_type).toBe('consume_tool_execute');
+    expect(response.summary).toEqual({ net_credits: -3 });
+  });
+
+  it('wraps network failures in QverisApiError with status 0', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('socket hang up'));
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const error = await client.discover('weather').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(QverisApiError);
+    expect((error as QverisApiError).status).toBe(0);
+    expect((error as QverisApiError).message).toBe('socket hang up');
+    expect((error as QverisApiError).observability?.error_type).toBe('network_error');
+  });
+
+  it('throws QverisApiError on invalid JSON bodies', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      headers: new Headers(),
+    } as unknown as Response);
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const error = await client.discover('weather').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(QverisApiError);
+    expect((error as QverisApiError).observability?.error_type).toBe('invalid_json');
+  });
+});

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -309,6 +309,19 @@ describe('Qveris client', () => {
     expect(response.summary).toEqual({ net_credits: -3 });
   });
 
+  it('maps aborted requests to status 408 with timeout error_type', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('This operation was aborted'), { name: 'AbortError' }));
+
+    const client = new Qveris({ apiKey: API_KEY });
+    const error = await client.discover('weather').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(QverisApiError);
+    expect((error as QverisApiError).status).toBe(408);
+    expect((error as QverisApiError).message).toContain('timed out');
+    expect((error as QverisApiError).observability?.error_type).toBe('timeout');
+  });
+
   it('wraps network failures in QverisApiError with status 0', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('socket hang up'));
 

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -1,0 +1,421 @@
+/**
+ * QVeris API client.
+ *
+ * A lightweight, dependency-free typed client for the QVeris REST API using
+ * native fetch (Node.js 18+). Handles authentication, region resolution,
+ * success-envelope unwrapping, timeouts, and error normalization.
+ *
+ * The wire semantics mirror the Python SDK (`qveris` on PyPI) and the MCP
+ * server (`@qverisai/mcp`).
+ *
+ * @module client
+ */
+
+import { QverisApiError } from './errors.js';
+import type {
+  ApiEnvelope,
+  ApiError,
+  ApiObservability,
+  ApiOperation,
+  CreditsLedgerRequest,
+  CreditsLedgerResponse,
+  CreditsResponse,
+  ExecuteResponse,
+  QverisClientConfig,
+  SearchResponse,
+  UsageEventsResponse,
+  UsageHistoryRequest,
+} from './types.js';
+
+/** Region-specific API base URLs */
+const REGION_URLS: Record<string, string> = {
+  global: 'https://qveris.ai/api/v1',
+  cn: 'https://qveris.cn/api/v1',
+};
+
+/**
+ * Detect region from API key prefix.
+ * sk-cn-xxx -> cn, sk-xxx -> global
+ */
+function detectRegionFromKey(apiKey: string): string {
+  return apiKey.startsWith('sk-cn-') ? 'cn' : 'global';
+}
+
+/**
+ * Resolve the base URL for the QVeris API.
+ * Priority: explicit baseUrl > QVERIS_BASE_URL env > QVERIS_REGION env > key prefix auto-detect > default
+ */
+function resolveBaseUrl(apiKey: string, explicitBaseUrl?: string): string {
+  if (explicitBaseUrl) return explicitBaseUrl.replace(/\/+$/, '');
+  if (typeof process !== 'undefined') {
+    if (process.env.QVERIS_BASE_URL) return process.env.QVERIS_BASE_URL.replace(/\/+$/, '');
+    if (process.env.QVERIS_REGION) {
+      const region = process.env.QVERIS_REGION.toLowerCase();
+      return REGION_URLS[region] ?? REGION_URLS.global;
+    }
+  }
+  return REGION_URLS[detectRegionFromKey(apiKey)];
+}
+
+/** Default timeout: 30s for discover/inspect/audit, 120s for call */
+const DEFAULT_TIMEOUT_MS = 30_000;
+const EXECUTE_TIMEOUT_MS = 120_000;
+
+/** Options for {@link Qveris.discover}. */
+export interface DiscoverOptions {
+  /** Maximum number of results (1-100, server default 20) */
+  limit?: number;
+  /** Session identifier for tracking */
+  sessionId?: string;
+  /** Per-request timeout override in milliseconds */
+  timeoutMs?: number;
+}
+
+/** Options for {@link Qveris.inspect}. */
+export interface InspectOptions {
+  /** The search_id from the discover call that returned the tool(s) */
+  searchId?: string;
+  /** Session identifier for tracking */
+  sessionId?: string;
+  /** Per-request timeout override in milliseconds */
+  timeoutMs?: number;
+}
+
+/** Options for {@link Qveris.call}. */
+export interface CallOptions {
+  /** Key-value parameters matching the tool's parameter schema */
+  parameters: Record<string, unknown>;
+  /** The search_id from the discover call that returned this tool */
+  searchId?: string;
+  /** Session identifier for tracking */
+  sessionId?: string;
+  /** Max response bytes before truncation (-1 for no limit, server default 20480) */
+  maxResponseSize?: number;
+  /** Per-request timeout override in milliseconds (default 120s) */
+  timeoutMs?: number;
+}
+
+/**
+ * QVeris API client.
+ *
+ * @example
+ * ```typescript
+ * import { Qveris } from '@qverisai/sdk';
+ *
+ * const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+ *
+ * const found = await qveris.discover('stock price market data API', { limit: 5 });
+ * const tool = found.results[0];
+ *
+ * const outcome = await qveris.call(tool.tool_id, {
+ *   searchId: found.search_id,
+ *   parameters: { symbol: 'AAPL' },
+ * });
+ * ```
+ */
+export class Qveris {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly defaultTimeoutMs: number;
+
+  constructor(config: QverisClientConfig) {
+    if (!config.apiKey) {
+      throw new Error(
+        'QVeris API key is required.\n' +
+          'Global: https://qveris.ai/account?page=api-keys\n' +
+          'China:  https://qveris.cn/account?page=api-keys',
+      );
+    }
+    this.apiKey = config.apiKey;
+    this.baseUrl = resolveBaseUrl(config.apiKey, config.baseUrl);
+    this.defaultTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /**
+   * Create a client from the QVERIS_API_KEY environment variable.
+   * Region is auto-detected from the key prefix (sk-cn-xxx -> cn), or
+   * overridden via QVERIS_REGION / QVERIS_BASE_URL.
+   */
+  static fromEnv(overrides?: Omit<QverisClientConfig, 'apiKey'>): Qveris {
+    const apiKey = process.env.QVERIS_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        'QVERIS_API_KEY environment variable is required.\n' +
+          'Global: https://qveris.ai/account?page=api-keys\n' +
+          'China:  https://qveris.cn/account?page=api-keys',
+      );
+    }
+    return new Qveris({ apiKey, ...overrides });
+  }
+
+  /**
+   * Discover capabilities from a natural-language query. Free.
+   */
+  async discover(query: string, options: DiscoverOptions = {}): Promise<SearchResponse> {
+    return this.request<SearchResponse>(
+      'discover',
+      'POST',
+      '/search',
+      {
+        query,
+        ...(options.limit !== undefined && { limit: options.limit }),
+        ...(options.sessionId !== undefined && { session_id: options.sessionId }),
+      },
+      options.timeoutMs,
+    );
+  }
+
+  /**
+   * Inspect capabilities by id to get current parameter schemas. Free.
+   * An empty id list resolves locally without a network request.
+   */
+  async inspect(toolIds: string | string[], options: InspectOptions = {}): Promise<SearchResponse> {
+    const ids = typeof toolIds === 'string' ? [toolIds] : toolIds;
+    if (ids.length === 0) {
+      return { search_id: options.searchId ?? '', total: 0, results: [] };
+    }
+    return this.request<SearchResponse>(
+      'inspect',
+      'POST',
+      '/tools/by-ids',
+      {
+        tool_ids: ids,
+        ...(options.searchId !== undefined && { search_id: options.searchId }),
+        ...(options.sessionId !== undefined && { session_id: options.sessionId }),
+      },
+      options.timeoutMs,
+    );
+  }
+
+  /**
+   * Call a capability. The response may include pre-settlement billing;
+   * final charges are reflected in usage() and ledger().
+   */
+  async call(toolId: string, options: CallOptions): Promise<ExecuteResponse> {
+    return this.request<ExecuteResponse>(
+      'call',
+      'POST',
+      `/tools/execute?tool_id=${encodeURIComponent(toolId)}`,
+      {
+        parameters: options.parameters,
+        search_id: options.searchId ?? null,
+        ...(options.sessionId !== undefined && { session_id: options.sessionId }),
+        ...(options.maxResponseSize !== undefined && {
+          max_response_size: options.maxResponseSize,
+        }),
+      },
+      options.timeoutMs ?? EXECUTE_TIMEOUT_MS,
+    );
+  }
+
+  /** Get current credit balance and bucket details. */
+  async credits(): Promise<CreditsResponse> {
+    return this.request<CreditsResponse>('credits', 'GET', '/auth/credits');
+  }
+
+  /** Query request-level usage audit history. */
+  async usage(filters: UsageHistoryRequest = {}): Promise<UsageEventsResponse> {
+    return this.request<UsageEventsResponse>(
+      'usage_history',
+      'GET',
+      '/auth/usage/history/v2',
+      undefined,
+      undefined,
+      filters as Record<string, unknown>,
+    );
+  }
+
+  /** Query final credits ledger entries. */
+  async ledger(filters: CreditsLedgerRequest = {}): Promise<CreditsLedgerResponse> {
+    return this.request<CreditsLedgerResponse>(
+      'credits_ledger',
+      'GET',
+      '/auth/credits/ledger',
+      undefined,
+      undefined,
+      filters as Record<string, unknown>,
+    );
+  }
+
+  /**
+   * Makes an authenticated HTTP request and unwraps success envelopes.
+   */
+  private async request<T>(
+    operation: ApiOperation,
+    method: 'GET' | 'POST',
+    endpoint: string,
+    body?: unknown,
+    timeoutMs?: number,
+    query?: Record<string, unknown>,
+  ): Promise<T> {
+    const url = new URL(`${this.baseUrl}${endpoint}`);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined && value !== null && value !== '') {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+    const controller = new AbortController();
+    const resolvedTimeoutMs = timeoutMs ?? this.defaultTimeoutMs;
+    const queryParams = Object.fromEntries(url.searchParams.entries());
+    const requestContext: ApiObservability = {
+      source: 'qveris_api',
+      operation,
+      method,
+      endpoint,
+      url: url.toString(),
+      ...(Object.keys(queryParams).length > 0 && { query_params: queryParams }),
+      timeout_ms: resolvedTimeoutMs,
+    };
+    const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
+
+    try {
+      const response = await fetch(url.toString(), {
+        method,
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const status = response.status;
+        let errorMessage: string;
+        let errorDetails: unknown;
+
+        try {
+          const errorBody = (await response.json()) as Record<string, unknown>;
+          errorMessage =
+            (errorBody.error_message as string) ||
+            (errorBody.message as string) ||
+            (errorBody.error as string) ||
+            response.statusText;
+          errorDetails = errorBody;
+        } catch {
+          errorMessage = response.statusText || `HTTP ${status}`;
+        }
+
+        if (status === 402) {
+          const pricingHost = this.baseUrl.includes('qveris.cn')
+            ? 'https://qveris.cn'
+            : 'https://qveris.ai';
+          errorMessage = `Insufficient credits. ${errorMessage}. Purchase credits at ${pricingHost}/pricing`;
+        }
+
+        throw new QverisApiError({
+          status,
+          message: errorMessage,
+          ...(errorDetails !== undefined && { details: errorDetails }),
+          observability: withErrorContext(
+            requestContext,
+            'http_error',
+            status,
+            extractRequestId(response),
+          ),
+        });
+      }
+
+      let payload: unknown;
+      try {
+        payload = await response.json();
+      } catch {
+        throw new QverisApiError({
+          status: response.status,
+          message: 'Invalid or empty JSON response from API',
+          observability: withErrorContext(
+            requestContext,
+            'invalid_json',
+            response.status,
+            extractRequestId(response),
+          ),
+        });
+      }
+
+      return this.unwrapEnvelope<T>(payload, requestContext);
+    } catch (err: unknown) {
+      if (err instanceof QverisApiError) {
+        throw err;
+      }
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new QverisApiError({
+          status: 408,
+          message: 'Request timed out. Check connectivity or increase timeout.',
+          observability: withErrorContext(requestContext, 'timeout', 0),
+          ...(errorCause(err) && { cause: errorCause(err) }),
+        });
+      }
+      throw new QverisApiError({
+        status: 0,
+        message: err instanceof Error && err.message ? err.message : 'Network request failed',
+        observability: withErrorContext(requestContext, 'network_error', 0),
+        ...(errorCause(err) && { cause: errorCause(err) }),
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Unwrap `{status: "success", data: ...}` envelopes; raw payloads pass
+   * through. A failure envelope throws before any result parsing, matching
+   * the Python SDK behavior.
+   */
+  private unwrapEnvelope<T>(payload: unknown, context: ApiObservability): T {
+    if (
+      payload !== null &&
+      typeof payload === 'object' &&
+      'status' in payload &&
+      'data' in payload &&
+      typeof (payload as { status: unknown }).status === 'string'
+    ) {
+      const envelope = payload as ApiEnvelope<T>;
+      if (envelope.status !== 'success') {
+        throw new QverisApiError({
+          status: envelope.status_code ?? 400,
+          message: envelope.message ?? `API returned status "${envelope.status}"`,
+          details: payload,
+          observability: withErrorContext(context, 'http_error', envelope.status_code ?? 400),
+        });
+      }
+      return envelope.data;
+    }
+    return payload as T;
+  }
+}
+
+function withErrorContext(
+  context: ApiObservability,
+  errorType: NonNullable<ApiObservability['error_type']>,
+  httpStatus?: number,
+  requestId?: string,
+): ApiObservability {
+  return {
+    ...context,
+    error_type: errorType,
+    ...(httpStatus !== undefined && { http_status: httpStatus }),
+    ...(requestId && { request_id: requestId }),
+  };
+}
+
+function extractRequestId(response: Response): string | undefined {
+  const headers = response.headers;
+  return (
+    headers?.get('x-request-id') ??
+    headers?.get('x-qveris-request-id') ??
+    headers?.get('x-correlation-id') ??
+    undefined
+  );
+}
+
+function errorCause(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const cause = error.cause;
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === 'string' && cause) return cause;
+  return undefined;
+}
+
+export type { ApiError };

--- a/packages/js-sdk/src/errors.ts
+++ b/packages/js-sdk/src/errors.ts
@@ -1,0 +1,37 @@
+/**
+ * QVeris SDK error types.
+ *
+ * @module errors
+ */
+
+import type { ApiError, ApiObservability } from './types.js';
+
+/**
+ * Error thrown for any failed QVeris API interaction: HTTP errors,
+ * failure envelopes, timeouts, and network failures.
+ *
+ * Carries the same shape as the wire-level {@link ApiError} so callers can
+ * branch on `status` and inspect `observability` for diagnostics.
+ */
+export class QverisApiError extends Error implements ApiError {
+  /** HTTP status code (0 for network errors, 408 for timeouts) */
+  readonly status: number;
+
+  /** Original error details if available */
+  readonly details?: unknown;
+
+  /** Request metadata for diagnosing API failures */
+  readonly observability?: ApiObservability;
+
+  /** Lower-level transport or runtime cause when available */
+  readonly cause?: string;
+
+  constructor(error: ApiError) {
+    super(error.message);
+    this.name = 'QverisApiError';
+    this.status = error.status;
+    if (error.details !== undefined) this.details = error.details;
+    if (error.observability !== undefined) this.observability = error.observability;
+    if (error.cause !== undefined) this.cause = error.cause;
+  }
+}

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * QVeris TypeScript SDK.
+ *
+ * Typed client for the QVeris Agent External Data & Tool Harness:
+ * discover, inspect, call, plus usage and credits-ledger audit.
+ *
+ * @example
+ * ```typescript
+ * import { Qveris } from '@qverisai/sdk';
+ *
+ * const qveris = Qveris.fromEnv();
+ * const found = await qveris.discover('weather forecast API');
+ * ```
+ *
+ * @module @qverisai/sdk
+ */
+
+export { Qveris } from './client.js';
+export type { DiscoverOptions, InspectOptions, CallOptions } from './client.js';
+export { QverisApiError } from './errors.js';
+export * from './types.js';

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -1,0 +1,572 @@
+/**
+ * Qveris API Type Definitions
+ *
+ * This module contains TypeScript types that match the Qveris API schema.
+ * Aligned with backend ToolInfo, SearchResponse, ToolCallResponse, and
+ * the REST API documentation at docs/en-US/rest-api.md.
+ *
+ * @module types
+ * @see {@link https://qveris.ai/api/v1} Qveris API Base URL
+ */
+
+// ============================================================================
+// Search API Types
+// ============================================================================
+
+/**
+ * Request body for the Search Tools API.
+ */
+export interface SearchRequest {
+  /** Natural language search query describing the tool capability you need. */
+  query: string;
+
+  /**
+   * Maximum number of results to return.
+   * @default 20
+   * @minimum 1
+   * @maximum 100
+   */
+  limit?: number;
+
+  /** Session identifier for tracking user sessions. */
+  session_id?: string;
+}
+
+/**
+ * Parameter definition for a tool.
+ */
+export interface ToolParameter {
+  /** Parameter name (used as key in the parameters object) */
+  name: string;
+
+  /** Data type of the parameter */
+  type: 'string' | 'number' | 'boolean' | 'array' | 'object';
+
+  /** Whether this parameter must be provided */
+  required: boolean;
+
+  /** Human-readable description of what this parameter does */
+  description: string;
+
+  /** If present, restricts valid values to this list */
+  enum?: string[];
+}
+
+/**
+ * Example usage for a tool, showing sample parameters.
+ */
+export interface ToolExamples {
+  /** Sample parameter values demonstrating typical usage */
+  sample_parameters?: Record<string, unknown>;
+}
+
+/**
+ * Historical execution performance statistics for a tool.
+ */
+export interface ToolStats {
+  /** Historical average execution time in milliseconds */
+  avg_execution_time_ms?: number;
+
+  /** Historical success rate (0.0 - 1.0) */
+  success_rate?: number;
+
+  /** Legacy fallback estimate in credits per call */
+  cost?: number;
+}
+
+export interface BillingPrice {
+  amount_credits: number;
+  per?: number | null;
+  unit?: string | null;
+  unit_label?: string | null;
+}
+
+export interface BillingChargeLine {
+  component_key: string;
+  quantity?: number | null;
+  unit?: string | null;
+  unit_label?: string | null;
+  price?: BillingPrice | null;
+  amount_credits?: number | null;
+  description?: string | null;
+  is_adjustment?: boolean | null;
+}
+
+export interface BillingRule {
+  metering_mode?: string;
+  billing_unit?: string;
+  billing_unit_label?: string;
+  price?: BillingPrice | null;
+  price_breakdown?: Record<string, unknown>[] | null;
+  pricing_dimensions?: Record<string, unknown>[] | null;
+  minimum_charge_credits?: number | null;
+  snapshot_id?: number | null;
+  snapshot_version?: string | null;
+  runtime_pricing_version?: string | null;
+  pricing_source_system?: string | null;
+  description?: string;
+}
+
+export interface CompactBillingStatement {
+  price?: BillingPrice | null;
+  quantity?: number | null;
+  charge_lines?: BillingChargeLine[] | null;
+  minimum_charge_credits?: number | null;
+  list_amount_credits?: number | null;
+  requested_amount_credits?: number | null;
+  summary?: string | null;
+}
+
+/**
+ * Category/tag attached to a tool.
+ * Current API responses return category objects; legacy responses returned
+ * plain strings, so `ToolInfo.categories` accepts both.
+ */
+export interface ToolCategory {
+  slug?: string;
+  name?: string;
+  description?: string;
+}
+
+/**
+ * Coverage tag attached to a capability (e.g. market coverage).
+ */
+export interface ToolCapabilityTag {
+  id?: string;
+  name?: string;
+  type?: string;
+  description?: string;
+}
+
+/**
+ * Standardized capability descriptor attached to a tool
+ * (e.g. "MKT.BARS.ADJUSTED" with market coverage tags).
+ */
+export interface ToolCapability {
+  id?: string;
+  tag?: ToolCapabilityTag[];
+}
+
+/**
+ * Information about a tool returned from search results.
+ * Contains everything needed to understand and execute the tool.
+ */
+export interface ToolInfo {
+  /** Unique identifier for the tool (used in call) */
+  tool_id: string;
+
+  /** Human-readable display name */
+  name: string;
+
+  /** Detailed description of what the tool does */
+  description: string;
+
+  /** Tool categories/tags: category objects, or plain strings in legacy responses */
+  categories?: Array<string | ToolCategory>;
+
+  /** Standardized capability descriptors with coverage tags */
+  capabilities?: ToolCapability[];
+
+  /** Provider identifier */
+  provider_id?: string;
+
+  /** Name of the organization/service providing this tool */
+  provider_name?: string;
+
+  /** Description of the provider */
+  provider_description?: string;
+
+  /** Provider website URL */
+  provider_website_url?: string;
+
+  /**
+   * Geographic availability of the tool.
+   * - "global" - Available worldwide
+   * - "US|CA" - Whitelist: only available in US and Canada
+   * - "-CN|RU" - Blacklist: not available in China and Russia
+   */
+  region?: string;
+
+  /** List of parameters the tool accepts */
+  params?: ToolParameter[];
+
+  /** Usage examples with sample parameters */
+  examples?: ToolExamples;
+
+  /** Historical execution performance statistics */
+  stats?: ToolStats;
+
+  /** Structured rule-level billing metadata when available */
+  billing_rule?: BillingRule;
+
+  /** Pre-call cost estimate in credits, when available */
+  expected_cost?: string | number;
+
+  /** Relevance score for the search query (0.0 - 1.0, higher = better match) */
+  final_score?: number;
+
+  /** Human-readable explanation of why this tool was recommended (Discover results only) */
+  why_recommended?: string;
+
+  /** Whether this tool has been executed before (verified in production) */
+  has_last_execution?: boolean;
+
+  /** Most recent execution record, if available */
+  last_execution_record?: Record<string, unknown>;
+
+  /** Documentation URL for the tool */
+  docs_url?: string;
+
+  /** Protocol type */
+  protocol?: string;
+}
+
+/**
+ * Performance statistics for a search operation.
+ */
+export interface SearchStats {
+  /** Total time to complete the search in milliseconds */
+  search_time_ms?: number;
+
+  /** Vector recall count */
+  vector_recall_count?: number;
+
+  /** Fulltext recall count */
+  fulltext_recall_count?: number;
+}
+
+/**
+ * Response from the Search Tools API.
+ */
+export interface SearchResponse {
+  /** The original search query */
+  query?: string;
+
+  /**
+   * Unique identifier for this search.
+   * Required when calling call for any tool from these results.
+   */
+  search_id: string;
+
+  /** Total number of results returned */
+  total?: number;
+
+  /** Array of matching tools */
+  results: ToolInfo[];
+
+  /** Search performance statistics */
+  stats?: SearchStats;
+
+  /** User's remaining credits after this operation */
+  remaining_credits?: number;
+
+  /** Total elapsed time in milliseconds */
+  elapsed_time_ms?: number;
+}
+
+// ============================================================================
+// Get Tools by IDs API Types
+// ============================================================================
+
+/**
+ * Request body for the Get Tools by IDs API.
+ */
+export interface GetToolsByIdsRequest {
+  /** Array of tool IDs to retrieve information for. */
+  tool_ids: string[];
+
+  /** The search_id from the search that returned the tool(s). */
+  search_id?: string;
+
+  /** Session identifier for tracking user sessions. */
+  session_id?: string;
+}
+
+// ============================================================================
+// Execute API Types
+// ============================================================================
+
+/**
+ * Request body for the Execute Tool API.
+ */
+export interface ExecuteRequest {
+  /**
+   * The search_id from the search that returned this tool.
+   * Links the execution to the original search for analytics and billing.
+   */
+  search_id: string;
+
+  /** Session identifier for tracking user sessions. */
+  session_id?: string;
+
+  /**
+   * Key-value pairs of parameters to pass to the tool.
+   * Must match the parameter schema from the tool's definition.
+   */
+  parameters: Record<string, unknown>;
+
+  /**
+   * Maximum size of response data in bytes.
+   * If the tool generates data longer than this, it will be truncated
+   * and a download URL will be provided for the full content.
+   * @default 20480 (20KB)
+   * @minimum -1 (-1 means no limit)
+   */
+  max_response_size?: number;
+}
+
+/**
+ * Result data when the response fits within max_response_size.
+ */
+export interface ExecuteResultData {
+  /** The actual result data from the tool execution */
+  data: unknown;
+}
+
+/**
+ * Result data when the response exceeds max_response_size.
+ * Provides truncated content and a URL to download the full result.
+ */
+export interface ExecuteResultTruncated {
+  /** Explanation message about the truncation */
+  message: string;
+
+  /**
+   * URL to download the complete result file.
+   * Valid for 120 minutes.
+   */
+  full_content_file_url: string;
+
+  /**
+   * The initial portion of the response (max_response_size bytes).
+   * Useful for previewing the data structure.
+   */
+  truncated_content: string;
+
+  /**
+   * JSON Schema describing the structure of the full content.
+   * Helps the agent understand the data shape without downloading.
+   */
+  content_schema?: Record<string, unknown>;
+}
+
+/**
+ * Union type for execution results (either full data or truncated).
+ */
+export type ExecuteResult = ExecuteResultData | ExecuteResultTruncated;
+
+/**
+ * Response from the Execute Tool API.
+ */
+export interface ExecuteResponse {
+  /** Unique identifier for this execution record */
+  execution_id: string;
+
+  /** The tool that was executed */
+  tool_id: string;
+
+  /** The parameters that were passed to the tool */
+  parameters: Record<string, unknown>;
+
+  /**
+   * The execution result.
+   * Contains either `data` (if within size limit) or truncation info.
+   */
+  result?: ExecuteResult;
+
+  /** Whether the execution completed successfully */
+  success: boolean;
+
+  /**
+   * Error message if execution failed.
+   * Common reasons: insufficient balance, quota exceeded, invalid parameters.
+   */
+  error_message?: string | null;
+
+  /** Execution duration in seconds */
+  execution_time?: number;
+
+  /** Execution duration in milliseconds (alternative field) */
+  elapsed_time_ms?: number;
+
+  /** Legacy fallback estimate; use usage audit or credits ledger for final charge */
+  cost?: number;
+
+  /** Structured pre-settlement billing statement when available */
+  billing?: CompactBillingStatement;
+
+  /** Legacy/full pre-settlement bill snapshot when returned directly */
+  pre_settlement_bill?: Record<string, unknown>;
+
+  /** User's remaining credits after this execution */
+  remaining_credits?: number;
+
+  /** Timestamp of execution (ISO 8601 format) */
+  created_at?: string;
+}
+
+// ============================================================================
+// Account Audit API Types
+// ============================================================================
+
+export interface ApiEnvelope<T> {
+  status: string;
+  message?: string;
+  status_code?: number;
+  data: T;
+}
+
+export interface CreditsResponse {
+  remaining_credits: number;
+  daily_free?: Record<string, unknown>;
+  invite_reward?: Record<string, unknown>;
+  welcome_bonus?: Record<string, unknown>;
+  purchased?: Record<string, unknown>;
+}
+
+export interface UsageHistoryRequest {
+  start_date?: string;
+  end_date?: string;
+  summary?: boolean;
+  bucket?: string;
+  event_type?: string;
+  kind?: string;
+  success?: boolean;
+  charge_outcome?: string;
+  search_id?: string;
+  execution_id?: string;
+  min_credits?: number;
+  max_credits?: number;
+  limit?: number;
+  page?: number;
+  page_size?: number;
+}
+
+export interface UsageEventItem {
+  id: string;
+  event_type: string;
+  kind?: string | null;
+  source_system: string;
+  source_ref_type?: string | null;
+  source_ref_id?: string | null;
+  session_id?: string | null;
+  search_id?: string | null;
+  execution_id?: string | null;
+  tool_id?: string | null;
+  model?: string | null;
+  query?: string | null;
+  success: boolean;
+  charge_outcome?: string | null;
+  error_message?: string | null;
+  billing_snapshot_status?: string | null;
+  pre_settlement_bill?: Record<string, unknown> | null;
+  settlement_result?: Record<string, unknown> | null;
+  requested_amount_credits?: number | null;
+  actual_amount_credits?: number | null;
+  credits_ledger_entry_id?: string | null;
+  display_target?: string | null;
+  billing_summary?: string | null;
+  pre_settlement_amount_credits?: number | null;
+  settled_amount_credits?: number | null;
+  created_at: string;
+}
+
+export interface UsageEventsResponse {
+  items: UsageEventItem[];
+  total: number;
+  page: number;
+  page_size: number;
+  summary?: Record<string, unknown> | null;
+}
+
+export interface CreditsLedgerRequest {
+  start_date?: string;
+  end_date?: string;
+  summary?: boolean;
+  bucket?: string;
+  entry_type?: string;
+  direction?: string;
+  min_credits?: number;
+  max_credits?: number;
+  limit?: number;
+  page?: number;
+  page_size?: number;
+}
+
+export interface CreditsLedgerItem {
+  id: string;
+  entry_type: string;
+  amount_credits: number;
+  source_system: string;
+  source_ref_type?: string | null;
+  source_ref_id?: string | null;
+  pre_settlement_bill?: Record<string, unknown> | null;
+  settlement_result?: Record<string, unknown> | null;
+  balance_before?: Record<string, unknown> | null;
+  balance_after?: Record<string, unknown> | null;
+  ledger_metadata?: Record<string, unknown> | null;
+  description?: string | null;
+  created_at: string;
+}
+
+export interface CreditsLedgerResponse {
+  items: CreditsLedgerItem[];
+  total: number;
+  page: number;
+  page_size: number;
+  summary?: Record<string, unknown> | null;
+}
+
+// ============================================================================
+// API Client Types
+// ============================================================================
+
+/**
+ * Configuration options for the Qveris API client.
+ */
+export interface QverisClientConfig {
+  /** API authentication token */
+  apiKey: string;
+
+  /** Base URL for the API (defaults to production) */
+  baseUrl?: string;
+
+  /** Default request timeout in milliseconds */
+  timeoutMs?: number;
+}
+
+/**
+ * Error response from the Qveris API.
+ */
+export type ApiOperation = 'discover' | 'inspect' | 'call' | 'credits' | 'usage_history' | 'credits_ledger';
+export type ApiErrorType = 'http_error' | 'invalid_json' | 'timeout' | 'network_error';
+
+export interface ApiObservability {
+  source: 'qveris_api';
+  operation: ApiOperation;
+  method: 'GET' | 'POST';
+  endpoint: string;
+  url: string;
+  query_params?: Record<string, string>;
+  timeout_ms: number;
+  http_status?: number;
+  request_id?: string;
+  error_type?: ApiErrorType;
+}
+
+export interface ApiError {
+  /** HTTP status code */
+  status: number;
+
+  /** Error message */
+  message: string;
+
+  /** Original error details if available */
+  details?: unknown;
+
+  /** Request metadata for diagnosing API/provider/tool-chain failures. */
+  observability?: ApiObservability;
+
+  /** Lower-level transport or runtime cause when available. */
+  cause?: string;
+}

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/js-sdk/vitest.config.ts
+++ b/packages/js-sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

First cut of the TypeScript SDK (#106) — the largest gap vs. comparable agent-tool platforms, which all ship Python + TS SDKs.

`@qverisai/sdk`: typed, **zero-dependency** (native fetch, Node 18+) client for `discover` / `inspect` / `call` / `credits` / `usage` / `ledger`.

## Design

Wire semantics deliberately mirror the Python SDK and the MCP server:

| Behavior | Source of truth |
|---|---|
| Success-envelope unwrapping; failure envelope throws **before** result parsing | Python SDK `client/api.py` |
| `inspect([])` short-circuits locally without a network request | Python SDK |
| Region resolution: explicit `baseUrl` > `QVERIS_BASE_URL` > `QVERIS_REGION` > key-prefix auto-detect (`sk-cn-…` → qveris.cn) | MCP `api/client.ts` |
| 402 → purchase-link hint; timeout → 408; network → status 0; `observability` context on every error | MCP `api/client.ts` |
| Types incl. category objects, `capabilities`, `why_recommended`, `expected_cost: string \| number` | MCP `types.ts` (aligned with the OpenAPI spec in #102) |

Errors are `QverisApiError` — a proper `Error` subclass carrying `status` / `details` / `observability` / `cause`.

## Packaging & CI

- `js-sdk-publish.yml`: `js-sdk-v*` tags → node 18/20/22 test matrix → publish → GitHub Release with annotated-tag Highlights (same composition as the other three publish workflows, including the tag re-fetch fix from #101)
- `contract-tests.yml`: new `js-sdk-tests` job (typecheck + vitest) gating PRs that touch `packages/js-sdk/src`
- Root README: TypeScript SDK rows in access methods and package tables

## Test plan

- 15 vitest contract tests (mirroring `test_client_contracts.py`): discover/inspect/call request+response shapes, envelope unwrap, failure envelope, HTTP/402/network/invalid-JSON errors, usage/ledger GET filters, baseUrl resolution — **15/15 pass**; `tsc --noEmit` clean; build clean
- **Live smoke test against production**: discover (why_recommended/expected_cost/category objects parsed), inspect, usage — all passed. Notably the live API returned `expected_cost` as a *number* (2.37) where CLI probes previously saw strings — the `string | number` type covers both.

## Follow-ups (not in this PR)

- Type-level drift check between `src/types.ts` and the generated `openapi.d.ts` (tracked under #106 acceptance)
- `docs/en-US`/`zh-CN` doc pages + website docs-sync manifest addition
- Vercel AI SDK adapter (#109)

Closes nothing yet — #106 stays open for the follow-ups.