### PR TITLE
chore: update copyright year to 2026 in LICENSE files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 QVerisAI
+Copyright (c) 2026 QVerisAI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/js-sdk/LICENSE
+++ b/packages/js-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 QVerisAI
+Copyright (c) 2026 QVerisAI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mcp/LICENSE
+++ b/packages/mcp/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 QVerisAI
+Copyright (c) 2026 QVerisAI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/python-sdk/LICENSE
+++ b/packages/python-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 QVerisAI
+Copyright (c) 2026 QVerisAI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Why

Four LICENSE files (root, `js-sdk`, `mcp`, `python-sdk`) still read `Copyright (c) 2025 QVerisAI`, while `packages/openclaw-qveris-plugin/LICENSE` already used **2026** — so the repo was inconsistent. Align all five on 2026.

## Scope (deliberately narrow)

Only LICENSE copyright lines change. I audited every `2025` in the repo; these are **intentionally left as-is** because they are not copyright years:

- `packages/mcp/server.json` — MCP schema version `2025-12-11` (a real schema identifier)
- `packages/mcp/src/**/*.test.ts` — test-fixture `created_at: '2025-01-15…'`
- `packages/openclaw-qveris-plugin/src/qveris-tools.ts` — an ISO-8601 date example in a param description
- `packages/python-sdk/uv.lock` — dependency metadata

READMEs and other docs carry **no** copyright year, so nothing else needed updating.

## Note

Used bare `2026` (matching the existing openclaw precedent and the request). A range `2025-2026` would also be defensible since the project started in 2025 — easy to switch if preferred.

## Test plan

- `git grep 'Copyright (c) 2025' -- '*LICENSE*'` → no matches
- All 5 LICENSE files now read `Copyright (c) 2026 QVerisAI`