### PR TITLE
fix(recipes): drop no-op --summary flag from usage/ledger examples

### DIFF
--- a/recipes/crypto-monitoring/README.md
+++ b/recipes/crypto-monitoring/README.md
@@ -22,8 +22,8 @@ qveris init \
 Use audit commands after execution:
 
 ```bash
-qveris usage --execution-id "exec_..." --summary --json
-qveris ledger --limit 5 --summary --json
+qveris usage --execution-id "exec_..." --json
+qveris ledger --limit 5 --json
 ```
 
 ## Python SDK

--- a/recipes/data-analysis/README.md
+++ b/recipes/data-analysis/README.md
@@ -22,8 +22,8 @@ qveris init \
 Audit the sample call:
 
 ```bash
-qveris usage --execution-id "exec_..." --summary --json
-qveris ledger --limit 5 --summary --json
+qveris usage --execution-id "exec_..." --json
+qveris ledger --limit 5 --json
 ```
 
 ## Python SDK

--- a/recipes/developer-automation/README.md
+++ b/recipes/developer-automation/README.md
@@ -22,8 +22,8 @@ qveris init \
 Audit the call:
 
 ```bash
-qveris usage --execution-id "exec_..." --summary --json
-qveris ledger --limit 5 --summary --json
+qveris usage --execution-id "exec_..." --json
+qveris ledger --limit 5 --json
 ```
 
 ## Python SDK

--- a/recipes/finance-research/README.md
+++ b/recipes/finance-research/README.md
@@ -24,8 +24,8 @@ qveris init \
 After a call returns an `execution_id`, audit charge outcome:
 
 ```bash
-qveris usage --execution-id "exec_..." --summary --json
-qveris ledger --limit 5 --summary --json
+qveris usage --execution-id "exec_..." --json
+qveris ledger --limit 5 --json
 ```
 
 ## Python SDK

--- a/recipes/risk-compliance/README.md
+++ b/recipes/risk-compliance/README.md
@@ -22,8 +22,8 @@ qveris init \
 Audit the execution after you receive `execution_id`:
 
 ```bash
-qveris usage --execution-id "exec_..." --summary --json
-qveris ledger --limit 5 --summary --json
+qveris usage --execution-id "exec_..." --json
+qveris ledger --limit 5 --json
 ```
 
 ## Python SDK


### PR DESCRIPTION
## Problem

Every recipe's CLI audit examples use `qveris usage ... --summary --json` and `qveris ledger ... --summary --json`, but **`--summary` is not a real CLI flag**. The `usage`/`ledger` commands select output shape via `--mode` (`summary` | `search` | `export_file`), resolved by `resolveMode(flags.mode)`; `summary` is the default. `--summary` isn't in the flag table, so it falls through to positional args and is silently ignored — the commands only *appear* to work because summary is already the default.

Surfaced while reviewing #128 (which introduced the explainable-routing recipe and already avoids the flag).

## Fix

Drop `--summary` from the `usage`/`ledger` CLI examples in all five recipes (crypto-monitoring, data-analysis, developer-automation, finance-research, risk-compliance). Summary remains the default output. This matches the newest recipe (explainable-routing) and the CLI's own `qveris init` hints, which use the real `--mode summary` / `--mode search` form.

Python SDK `summary=True` keyword args are unaffected — those are real client parameters, left as-is.

## Test plan

- `git grep -- '--summary' -- recipes/` → no matches
- `node scripts/validate-ecosystem-manifests.mjs` → 5/5 ok
- Removed flag was a verified no-op (`resolveMode` defaults to `summary`), so command behavior is unchanged