### PR TITLE
chore(release): mcp 0.7.3, js-sdk 0.2.0

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -77,6 +77,10 @@ try {
 }
 ```
 
+## Version history note
+
+Versions `0.1.x` of this npm package were an early MCP-focused SDK, since superseded by [`@qverisai/mcp`](https://www.npmjs.com/package/@qverisai/mcp). The typed REST client documented here starts at **`0.2.0`**.
+
 ## Related
 
 - [QVeris CLI](https://www.npmjs.com/package/@qverisai/cli) — `qveris discover / inspect / call / usage / ledger`

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.1",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "QVeris TypeScript SDK for agent capability discovery, inspection, calling, and audit",
   "keywords": [
     "qveris",

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.qverisai/mcp",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "subfolder": "packages/mcp"
   },
   "websiteUrl": "https://qveris.ai",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

| Package | Version | Notes |
|---|---|---|
| `@qverisai/mcp` | 0.7.2 → **0.7.3** | Ships #102/#103/#105/#117; carries `mcpName` to npm — prerequisite for the official MCP Registry submission (#108). `server.json` version kept in sync |
| `@qverisai/sdk` | 0.1.0 → **0.2.0** | First release of the typed REST client. The npm name carries legacy 0.1.x versions (an early MCP-focused SDK, since renamed to `@qverisai/mcp`; 44 downloads/month, effectively abandoned), so npm rejected `0.1.0` — the new line starts at 0.2.0, with a version-history note added to the README |

Version-field-only changes plus the README note.

## Test plan

- MCP: `tsc --noEmit` clean; vitest 68/68 locally; full node matrix runs on the tag
- JS SDK: 16/16 tests; full node matrix runs on the tag
- After merge: annotated tags `mcp-v0.7.3` and `js-sdk-v0.2.0` on the merge commit trigger the publishes

## Post-merge cleanup

- The unpublishable `js-sdk-v0.1.0` tag has been deleted (no npm publish or GitHub release was created)
- Optional follow-up: `npm deprecate @qverisai/sdk@"<0.2.0" "Legacy MCP-focused SDK; use @qverisai/mcp for MCP or upgrade to >=0.2.0 for the typed REST client"`