### PR TITLE
chore: add root LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 QVerisAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Why

The repo declares `"license": "MIT"` in every `package.json` and both READMEs render a license badge linking to `/blob/main/LICENSE`, but there was **no root `LICENSE` file** — only per-package copies. Consequences:

- The README license-badge link **404s**
- GitHub's repo-level license detection is blank (so the shields.io badge shows unknown)
- The Glama MCP directory listing rates the license **"F / not found"** (surfaced while claiming the auto-indexed QVeris server for #108)

## Change

Add a root `LICENSE` — **byte-identical** to `packages/mcp/LICENSE` (MIT, Copyright 2025 QVerisAI), matching the existing per-package convention. No README changes needed; the existing links now resolve.

## Test plan

- `diff LICENSE packages/mcp/LICENSE` → identical
- After merge: README badge link resolves, GitHub detects MIT, Glama license rating updates on re-index