### PR TITLE
fix(mcp): start without QVERIS_API_KEY so clients can list tools; release 0.7.5

### DIFF
--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.QVerisAI/mcp",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "subfolder": "packages/mcp"
   },
   "websiteUrl": "https://qveris.ai",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -138,6 +138,13 @@ describe('MCP public tool interface', () => {
     });
   });
 
+  it('returns an actionable error when called without a client (no QVERIS_API_KEY)', async () => {
+    const result = await executeQverisMcpTool(undefined, 'session-1', 'discover', { query: 'weather' });
+
+    expect(result.isError).toBe(true);
+    expect(payload(result).error).toContain('QVERIS_API_KEY');
+  });
+
   it('returns MCP error payloads for validation, unknown tools, and API errors', async () => {
     const client = {
       searchTools: vi.fn().mockRejectedValue({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -191,12 +191,32 @@ function compactObject(input: Record<string, unknown>): Record<string, unknown> 
  * Route one MCP tool call to the matching Qveris operation.
  */
 export async function executeQverisMcpTool(
-  client: QverisClient,
+  client: QverisClient | undefined,
   defaultSessionId: string,
   rawName: string,
   args: unknown,
   warn: (message: string) => void = (message) => process.stderr.write(message),
 ): Promise<CallToolResult> {
+  // Tool listing works without credentials, but calls need a key. When the
+  // server started without QVERIS_API_KEY the client is undefined; return an
+  // actionable error instead of crashing.
+  if (!client) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error:
+              'QVERIS_API_KEY is not set. Tool listing works without a key, but tool calls require one. ' +
+              'Create a key (global: https://qveris.ai/account?page=api-keys, ' +
+              'China: https://qveris.cn/account?page=api-keys), set QVERIS_API_KEY, and restart the server.',
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   // Resolve deprecated aliases.
   let name = rawName;
   if (DEPRECATED_ALIASES[rawName]) {
@@ -396,15 +416,20 @@ export async function executeQverisMcpTool(
  * inspect, and call handlers, and starts listening for requests.
  */
 export async function main(): Promise<void> {
-  // Initialize API client (validates QVERIS_API_KEY)
-  let client: QverisClient;
+  // Initialize the API client when credentials are available. The server still
+  // starts without QVERIS_API_KEY so MCP clients and registry scanners can list
+  // tools before credentials are configured; tool calls then return an
+  // actionable error until a key is set.
+  let client: QverisClient | undefined;
   try {
     client = createClientFromEnv();
   } catch (error) {
     console.error(
       error instanceof Error ? error.message : 'Failed to initialize Qveris client'
     );
-    process.exit(1);
+    console.error(
+      'Starting without credentials: tool listing is available; set QVERIS_API_KEY to enable tool calls.'
+    );
   }
 
   // Generate a default session ID for this server instance


### PR DESCRIPTION
## Why

Surfaced while polishing the Glama Score profile (#108 follow-up). Glama's "Server Coherence" and "Tool Definition Quality" checks sat **unevaluated** because they require running the server and calling `tools/list` — but `main()` called `createClientFromEnv()` and `process.exit(1)` whenever `QVERIS_API_KEY` was absent, so **the server never started without a key**.

This also hurt real UX: MCP clients (Claude Desktop, Cursor, MCP Inspector) call `tools/list` during connection, before the user has configured credentials. A missing key meant the server crashed instead of showing its tools.

## Change

The server now **starts without a key**:
- `tools/list` is already static and client-independent, so it works with no credentials.
- `executeQverisMcpTool` takes `client: QverisClient | undefined` and, when it's undefined, returns an actionable `QVERIS_API_KEY is not set…` MCP error on an actual **call** — instead of the process exiting at startup.
- Behavior when a key IS present is unchanged.

## Test plan

- `tsc --noEmit` clean; vitest **69/69** (added a test: `executeQverisMcpTool(undefined, …)` returns an `isError` result mentioning `QVERIS_API_KEY`)
- **Live smoke test** of the built server with the key unset (`env -u QVERIS_API_KEY node dist/index.js`): full MCP `initialize` + `tools/list` handshake returns all 8 tools; stderr logs "Starting without credentials…" then "v0.7.5 started" (previously it exited 1 immediately)
- Version-only bumps in `package.json` / `package-lock.json` / `server.json` (0.7.4 → 0.7.5)

## Effect on the Glama score

After 0.7.5 publishes and Glama re-scans, "Server Coherence" and "Tool Definition Quality" become evaluable. The license "F" is already fixed by the root LICENSE (#124) and needs a Glama re-sync. The remaining checklist items (Glama release, recent usage, related servers, profile completion) are Glama admin-panel / time-accrued and are not repo-side levers — noted for follow-up.