### PR TITLE
fix(mcp): correct mcpName casing for official registry; release 0.7.4

### DIFF
--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
-  "mcpName": "io.github.qverisai/mcp",
-  "version": "0.7.3",
+  "mcpName": "io.github.QVerisAI/mcp",
+  "version": "0.7.4",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.qverisai/mcp",
+  "name": "io.github.QVerisAI/mcp",
   "description": "Discover, inspect and call ranked external data & tool APIs with unified billing and usage audit",
   "repository": {
     "url": "https://github.com/QVerisAI/qveris-agent-toolkit",
@@ -8,13 +8,13 @@
     "subfolder": "packages/mcp"
   },
   "websiteUrl": "https://qveris.ai",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Problem

First real `mcp-publisher publish` attempt (#108) failed twice:

1. `403` — the registry's GitHub-auth namespace grant is the org's canonical casing `io.github.QVerisAI/*`, and the check is case-sensitive against our lowercase `io.github.qverisai/mcp`
2. After correcting the server.json name locally: `400` — the npm `mcpName` ownership validation is *also* case-sensitive, and `@qverisai/mcp@0.7.3` on npm carries the lowercase value

So npm must carry the corrected `mcpName`, which requires a patch release.

## Changes

- `mcpName` / `server.json` name → `io.github.QVerisAI/mcp`
- Version 0.7.3 → **0.7.4** in `package.json` / `package-lock.json` / `server.json`

## Test plan

- All three JSON files parse; version fields consistent
- After merge: annotated tag `mcp-v0.7.4` → npm publish → `mcp-publisher publish` should pass both validations