### PR TITLE
feat(python-sdk): per-session budget guard for the agent (#111)

### DIFF
--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -139,8 +139,25 @@ async with Agent(config=QverisConfig(base_url="https://qveris.cn/api/v1")) as ag
 | `tool_result` | 工具调用的执行结果（`event.tool_result` 含 `name`、`result`、`is_error`） |
 | `metrics` | provider 上报的 token 用量 / 耗时 |
 | `error` | 终止本次运行的致命错误 |
+| `budget_warning` / `budget_exceeded` | 会话消耗越过预警阈值 / 某次调用因超预算被拦截（见 [预算护栏](#预算护栏)） |
 
 给 `run(...)` 传 `stream=False` 可改为接收完整助手轮次而非增量分片。
+
+### 预算护栏
+
+设置会话级积分预算以约束自主消耗：
+
+```python
+agent = Agent(budget_credits=25)
+```
+
+设置后，agent 会从 `discover` / `inspect` 学习每个能力的 `expected_cost`，并在**请求发出之前拦截预计会超预算的 `call`**——同时发出 `budget_exceeded` 事件，让模型改选更便宜的能力或停止。它从 `call` 的账单累计实际消耗，并在接近上限时发出一次 `budget_warning`。可随时查询状态：
+
+```python
+status = agent.budget_status()   # {"limit": 25, "spent": 12.0, "remaining": 13.0}，或 None
+```
+
+`spent` 反映预结算金额——请用 `usage(...)` / `ledger(...)` 核对最终扣费。成本未知的能力不会被拦截（无法估算）。未设置 `budget_credits` 时，agent 行为完全不变。
 
 ## 配置参考
 
@@ -281,6 +298,7 @@ agent = Agent(llm_provider=MyProvider())
 | `crypto_market.py` | 加密货币价格与成交量数据 |
 | `data_analysis.py` | 用外部能力数据丰富数据集 |
 | `explainable_routing.py` | 基于 `why_recommended` / `expected_cost` 的成本感知能力选型 |
+| `budget_guard.py` | 用 `Agent(budget_credits=...)` 设置会话级积分预算 |
 | `agent_loop_integration.py` | LLM agent 循环集成 |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。运行前请确保已设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1`。

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -133,8 +133,25 @@ async with Agent() as agent:
 | `tool_result` | Output of an executed tool call (`event.tool_result` has `name`, `result`, `is_error`) |
 | `metrics` | Token usage / timing, when the provider reports it |
 | `error` | Fatal error that ended the run |
+| `budget_warning` / `budget_exceeded` | Session spend crossed the warn threshold / a call was blocked to stay within budget (see [Budget guard](#budget-guard)) |
 
 Pass `stream=False` to `run(...)` to receive complete assistant turns instead of deltas.
+
+### Budget guard
+
+Set a per-session credit budget to bound autonomous spend:
+
+```python
+agent = Agent(budget_credits=25)
+```
+
+When set, the agent learns each capability's `expected_cost` from `discover` / `inspect` and **blocks a `call` projected to exceed the budget before the request is sent** — emitting a `budget_exceeded` event so the model can pick a cheaper capability or stop. It accumulates actual spend from `call` billing and emits a single `budget_warning` as spend approaches the limit. Query the state any time:
+
+```python
+status = agent.budget_status()   # {"limit": 25, "spent": 12.0, "remaining": 13.0}, or None
+```
+
+`spent` reflects pre-settlement charges — reconcile final charges with `usage(...)` / `ledger(...)`. Capabilities whose cost is unknown are not blocked (they cannot be estimated). Without `budget_credits`, agent behavior is unchanged.
 
 ## Configuration reference
 
@@ -275,6 +292,7 @@ Runnable examples live under [`packages/python-sdk/examples/`](https://github.co
 | `crypto_market.py` | Crypto price and volume data |
 | `data_analysis.py` | Dataset enrichment with external capability data |
 | `explainable_routing.py` | Cost-aware capability selection with `why_recommended` / `expected_cost` |
+| `budget_guard.py` | Per-session credit budget with `Agent(budget_credits=...)` |
 | `agent_loop_integration.py` | LLM agent loop integration |
 
 Capability examples run `discover`/`inspect` when `QVERIS_API_KEY` is set, and only execute `call` when `RUN_QVERIS_CALLS=1`.

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -133,8 +133,25 @@ async with Agent() as agent:
 | `tool_result` | 工具调用的执行结果（`event.tool_result` 含 `name`、`result`、`is_error`） |
 | `metrics` | provider 上报的 token 用量 / 耗时 |
 | `error` | 终止本次运行的致命错误 |
+| `budget_warning` / `budget_exceeded` | 会话消耗越过预警阈值 / 某次调用因超预算被拦截（见 [预算护栏](#预算护栏)） |
 
 给 `run(...)` 传 `stream=False` 可改为接收完整助手轮次而非增量分片。
+
+### 预算护栏
+
+设置会话级积分预算以约束自主消耗：
+
+```python
+agent = Agent(budget_credits=25)
+```
+
+设置后，agent 会从 `discover` / `inspect` 学习每个能力的 `expected_cost`，并在**请求发出之前拦截预计会超预算的 `call`**——同时发出 `budget_exceeded` 事件，让模型改选更便宜的能力或停止。它从 `call` 的账单累计实际消耗，并在接近上限时发出一次 `budget_warning`。可随时查询状态：
+
+```python
+status = agent.budget_status()   # {"limit": 25, "spent": 12.0, "remaining": 13.0}，或 None
+```
+
+`spent` 反映预结算金额——请用 `usage(...)` / `ledger(...)` 核对最终扣费。成本未知的能力不会被拦截（无法估算）。未设置 `budget_credits` 时，agent 行为完全不变。
 
 ## 配置参考
 
@@ -275,6 +292,7 @@ agent = Agent(llm_provider=MyProvider())
 | `crypto_market.py` | 加密货币价格与成交量数据 |
 | `data_analysis.py` | 用外部能力数据丰富数据集 |
 | `explainable_routing.py` | 基于 `why_recommended` / `expected_cost` 的成本感知能力选型 |
+| `budget_guard.py` | 用 `Agent(budget_credits=...)` 设置会话级积分预算 |
 | `agent_loop_integration.py` | LLM agent 循环集成 |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -153,7 +153,7 @@ agent = Agent(llm_provider=MyProvider())
 
 ## Examples
 
-Six runnable examples are included under [`examples/`](examples):
+Seven runnable examples are included under [`examples/`](examples):
 
 | Example | Scenario |
 |---------|----------|
@@ -162,6 +162,7 @@ Six runnable examples are included under [`examples/`](examples):
 | `crypto_market.py` | Crypto price and volume data |
 | `data_analysis.py` | Dataset enrichment with external capability data |
 | `explainable_routing.py` | Cost-aware capability selection with `why_recommended` / `expected_cost` |
+| `budget_guard.py` | Per-session credit budget with `Agent(budget_credits=...)` |
 | `agent_loop_integration.py` | LLM agent loop integration |
 
 The capability examples run `discover` and `inspect` when `QVERIS_API_KEY` is set. They only execute `call` when `RUN_QVERIS_CALLS=1` is set.

--- a/packages/python-sdk/examples/budget_guard.py
+++ b/packages/python-sdk/examples/budget_guard.py
@@ -1,0 +1,67 @@
+"""Cost-aware agent with a per-session credit budget.
+
+`Agent(budget_credits=N)` bounds how many credits the loop may spend: it learns
+`expected_cost` from discover/inspect, blocks a `call` projected to exceed the
+budget *before* the request is sent (emitting a `budget_exceeded` event so the
+model can pick a cheaper capability or stop), and warns as spend approaches the
+limit. Without `budget_credits`, agent behavior is unchanged.
+
+Run:
+    python budget_guard.py                       # offline BudgetTracker demo
+    # with keys set, also runs a real budgeted agent loop:
+    export QVERIS_API_KEY="sk-..." OPENAI_API_KEY="sk-..."
+    python budget_guard.py
+"""
+
+import asyncio
+import os
+
+from qveris import Agent, BudgetTracker, Message
+
+
+def offline_demo() -> None:
+    """Deterministic illustration of the guard — no network, no keys."""
+    print("== BudgetTracker (offline) ==")
+    budget = BudgetTracker(limit=10)
+    # The agent normally feeds discover/inspect results in for you; here we do it by hand.
+    budget.observe({"results": [{"tool_id": "cheap.v1", "expected_cost": "1"},
+                                {"tool_id": "pricey.v1", "expected_cost": "24.2"}]})
+
+    print(f"budget: {budget.snapshot()}")
+    print(f"call cheap.v1 (est 1)?  blocked={budget.check('cheap.v1') is not None}")
+    print(f"call pricey.v1 (est 24.2)?  blocked={budget.check('pricey.v1') is not None}")
+
+    budget.record({"billing": {"list_amount_credits": 1}})  # actually spent 1 on cheap.v1
+    print(f"after spending 1: {budget.snapshot()}\n")
+
+
+async def agent_demo() -> None:
+    if not os.getenv("QVERIS_API_KEY") or not os.getenv("OPENAI_API_KEY"):
+        print("Set QVERIS_API_KEY and OPENAI_API_KEY to run the budgeted agent loop.")
+        return
+
+    print("== Budgeted agent loop ==")
+    agent = Agent(budget_credits=25)
+    try:
+        messages = [Message(role="user", content="Find a stock quote capability and quote AAPL.")]
+        async for event in agent.run(messages):
+            if event.type == "content" and event.content:
+                print(event.content, end="", flush=True)
+            elif event.type == "tool_call" and event.tool_call:
+                print(f"\n-> {event.tool_call.get('function', {}).get('name')}")
+            elif event.type == "budget_warning":
+                print(f"\n[budget] warning: {event.budget}")
+            elif event.type == "budget_exceeded":
+                print(f"\n[budget] blocked over-budget call: {event.budget}")
+        print(f"\nfinal budget: {agent.budget_status()}")
+    finally:
+        await agent.close()
+
+
+async def main() -> None:
+    offline_demo()
+    await agent_demo()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python-sdk/qveris/__init__.py
+++ b/packages/python-sdk/qveris/__init__.py
@@ -1,3 +1,4 @@
+from .agent.budget import BudgetTracker
 from .agent.core import Agent
 from .client.api import QverisClient
 from .config import QverisConfig, AgentConfig
@@ -20,6 +21,7 @@ from .types import (
 
 __all__ = [
     "Agent",
+    "BudgetTracker",
     "QverisClient",
     "QverisConfig",
     "AgentConfig",

--- a/packages/python-sdk/qveris/agent/budget.py
+++ b/packages/python-sdk/qveris/agent/budget.py
@@ -16,25 +16,31 @@ already handles, so the tracker needs no extra network calls.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, Optional
 
 
 def parse_credits(value: Any) -> Optional[float]:
     """Coerce an ``expected_cost`` / credit value (str, int, or float) to float.
 
-    Returns ``None`` for missing or unparseable values. ``bool`` is rejected so
-    a stray ``True``/``False`` is not read as ``1.0``/``0.0``.
+    Returns ``None`` for missing, unparseable, or non-finite values. ``bool`` is
+    rejected so a stray ``True``/``False`` is not read as ``1.0``/``0.0``.
+    Non-finite values (``NaN`` / ``inf``, which ``json.loads`` and pydantic both
+    admit) are rejected so a malformed billing amount cannot poison cumulative
+    spend and silently disable the guard.
     """
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
+        result = float(value)
+    elif isinstance(value, str):
         try:
-            return float(value.strip())
+            result = float(value.strip())
         except ValueError:
             return None
-    return None
+    else:
+        return None
+    return result if math.isfinite(result) else None
 
 
 class BudgetTracker:
@@ -45,6 +51,17 @@ class BudgetTracker:
             tracker entirely.
         warn_ratio: Emit a single warning once cumulative spend first reaches
             this fraction of ``limit`` (default 0.8).
+
+    Notes:
+        - Best-effort, not a hard cap: blocking uses the pre-call
+          ``expected_cost`` estimate while ``spent`` accumulates the actual
+          (possibly larger) charge, so a call estimated under-budget that
+          charges more can push ``spent`` past ``limit``. The guard is only as
+          tight as ``discover`` / ``inspect`` coverage — a call whose cost was
+          never observed cannot be estimated and is not blocked.
+        - The tracker is per-``Agent`` session state, not per-``run()``. Don't
+          share one ``Agent`` across concurrent ``run()`` calls if you rely on
+          the budget: they share and race ``spent``.
     """
 
     def __init__(self, limit: Optional[float] = None, warn_ratio: float = 0.8) -> None:

--- a/packages/python-sdk/qveris/agent/budget.py
+++ b/packages/python-sdk/qveris/agent/budget.py
@@ -1,0 +1,144 @@
+"""Session-scoped credit budget for the agent loop.
+
+``BudgetTracker`` bounds how many credits an autonomous agent may spend. It is
+disabled (a no-op) unless a limit is set, so default agent behavior is
+unchanged. When enabled it:
+
+- learns per-capability cost estimates from ``discover`` / ``inspect`` results
+  (the ``expected_cost`` field), then
+- blocks a ``call`` whose estimate would push cumulative spend over the limit
+  *before the request is sent*, and
+- accumulates actual spend from each ``call`` response's billing.
+
+Cost estimates and charges are read from the JSON-shaped tool results the agent
+already handles, so the tracker needs no extra network calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def parse_credits(value: Any) -> Optional[float]:
+    """Coerce an ``expected_cost`` / credit value (str, int, or float) to float.
+
+    Returns ``None`` for missing or unparseable values. ``bool`` is rejected so
+    a stray ``True``/``False`` is not read as ``1.0``/``0.0``.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+class BudgetTracker:
+    """Track and enforce a per-session credit budget.
+
+    Args:
+        limit: Maximum credits the session may spend. ``None`` disables the
+            tracker entirely.
+        warn_ratio: Emit a single warning once cumulative spend first reaches
+            this fraction of ``limit`` (default 0.8).
+    """
+
+    def __init__(self, limit: Optional[float] = None, warn_ratio: float = 0.8) -> None:
+        self.limit = limit
+        self.warn_ratio = warn_ratio
+        self.spent = 0.0
+        self._estimates: Dict[str, float] = {}
+        self._warned = False
+
+    @property
+    def enabled(self) -> bool:
+        return self.limit is not None
+
+    @property
+    def remaining(self) -> Optional[float]:
+        if self.limit is None:
+            return None
+        return max(0.0, self.limit - self.spent)
+
+    def observe(self, result: Any) -> None:
+        """Cache ``expected_cost`` per ``tool_id`` from a discover/inspect payload."""
+        if not self.enabled or not isinstance(result, dict):
+            return
+        for item in result.get("results") or []:
+            if not isinstance(item, dict):
+                continue
+            tool_id = item.get("tool_id")
+            cost = parse_credits(item.get("expected_cost"))
+            if isinstance(tool_id, str) and cost is not None:
+                self._estimates[tool_id] = cost
+
+    def estimate(self, tool_id: Optional[str]) -> Optional[float]:
+        """Return the cached cost estimate for ``tool_id``, if known."""
+        if not isinstance(tool_id, str):
+            return None
+        return self._estimates.get(tool_id)
+
+    def check(self, tool_id: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Return a block payload if calling ``tool_id`` would exceed the budget.
+
+        Returns ``None`` (allowed) when the tracker is disabled, the cost is
+        unknown (cannot estimate, so not blocked), or the projected spend is
+        within the limit.
+        """
+        if not self.enabled:
+            return None
+        est = self.estimate(tool_id)
+        if est is None:
+            return None
+        projected = self.spent + est
+        if projected > self.limit:  # type: ignore[operator]
+            return {
+                "tool_id": tool_id,
+                "estimated": est,
+                "spent": self.spent,
+                "limit": self.limit,
+                "remaining": self.remaining,
+                "projected": projected,
+            }
+        return None
+
+    def record(self, execution: Any) -> Optional[Dict[str, Any]]:
+        """Add the actual charge from a ``call`` result to cumulative spend.
+
+        Returns a warning payload the first time spend reaches
+        ``warn_ratio * limit``; otherwise ``None``.
+        """
+        if not self.enabled:
+            return None
+        charge = self._charge_of(execution)
+        if charge:
+            self.spent += charge
+        if (
+            not self._warned
+            and self.limit is not None
+            and self.spent >= self.limit * self.warn_ratio
+        ):
+            self._warned = True
+            return self.snapshot()
+        return None
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return the current budget state (queryable, reconcilable with usage/ledger)."""
+        return {"limit": self.limit, "spent": self.spent, "remaining": self.remaining}
+
+    @staticmethod
+    def _charge_of(execution: Any) -> float:
+        """Extract the pre-settlement charge from a call result dict."""
+        if not isinstance(execution, dict):
+            return 0.0
+        billing = execution.get("billing")
+        if isinstance(billing, dict):
+            for key in ("list_amount_credits", "requested_amount_credits"):
+                value = parse_credits(billing.get(key))
+                if value is not None:
+                    return value
+        return parse_credits(execution.get("cost")) or 0.0

--- a/packages/python-sdk/qveris/agent/budget.py
+++ b/packages/python-sdk/qveris/agent/budget.py
@@ -43,6 +43,26 @@ def parse_credits(value: Any) -> Optional[float]:
     return result if math.isfinite(result) else None
 
 
+def _as_dict(value: Any) -> Optional[Dict[str, Any]]:
+    """Return a plain-dict view of a dict or a pydantic model, else ``None``.
+
+    The agent loop feeds JSON-shaped dicts (from ``model_dump()``), but the
+    public ``BudgetTracker`` may be handed pydantic models (``SearchResponse``,
+    ``ToolExecutionResponse``) directly — accept both so a model does not
+    silently disable estimate caching or spend accumulation.
+    """
+    if isinstance(value, dict):
+        return value
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            dumped = dump()
+        except Exception:
+            return None
+        return dumped if isinstance(dumped, dict) else None
+    return None
+
+
 class BudgetTracker:
     """Track and enforce a per-session credit budget.
 
@@ -82,14 +102,21 @@ class BudgetTracker:
         return max(0.0, self.limit - self.spent)
 
     def observe(self, result: Any) -> None:
-        """Cache ``expected_cost`` per ``tool_id`` from a discover/inspect payload."""
-        if not self.enabled or not isinstance(result, dict):
+        """Cache ``expected_cost`` per ``tool_id`` from a discover/inspect payload.
+
+        Accepts a dict or a pydantic ``SearchResponse``.
+        """
+        if not self.enabled:
             return
-        for item in result.get("results") or []:
-            if not isinstance(item, dict):
+        data = _as_dict(result)
+        if data is None:
+            return
+        for item in data.get("results") or []:
+            entry = _as_dict(item)
+            if entry is None:
                 continue
-            tool_id = item.get("tool_id")
-            cost = parse_credits(item.get("expected_cost"))
+            tool_id = entry.get("tool_id")
+            cost = parse_credits(entry.get("expected_cost"))
             if isinstance(tool_id, str) and cost is not None:
                 self._estimates[tool_id] = cost
 
@@ -149,13 +176,17 @@ class BudgetTracker:
 
     @staticmethod
     def _charge_of(execution: Any) -> float:
-        """Extract the pre-settlement charge from a call result dict."""
-        if not isinstance(execution, dict):
+        """Extract the pre-settlement charge from a call result.
+
+        Accepts a dict or a pydantic ``ToolExecutionResponse``.
+        """
+        data = _as_dict(execution)
+        if data is None:
             return 0.0
-        billing = execution.get("billing")
-        if isinstance(billing, dict):
+        billing = _as_dict(data.get("billing"))
+        if billing is not None:
             for key in ("list_amount_credits", "requested_amount_credits"):
                 value = parse_credits(billing.get(key))
                 if value is not None:
                     return value
-        return parse_credits(execution.get("cost")) or 0.0
+        return parse_credits(data.get("cost")) or 0.0

--- a/packages/python-sdk/qveris/agent/core.py
+++ b/packages/python-sdk/qveris/agent/core.py
@@ -46,6 +46,7 @@ from ..config import AgentConfig, QverisConfig
 from ..llm.base import LLMProvider
 from ..llm.openai import OpenAIProvider
 from ..types import ChatResponse, Message, StreamEvent
+from .budget import BudgetTracker
 from .memory import prune_tool_history
 
 # Type alias for extra tool handler callback.
@@ -92,10 +93,15 @@ class Agent:
         llm_provider: Optional[LLMProvider] = None,
         extra_tools: Optional[List[ChatCompletionToolParam]] = None,
         extra_tool_handler: Optional[ExtraToolHandler] = None,
-        debug_callback: Optional[Callable[[str], None]] = None
+        debug_callback: Optional[Callable[[str], None]] = None,
+        budget_credits: Optional[float] = None,
     ):
         self.config = config or QverisConfig()
         self.agent_config = agent_config or AgentConfig()
+
+        # Optional per-session credit budget. Disabled (no-op) when None, so
+        # default agent behavior is unchanged.
+        self.budget = BudgetTracker(budget_credits)
 
         # Setup API Client with debug callback
         self.client = QverisClient(self.config, debug_callback=debug_callback)
@@ -175,6 +181,15 @@ class Agent:
         prompt, that internal system message is omitted so callers can reuse the list directly.
         """
         return [message.model_copy(deep=True) for message in self.last_messages]
+
+    def budget_status(self) -> Optional[Dict[str, Any]]:
+        """Return the current budget state (``limit`` / ``spent`` / ``remaining``).
+
+        Returns ``None`` when no ``budget_credits`` was set. ``spent`` reflects
+        pre-settlement charges from ``call`` responses; reconcile final charges
+        with ``usage(...)`` / ``ledger(...)``.
+        """
+        return self.budget.snapshot() if self.budget.enabled else None
 
     async def run(
         self,
@@ -329,12 +344,42 @@ class Agent:
                         )
                         continue
 
-                    # Execute Tool
-                    result, is_error, handled = await self.client.handle_tool_call(
-                        func_name=func_name,
-                        func_args=func_args,
-                        session_id=self.session_id
-                    )
+                    # Budget guard: block a call projected to exceed the session
+                    # budget *before* sending it, and surface a budget_exceeded
+                    # event so the model can pick a cheaper capability or stop.
+                    is_call = func_name in ("call", "execute_tool")
+                    block = self.budget.check(func_args.get("tool_id")) if is_call else None
+                    if block is not None:
+                        result = {
+                            "error": "budget_exceeded",
+                            "message": (
+                                f"Call skipped to stay within budget: an estimated "
+                                f"{block['estimated']:g} credits would bring session spend to "
+                                f"{block['projected']:g}, over the {block['limit']:g}-credit limit "
+                                f"({block['remaining']:g} remaining). Choose a cheaper capability "
+                                f"or stop."
+                            ),
+                            **block,
+                        }
+                        is_error, handled = True, True
+                        yield StreamEvent(type="budget_exceeded", budget=block)
+                    else:
+                        # Execute Tool
+                        result, is_error, handled = await self.client.handle_tool_call(
+                            func_name=func_name,
+                            func_args=func_args,
+                            session_id=self.session_id
+                        )
+
+                        # Learn cost estimates from discover/inspect; accumulate
+                        # spend and warn from call responses.
+                        if handled and not is_error:
+                            if func_name in ("discover", "search_tools", "inspect", "get_tools_by_ids"):
+                                self.budget.observe(result)
+                            elif is_call:
+                                warning = self.budget.record(result)
+                                if warning is not None:
+                                    yield StreamEvent(type="budget_warning", budget=warning)
 
                     # Handle extra tools if not a built-in Qveris tool
                     if not handled:

--- a/packages/python-sdk/qveris/types.py
+++ b/packages/python-sdk/qveris/types.py
@@ -264,13 +264,25 @@ class Message(QverisModel):
 
 
 class StreamEvent(QverisModel):
-    type: Literal["content", "reasoning", "tool_call", "tool_result", "metrics", "error", "reasoning_details"]
+    type: Literal[
+        "content",
+        "reasoning",
+        "tool_call",
+        "tool_result",
+        "metrics",
+        "error",
+        "reasoning_details",
+        "budget_warning",
+        "budget_exceeded",
+    ]
     content: Optional[str] = None
     tool_call: Optional[Dict[str, Any]] = None
     tool_result: Optional[Dict[str, Any]] = None
     metrics: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
     details: Optional[Any] = None
+    # Budget state for budget_warning / budget_exceeded events.
+    budget: Optional[Dict[str, Any]] = None
 
 
 class AgentMetrics(QverisModel):

--- a/packages/python-sdk/tests/test_agent_runtime.py
+++ b/packages/python-sdk/tests/test_agent_runtime.py
@@ -140,3 +140,121 @@ async def test_agent_routes_unhandled_tool_calls_to_extra_handler() -> None:
         "args": {"query": "weather forecast", "limit": 1},
         "value": 42,
     }
+
+
+class BudgetScenarioLLM:
+    """Discover once, then attempt to call `pricey.tool.v1`, then stop."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def chat(self, messages, tools, config):
+        self.calls += 1
+        if self.calls == 1:
+            return ChatResponse(
+                tool_calls=[{
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "discover", "arguments": json.dumps({"query": "x", "limit": 1})},
+                }]
+            )
+        if self.calls == 2:
+            return ChatResponse(
+                tool_calls=[{
+                    "id": "c2",
+                    "type": "function",
+                    "function": {
+                        "name": "call",
+                        "arguments": json.dumps(
+                            {"tool_id": "pricey.tool.v1", "search_id": "s1", "params_to_tool": {}}
+                        ),
+                    },
+                }]
+            )
+        return ChatResponse(content="done")
+
+    async def chat_stream(self, messages, tools, config):
+        raise AssertionError("streaming path is not used in this test")
+
+
+class BudgetScenarioClient:
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+        self.closed = False
+
+    async def handle_tool_call(self, func_name, func_args, session_id=None):
+        self.calls.append(func_name)
+        if func_name == "discover":
+            return {"search_id": "s1", "results": [{"tool_id": "pricey.tool.v1", "expected_cost": "50"}]}, False, True
+        if func_name == "call":
+            return {"execution_id": "e1", "success": True, "billing": {"list_amount_credits": 50}}, False, True
+        return None, False, False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _run_budget_agent(budget_credits):
+    agent = Agent(
+        config=QverisConfig(api_key="sk-test", max_iterations=4),
+        agent_config=AgentConfig(model="unit-test-model"),
+        llm_provider=BudgetScenarioLLM(),
+        budget_credits=budget_credits,
+    )
+    await agent.client.close()
+    client = BudgetScenarioClient()
+    agent.client = client
+    try:
+        events = [
+            event
+            async for event in agent.run([Message(role="user", content="do it")], stream=False)
+        ]
+    finally:
+        await agent.close()
+    return agent, client, events
+
+
+@pytest.mark.asyncio
+async def test_agent_blocks_call_over_budget_without_executing() -> None:
+    agent, client, events = await _run_budget_agent(budget_credits=10)
+
+    # The call was blocked before reaching the client — only discover ran.
+    assert client.calls == ["discover"]
+    types = [event.type for event in events]
+    assert "budget_exceeded" in types
+
+    exceeded = next(event for event in events if event.type == "budget_exceeded")
+    assert exceeded.budget["tool_id"] == "pricey.tool.v1"
+    assert exceeded.budget["estimated"] == 50.0
+    assert exceeded.budget["limit"] == 10
+
+    # Nothing was spent; state is queryable.
+    assert agent.budget_status() == {"limit": 10, "spent": 0.0, "remaining": 10}
+
+    # The model still gets a tool result explaining the block.
+    tool_result = next(
+        event.tool_result for event in events if event.type == "tool_result" and event.tool_result["name"] == "call"
+    )
+    assert tool_result["is_error"] is True
+    assert tool_result["result"]["error"] == "budget_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_agent_executes_and_records_within_budget_call() -> None:
+    agent, client, events = await _run_budget_agent(budget_credits=100)
+
+    # Within budget: the call executed and spend was recorded.
+    assert client.calls == ["discover", "call"]
+    assert agent.budget_status() == {"limit": 100, "spent": 50.0, "remaining": 50.0}
+    assert "budget_exceeded" not in [event.type for event in events]
+
+
+@pytest.mark.asyncio
+async def test_agent_without_budget_is_unchanged() -> None:
+    agent, client, events = await _run_budget_agent(budget_credits=None)
+
+    # No budget: default behavior, call executes, no budget events, no status.
+    assert client.calls == ["discover", "call"]
+    assert agent.budget_status() is None
+    assert "budget_exceeded" not in [event.type for event in events]
+    assert "budget_warning" not in [event.type for event in events]

--- a/packages/python-sdk/tests/test_budget.py
+++ b/packages/python-sdk/tests/test_budget.py
@@ -1,0 +1,95 @@
+from qveris import BudgetTracker
+from qveris.agent.budget import parse_credits
+
+
+def test_parse_credits_handles_str_number_and_rejects_bool_and_junk() -> None:
+    assert parse_credits("2.37") == 2.37
+    assert parse_credits(3) == 3.0
+    assert parse_credits(1.5) == 1.5
+    assert parse_credits(" 4 ") == 4.0
+    assert parse_credits(True) is None
+    assert parse_credits(None) is None
+    assert parse_credits("n/a") is None
+    assert parse_credits({}) is None
+
+
+def test_disabled_tracker_is_a_noop() -> None:
+    b = BudgetTracker(None)
+    assert b.enabled is False
+    assert b.remaining is None
+    b.observe({"results": [{"tool_id": "t", "expected_cost": "5"}]})
+    assert b.check("t") is None  # never blocks
+    assert b.record({"billing": {"list_amount_credits": 5}}) is None
+    assert b.spent == 0.0
+    assert b.snapshot() == {"limit": None, "spent": 0.0, "remaining": None}
+
+
+def test_observe_caches_expected_cost_from_str_and_number() -> None:
+    b = BudgetTracker(100)
+    b.observe(
+        {
+            "results": [
+                {"tool_id": "cheap", "expected_cost": "1"},
+                {"tool_id": "pricey", "expected_cost": 24.2},
+                {"tool_id": "nocost"},
+                "not-a-dict",
+            ]
+        }
+    )
+    assert b.estimate("cheap") == 1.0
+    assert b.estimate("pricey") == 24.2
+    assert b.estimate("nocost") is None
+    assert b.estimate("unknown") is None
+
+
+def test_check_blocks_only_when_projected_spend_exceeds_limit() -> None:
+    b = BudgetTracker(10)
+    b.observe({"results": [{"tool_id": "t", "expected_cost": "6"}]})
+
+    # Within budget: 0 + 6 <= 10 -> allowed.
+    assert b.check("t") is None
+
+    # Unknown cost is never blocked (cannot estimate).
+    assert b.check("unknown") is None
+
+    # After spending 5, a second 6-credit call (11 > 10) is blocked.
+    b.record({"billing": {"list_amount_credits": 5}})
+    block = b.check("t")
+    assert block is not None
+    assert block["estimated"] == 6.0
+    assert block["spent"] == 5.0
+    assert block["projected"] == 11.0
+    assert block["limit"] == 10
+
+
+def test_record_accumulates_charge_with_billing_precedence_and_cost_fallback() -> None:
+    b = BudgetTracker(100)
+    b.record({"billing": {"list_amount_credits": 3}})
+    assert b.spent == 3.0
+    # requested_amount_credits used when list is absent
+    b.record({"billing": {"requested_amount_credits": 2}})
+    assert b.spent == 5.0
+    # cost fallback when no billing
+    b.record({"cost": "4"})
+    assert b.spent == 9.0
+    # unparseable charge does not change spend
+    b.record({"cost": "n/a"})
+    assert b.spent == 9.0
+
+
+def test_record_emits_a_single_warning_at_the_threshold() -> None:
+    b = BudgetTracker(10, warn_ratio=0.8)
+    assert b.record({"cost": 5}) is None  # 5/10 < 0.8
+    warn = b.record({"cost": 3})  # 8/10 >= 0.8
+    assert warn is not None
+    assert warn["spent"] == 8.0
+    assert warn["remaining"] == 2.0
+    # No repeat warning on further spend.
+    assert b.record({"cost": 1}) is None
+
+
+def test_remaining_never_goes_negative() -> None:
+    b = BudgetTracker(5)
+    b.record({"cost": 8})
+    assert b.spent == 8.0
+    assert b.remaining == 0.0

--- a/packages/python-sdk/tests/test_budget.py
+++ b/packages/python-sdk/tests/test_budget.py
@@ -13,6 +13,30 @@ def test_parse_credits_handles_str_number_and_rejects_bool_and_junk() -> None:
     assert parse_credits({}) is None
 
 
+def test_parse_credits_rejects_non_finite() -> None:
+    assert parse_credits("inf") is None
+    assert parse_credits("nan") is None
+    assert parse_credits(float("inf")) is None
+    assert parse_credits(float("-inf")) is None
+    assert parse_credits(float("nan")) is None
+
+
+def test_non_finite_billing_does_not_poison_spend_or_disable_guard() -> None:
+    b = BudgetTracker(10)
+    b.observe({"results": [{"tool_id": "t", "expected_cost": "6"}]})
+
+    # A NaN/inf billing amount must be ignored, not accumulated into spent.
+    b.record({"billing": {"list_amount_credits": float("nan")}})
+    assert b.spent == 0.0
+    b.record({"billing": {"list_amount_credits": float("inf")}})
+    assert b.spent == 0.0
+
+    # Guard still functions after: real 5 spent, a 6-credit call (11 > 10) blocks.
+    b.record({"billing": {"list_amount_credits": 5}})
+    assert b.spent == 5.0
+    assert b.check("t") is not None
+
+
 def test_disabled_tracker_is_a_noop() -> None:
     b = BudgetTracker(None)
     assert b.enabled is False

--- a/packages/python-sdk/tests/test_budget.py
+++ b/packages/python-sdk/tests/test_budget.py
@@ -37,6 +37,31 @@ def test_non_finite_billing_does_not_poison_spend_or_disable_guard() -> None:
     assert b.check("t") is not None
 
 
+def test_observe_and_record_accept_pydantic_models_not_just_dicts() -> None:
+    from qveris import SearchResponse, ToolExecutionResponse
+
+    b = BudgetTracker(100)
+
+    # observe() fed a pydantic SearchResponse directly (not a model_dump() dict).
+    b.observe(
+        SearchResponse(
+            search_id="s1",
+            results=[{"tool_id": "t", "name": "T", "expected_cost": "6"}],
+        )
+    )
+    assert b.estimate("t") == 6.0
+
+    # record() fed a pydantic ToolExecutionResponse directly.
+    b.record(
+        ToolExecutionResponse(
+            execution_id="e1",
+            success=True,
+            billing={"list_amount_credits": 6},
+        )
+    )
+    assert b.spent == 6.0
+
+
 def test_disabled_tracker_is_a_noop() -> None:
     b = BudgetTracker(None)
     assert b.enabled is False


### PR DESCRIPTION
Advances #111. Turns the QVeris billing closed loop into a product feature: a cost-aware guard that bounds an autonomous agent's spend — something competitors without a pre-call cost estimate + settlement chain can't do.

## What

`Agent(budget_credits=N)` — the agent learns each capability's `expected_cost` from `discover`/`inspect`, and **blocks a `call` projected to exceed the budget before the request is sent**, emitting a `budget_exceeded` event so the model can pick a cheaper capability or stop. It accumulates actual spend from `call` billing and emits a single `budget_warning` near the limit.

```python
agent = Agent(budget_credits=25)
async for event in agent.run(messages):
    if event.type == "budget_exceeded":
        ...  # a call was blocked to stay within budget
agent.budget_status()   # {"limit": 25, "spent": 12.0, "remaining": 13.0} or None
```

## Design

- **`BudgetTracker`** (`qveris.agent.budget`, exported from `qveris`) — pure, network-free, unit-tested. `observe()` caches `expected_cost` per `tool_id`; `check()` returns a block payload when projected spend exceeds the limit; `record()` accumulates from `billing.list_amount_credits` (→ `requested_amount_credits` → `cost` fallback) and warns once at `warn_ratio` (0.8).
- **Agent integration** — pre-call guard wraps `handle_tool_call`; on block it skips execution, returns a structured `budget_exceeded` error to the model, and never sends the request.
- **`StreamEvent`** gains `budget_warning` / `budget_exceeded` types and a `budget` field (additive).

## Acceptance criteria (from #111)

- ✅ Over-budget `call` does not fire — integration test asserts the client only ever received `discover`, not `call`.
- ✅ Budget state queryable via `budget_status()`; `spent` is pre-settlement, reconcilable with `usage()`/`ledger()`.
- ✅ No `budget_credits` → behavior unchanged (test: `budget_status()` is `None`, no budget events, `call` executes).
- Unknown-cost capabilities are not blocked (cannot estimate) — documented.

## Test plan

- `compileall qveris examples` clean
- Full python-sdk suite: **42 passed** (7 `BudgetTracker` unit + 3 agent integration: over-budget-blocked-without-executing, within-budget-executes-and-records, no-budget-unchanged)
- `examples/budget_guard.py` offline demo run verified (cheap allowed, 24.2-credit tool blocked against a 10-credit budget)
- Docs: Budget guard section + event-table rows in `python-sdk.md` (en/zh/cn), examples tables updated