### PR TITLE
feat(cli): enhanced doctor/init diagnostics with actionable hints (#110)

### DIFF
--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -360,7 +360,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-自检诊断：验证 Node.js 版本、API 密钥配置、API 地址、API 连通性。
+面向首次调用的自检诊断：依次检查 Node.js 版本、API 密钥、区域，再用一次免费的 `discover` 探测覆盖连通性、密钥有效性、剩余积分，以及响应结构是否符合 CLI 合同。每项失败都会给出可执行的修复建议。诊断不消耗积分（discover 免费）。加 `--json` 输出机器可读结果。
 
 ### `qveris config`
 

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -411,10 +411,11 @@ qveris> exit
 
 ### `qveris doctor`
 
-Self-check diagnostics: verifies Node.js version, API key configuration, base URL, and API connectivity.
+Self-check diagnostics for a working first call. Checks Node.js version, API key, region, then a free `discover` probe covering connectivity, key validity, remaining credits, and response-shape conformance to the CLI contract. Each failure prints an actionable fix. Diagnostics consume no credits (discover is free). Add `--json` for machine-readable output.
 
 ```bash
 qveris doctor
+qveris doctor --json
 ```
 
 ### `qveris config`

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -364,7 +364,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-自检诊断：验证 Node.js 版本、API 密钥配置、API 地址、API 连通性。
+面向首次调用的自检诊断：依次检查 Node.js 版本、API 密钥、区域，再用一次免费的 `discover` 探测覆盖连通性、密钥有效性、剩余积分，以及响应结构是否符合 CLI 合同。每项失败都会给出可执行的修复建议。诊断不消耗积分（discover 免费）。加 `--json` 输出机器可读结果。
 
 ### `qveris config`
 

--- a/packages/cli/src/client/preflight.mjs
+++ b/packages/cli/src/client/preflight.mjs
@@ -1,5 +1,5 @@
 import { resolve } from "../config/resolve.mjs";
-import { resolveBaseUrl } from "../config/region.mjs";
+import { resolveBaseUrl, getSiteUrl } from "../config/region.mjs";
 import { discoverTools } from "./api.mjs";
 import { ERROR_CODES } from "../errors/codes.mjs";
 
@@ -50,7 +50,7 @@ export function localPreflight({ apiKeyFlag, baseUrlFlag, nodeVersion = process.
   const checks = [nodeCheck(nodeVersion)];
 
   const { value: apiKey, source } = resolve("api_key", apiKeyFlag);
-  if (!apiKey || !apiKey.trim()) {
+  if (!apiKey || typeof apiKey !== "string" || !apiKey.trim()) {
     checks.push(check("api_key", "fail", ERROR_CODES.AUTH_MISSING_KEY.message, ERROR_CODES.AUTH_MISSING_KEY.hint));
     return { checks, ok: false, apiKey: null, baseUrl: null, region: null };
   }
@@ -87,8 +87,9 @@ export async function runPreflight({
   try {
     response = await probe({ apiKey: local.apiKey, baseUrl: local.baseUrl });
   } catch (err) {
-    const hint = err.hint || (err.code ? ERROR_CODES[err.code]?.hint : null) || null;
-    checks.push(check(codeToName(err.code), "fail", err.message, hint));
+    // A diagnostic must never crash: anything (even a non-Error) can be thrown.
+    const hint = err?.hint || (err?.code ? ERROR_CODES[err.code]?.hint : null) || null;
+    checks.push(check(codeToName(err?.code), "fail", err?.message || String(err), hint));
     return { checks, ok: false, contractVersion: CLI_CONTRACT_VERSION };
   }
 
@@ -101,7 +102,7 @@ export async function runPreflight({
         "credits",
         positive ? "ok" : "warn",
         `${response.remaining_credits} credits remaining`,
-        positive ? null : "Purchase credits at https://qveris.ai/pricing",
+        positive ? null : `Purchase credits at ${getSiteUrl(local.region, local.baseUrl)}/pricing`,
       ),
     );
   }

--- a/packages/cli/src/client/preflight.mjs
+++ b/packages/cli/src/client/preflight.mjs
@@ -1,0 +1,122 @@
+import { resolve } from "../config/resolve.mjs";
+import { resolveBaseUrl } from "../config/region.mjs";
+import { discoverTools } from "./api.mjs";
+import { ERROR_CODES } from "../errors/codes.mjs";
+
+/**
+ * OpenAPI contract version the CLI is built against (docs/openapi info.version).
+ * A true server-vs-client version comparison depends on the backend exposing a
+ * runtime contract version (WonderfulValley/qveris-website#1684); until then we
+ * report this and verify the probe response conforms to the expected shape.
+ */
+export const CLI_CONTRACT_VERSION = "2026-05-12";
+
+/** Build a single diagnostic check result. */
+function check(name, status, detail, hint = null) {
+  return { name, status, detail, hint };
+}
+
+function maskKey(key) {
+  return key.length > 10 ? `${key.slice(0, 6)}...${key.slice(-4)}` : "***";
+}
+
+/** Node.js version check (>=18). */
+export function nodeCheck(nodeVersion = process.version) {
+  const major = parseInt(String(nodeVersion).replace(/^v/, ""), 10);
+  if (Number.isFinite(major) && major >= 18) {
+    return check("node", "ok", `Node.js ${nodeVersion}`);
+  }
+  return check("node", "fail", `Node.js ${nodeVersion} — requires >=18`, "Upgrade to Node.js 18 or newer");
+}
+
+/** Map a thrown CliError code to a friendlier check name. */
+function codeToName(code) {
+  if (code === "AUTH_INVALID_KEY") return "api_key_valid";
+  if (code === "CREDITS_INSUFFICIENT") return "credits";
+  return "connectivity";
+}
+
+async function defaultProbe({ apiKey, baseUrl }) {
+  // "test" matches the probe query login/whoami use to validate a key.
+  return discoverTools({ apiKey, baseUrl, query: "test", limit: 1, timeoutMs: 10000 });
+}
+
+/**
+ * No-network checks: Node version, API key presence, region resolution.
+ * Returns the checks plus the resolved apiKey/baseUrl for callers that continue
+ * on to network work (e.g. `qveris init`).
+ */
+export function localPreflight({ apiKeyFlag, baseUrlFlag, nodeVersion = process.version } = {}) {
+  const checks = [nodeCheck(nodeVersion)];
+
+  const { value: apiKey, source } = resolve("api_key", apiKeyFlag);
+  if (!apiKey || !apiKey.trim()) {
+    checks.push(check("api_key", "fail", ERROR_CODES.AUTH_MISSING_KEY.message, ERROR_CODES.AUTH_MISSING_KEY.hint));
+    return { checks, ok: false, apiKey: null, baseUrl: null, region: null };
+  }
+  checks.push(check("api_key", "ok", `API key configured (${maskKey(apiKey)} via ${source})`));
+
+  const { baseUrl, region, source: regionSource } = resolveBaseUrl({ baseUrlFlag, apiKey });
+  checks.push(check("region", "ok", `Region ${region} (${regionSource}) → ${baseUrl}`));
+
+  return { checks, ok: checks.every((c) => c.status !== "fail"), apiKey, baseUrl, region };
+}
+
+/**
+ * Full diagnostics: local checks plus a free `discover` probe that verifies
+ * connectivity, API-key validity, credits, and contract-shape conformance.
+ * The probe is free (discover is not billed) and injectable for testing.
+ *
+ * @returns {Promise<{checks: Array, ok: boolean, contractVersion: string}>}
+ */
+export async function runPreflight({
+  apiKeyFlag,
+  baseUrlFlag,
+  nodeVersion = process.version,
+  probe = defaultProbe,
+} = {}) {
+  const local = localPreflight({ apiKeyFlag, baseUrlFlag, nodeVersion });
+  const checks = [...local.checks];
+
+  // Without a key or with a failing local check we cannot probe safely.
+  if (!local.apiKey || local.checks.some((c) => c.status === "fail")) {
+    return { checks, ok: false, contractVersion: CLI_CONTRACT_VERSION };
+  }
+
+  let response;
+  try {
+    response = await probe({ apiKey: local.apiKey, baseUrl: local.baseUrl });
+  } catch (err) {
+    const hint = err.hint || (err.code ? ERROR_CODES[err.code]?.hint : null) || null;
+    checks.push(check(codeToName(err.code), "fail", err.message, hint));
+    return { checks, ok: false, contractVersion: CLI_CONTRACT_VERSION };
+  }
+
+  checks.push(check("connectivity", "ok", "API reachable — free discover probe, no credits used"));
+
+  if (typeof response?.remaining_credits === "number") {
+    const positive = response.remaining_credits > 0;
+    checks.push(
+      check(
+        "credits",
+        positive ? "ok" : "warn",
+        `${response.remaining_credits} credits remaining`,
+        positive ? null : "Purchase credits at https://qveris.ai/pricing",
+      ),
+    );
+  }
+
+  const shapeOk = response && typeof response.search_id === "string" && Array.isArray(response.results);
+  checks.push(
+    shapeOk
+      ? check("contract", "ok", `Response conforms to contract ${CLI_CONTRACT_VERSION}`)
+      : check(
+          "contract",
+          "warn",
+          `Unexpected response shape for contract ${CLI_CONTRACT_VERSION}`,
+          "Update the CLI: npm install -g @qverisai/cli@latest",
+        ),
+  );
+
+  return { checks, ok: checks.every((c) => c.status !== "fail"), contractVersion: CLI_CONTRACT_VERSION };
+}

--- a/packages/cli/src/commands/doctor.mjs
+++ b/packages/cli/src/commands/doctor.mjs
@@ -23,7 +23,12 @@ export async function runDoctor(flags) {
 
   console.log();
   if (ok) {
-    console.log(`  ${green("All checks passed.")}\n`);
+    const warned = checks.some((c) => c.status === "warn");
+    if (warned) {
+      console.log(`  ${yellow("All checks passed, with warnings.")} Review the ${yellow("!")} items above.\n`);
+    } else {
+      console.log(`  ${green("All checks passed.")}\n`);
+    }
   } else {
     console.log(`  ${red("Some checks failed.")} Fix the items above and re-run ${bold("qveris doctor")}.\n`);
     process.exitCode = 1;

--- a/packages/cli/src/commands/doctor.mjs
+++ b/packages/cli/src/commands/doctor.mjs
@@ -1,52 +1,31 @@
-import { resolve } from "../config/resolve.mjs";
-import { discoverTools } from "../client/api.mjs";
-import { resolveBaseUrl } from "../config/region.mjs";
-import { bold, green, red, dim, cyan } from "../output/colors.mjs";
+import { runPreflight } from "../client/preflight.mjs";
+import { bold, green, red, yellow, dim } from "../output/colors.mjs";
+
+const ICON = { ok: green("✓"), warn: yellow("!"), fail: red("✘") };
 
 export async function runDoctor(flags) {
-  console.log(`\n  ${bold("QVeris CLI Doctor")}\n`);
-  let allOk = true;
+  const { checks, ok, contractVersion } = await runPreflight({
+    apiKeyFlag: flags.apiKey,
+    baseUrlFlag: flags.baseUrl,
+  });
 
-  // Check Node.js version
-  const nodeVersion = process.version;
-  const major = parseInt(nodeVersion.slice(1), 10);
-  if (major >= 18) {
-    console.log(`  ${green("\u2713")} Node.js ${nodeVersion}`);
-  } else {
-    console.log(`  ${red("\u2718")} Node.js ${nodeVersion} -- requires >=18`);
-    allOk = false;
+  if (flags.json) {
+    console.log(JSON.stringify({ ok, contract_version: contractVersion, checks }, null, 2));
+    if (!ok) process.exitCode = 1;
+    return;
   }
 
-  // Check API key
-  const { value: apiKey, source } = resolve("api_key", flags.apiKey);
-  if (apiKey && apiKey.trim()) {
-    const masked = apiKey.slice(0, 6) + "..." + apiKey.slice(-4);
-    console.log(`  ${green("\u2713")} API key configured (${masked} via ${source})`);
-
-    // Show resolved region
-    const { baseUrl, region, source: regionSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl, apiKey });
-    console.log(`  ${green("\u2713")} Region: ${region} ${dim(`(${regionSource})`)} → ${dim(baseUrl)}`);
-
-    // Test connectivity
-    process.stderr.write(`  \u2026 Testing API connectivity...\r`);
-    try {
-      await discoverTools({ apiKey, baseUrl, query: "test", limit: 1, timeoutMs: 10000 });
-      console.log(`  ${green("\u2713")} API connectivity OK                `);
-    } catch (err) {
-      console.log(`  ${red("\u2718")} API connectivity failed: ${err.message}  `);
-      allOk = false;
-    }
-  } else {
-    console.log(`  ${red("\u2718")} No API key configured`);
-    console.log(`     Run ${cyan("qveris login")} or set QVERIS_API_KEY`);
-    allOk = false;
+  console.log(`\n  ${bold("QVeris CLI Doctor")}\n`);
+  for (const c of checks) {
+    console.log(`  ${ICON[c.status] || "-"} ${c.detail}`);
+    if (c.hint && c.status !== "ok") console.log(`     ${dim(c.hint)}`);
   }
 
   console.log();
-  if (allOk) {
+  if (ok) {
     console.log(`  ${green("All checks passed.")}\n`);
   } else {
-    console.log(`  ${red("Some checks failed.")}\n`);
+    console.log(`  ${red("Some checks failed.")} Fix the items above and re-run ${bold("qveris doctor")}.\n`);
     process.exitCode = 1;
   }
 }

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -1,5 +1,6 @@
 import { resolveApiKey } from "../client/auth.mjs";
 import { callTool, discoverTools, inspectToolsByIds } from "../client/api.mjs";
+import { nodeCheck } from "../client/preflight.mjs";
 import { resolve } from "../config/resolve.mjs";
 import { resolveBaseUrl } from "../config/region.mjs";
 import { CliError } from "../errors/handler.mjs";
@@ -15,6 +16,15 @@ const DEFAULT_MAX_RESPONSE_SIZE = 20480;
 export async function runInit(queryArg, flags) {
   const steps = [];
   const startedAt = Date.now();
+
+  // Fail fast (before any network work) on an unsupported Node.js version, with
+  // an actionable message — the same check `qveris doctor` surfaces.
+  const node = nodeCheck(process.version);
+  if (node.status === "fail") {
+    const err = new CliError("API_ERROR", node.detail);
+    err.hint = node.hint;
+    throw err;
+  }
 
   if (!flags.json) {
     console.log(`\n  ${bold("QVeris init")} ${dim("first-call wizard")}\n`);

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -21,9 +21,8 @@ export async function runInit(queryArg, flags) {
   // an actionable message — the same check `qveris doctor` surfaces.
   const node = nodeCheck(process.version);
   if (node.status === "fail") {
-    const err = new CliError("API_ERROR", node.detail);
-    err.hint = node.hint;
-    throw err;
+    // NODE_UNSUPPORTED carries EX_CONFIG (environment) semantics + the hint.
+    throw new CliError("NODE_UNSUPPORTED", node.detail);
   }
 
   if (!flags.json) {

--- a/packages/cli/src/errors/codes.mjs
+++ b/packages/cli/src/errors/codes.mjs
@@ -12,6 +12,11 @@ export const ERROR_CODES = {
     hint: "Run 'qveris login' or set QVERIS_API_KEY",
     exit: EX_CONFIG,
   },
+  NODE_UNSUPPORTED: {
+    message: "Unsupported Node.js version",
+    hint: "Upgrade to Node.js 18 or newer",
+    exit: EX_CONFIG,
+  },
   AUTH_INVALID_KEY: {
     message: "Authentication failed",
     hint: "Check your key at https://qveris.ai/account",

--- a/packages/cli/test/preflight.test.mjs
+++ b/packages/cli/test/preflight.test.mjs
@@ -42,6 +42,28 @@ test("runPreflight: zero credits warns (not fails) with a purchase hint", async 
   assert.match(credits.hint, /pricing/);
 });
 
+test("runPreflight: zero-credits hint is region-aware (CN key → qveris.cn)", async () => {
+  const probe = async () => ({ search_id: "s1", results: [], remaining_credits: 0 });
+  const { checks } = await runPreflight({ apiKeyFlag: "sk-cn-test", probe });
+
+  assert.match(byName(checks).credits.hint, /qveris\.cn\/pricing/);
+});
+
+test("runPreflight: a non-string API key is treated as missing, not crashed", async () => {
+  let probed = false;
+  const { checks, ok } = await runPreflight({
+    apiKeyFlag: 12345, // e.g. a numeric value parsed from config
+    probe: async () => {
+      probed = true;
+      return {};
+    },
+  });
+
+  assert.equal(ok, false);
+  assert.equal(probed, false);
+  assert.equal(byName(checks).api_key.status, "fail");
+});
+
 test("runPreflight: invalid key becomes an actionable fail from the error knowledge base", async () => {
   const probe = async () => {
     throw new CliError("AUTH_INVALID_KEY", "Authentication failed");

--- a/packages/cli/test/preflight.test.mjs
+++ b/packages/cli/test/preflight.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { runPreflight, nodeCheck, CLI_CONTRACT_VERSION } from "../src/client/preflight.mjs";
+import { CliError } from "../src/errors/handler.mjs";
+
+const byName = (checks) => Object.fromEntries(checks.map((c) => [c.name, c]));
+
+test("nodeCheck passes on >=18 and fails older with a hint", () => {
+  assert.equal(nodeCheck("v18.0.0").status, "ok");
+  assert.equal(nodeCheck("v22.3.1").status, "ok");
+  const old = nodeCheck("v16.20.0");
+  assert.equal(old.status, "fail");
+  assert.ok(old.hint);
+});
+
+test("runPreflight: healthy probe reports connectivity, credits, and contract conformance", async () => {
+  const probe = async () => ({ search_id: "s1", results: [{ tool_id: "t" }], remaining_credits: 42 });
+  const { checks, ok, contractVersion } = await runPreflight({ apiKeyFlag: "sk-test", probe });
+
+  assert.equal(ok, true);
+  assert.equal(contractVersion, CLI_CONTRACT_VERSION);
+  const c = byName(checks);
+  assert.equal(c.node.status, "ok");
+  assert.equal(c.api_key.status, "ok");
+  assert.equal(c.connectivity.status, "ok");
+  assert.equal(c.credits.status, "ok");
+  assert.match(c.credits.detail, /42 credits/);
+  assert.equal(c.contract.status, "ok");
+});
+
+test("runPreflight: zero credits warns (not fails) with a purchase hint", async () => {
+  const probe = async () => ({ search_id: "s1", results: [], remaining_credits: 0 });
+  const { checks, ok } = await runPreflight({ apiKeyFlag: "sk-test", probe });
+
+  assert.equal(ok, true); // warn does not fail the run
+  const credits = byName(checks).credits;
+  assert.equal(credits.status, "warn");
+  assert.match(credits.hint, /pricing/);
+});
+
+test("runPreflight: invalid key becomes an actionable fail from the error knowledge base", async () => {
+  const probe = async () => {
+    throw new CliError("AUTH_INVALID_KEY", "Authentication failed");
+  };
+  const { checks, ok } = await runPreflight({ apiKeyFlag: "sk-bad", probe });
+
+  assert.equal(ok, false);
+  const fail = checks.find((x) => x.status === "fail");
+  assert.equal(fail.name, "api_key_valid");
+  assert.ok(fail.hint); // ERROR_CODES.AUTH_INVALID_KEY.hint
+});
+
+test("runPreflight: insufficient credits maps to a credits fail with pricing hint", async () => {
+  const probe = async () => {
+    const err = new CliError("CREDITS_INSUFFICIENT", "Insufficient credits");
+    err.hint = "Purchase credits at https://qveris.ai/pricing";
+    throw err;
+  };
+  const { checks, ok } = await runPreflight({ apiKeyFlag: "sk-test", probe });
+
+  assert.equal(ok, false);
+  const fail = checks.find((x) => x.status === "fail");
+  assert.equal(fail.name, "credits");
+  assert.match(fail.hint, /pricing/);
+});
+
+test("runPreflight: timeout maps to a connectivity fail with a hint", async () => {
+  const probe = async () => {
+    throw new CliError("NET_TIMEOUT");
+  };
+  const { checks, ok } = await runPreflight({ apiKeyFlag: "sk-test", probe });
+
+  assert.equal(ok, false);
+  const fail = checks.find((x) => x.status === "fail");
+  assert.equal(fail.name, "connectivity");
+  assert.ok(fail.hint);
+});
+
+test("runPreflight: unexpected response shape warns about contract drift", async () => {
+  const probe = async () => ({ unexpected: true }); // no search_id / results
+  const { checks } = await runPreflight({ apiKeyFlag: "sk-test", probe });
+
+  const contract = byName(checks).contract;
+  assert.equal(contract.status, "warn");
+  assert.ok(contract.hint);
+});
+
+test("runPreflight: missing key fails before probing (no network)", async () => {
+  const prev = {
+    key: process.env.QVERIS_API_KEY,
+    base: process.env.QVERIS_BASE_URL,
+    xdg: process.env.XDG_CONFIG_HOME,
+  };
+  const dir = mkdtempSync(join(tmpdir(), "qveris-preflight-"));
+  process.env.XDG_CONFIG_HOME = dir;
+  delete process.env.QVERIS_API_KEY;
+  delete process.env.QVERIS_BASE_URL;
+
+  let probed = false;
+  try {
+    const { checks, ok } = await runPreflight({
+      probe: async () => {
+        probed = true;
+        return {};
+      },
+    });
+
+    assert.equal(ok, false);
+    assert.equal(probed, false); // never probes without a key
+    const keyCheck = byName(checks).api_key;
+    assert.equal(keyCheck.status, "fail");
+    assert.ok(keyCheck.hint);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    for (const [k, v] of [
+      ["QVERIS_API_KEY", prev.key],
+      ["QVERIS_BASE_URL", prev.base],
+      ["XDG_CONFIG_HOME", prev.xdg],
+    ]) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});

--- a/packages/cli/test/preflight.test.mjs
+++ b/packages/cli/test/preflight.test.mjs
@@ -80,6 +80,35 @@ test("runPreflight: timeout maps to a connectivity fail with a hint", async () =
   assert.ok(fail.hint);
 });
 
+test("runPreflight: a non-CliError probe rejection degrades gracefully (no crash, no undefined)", async () => {
+  const probe = async () => {
+    throw new TypeError("socket hang up");
+  };
+  const { checks, ok } = await runPreflight({ apiKeyFlag: "sk-test", probe });
+
+  assert.equal(ok, false);
+  const fail = checks.find((x) => x.status === "fail");
+  assert.equal(fail.name, "connectivity");
+  assert.equal(fail.detail, "socket hang up");
+  assert.equal(fail.hint, null);
+});
+
+test("runPreflight: an unsupported Node version short-circuits before probing", async () => {
+  let probed = false;
+  const { checks, ok } = await runPreflight({
+    apiKeyFlag: "sk-test",
+    nodeVersion: "v16.0.0",
+    probe: async () => {
+      probed = true;
+      return { search_id: "s", results: [] };
+    },
+  });
+
+  assert.equal(ok, false);
+  assert.equal(probed, false); // never probes on an unsupported runtime
+  assert.equal(byName(checks).node.status, "fail");
+});
+
 test("runPreflight: unexpected response shape warns about contract drift", async () => {
   const probe = async () => ({ unexpected: true }); // no search_id / results
   const { checks } = await runPreflight({ apiKeyFlag: "sk-test", probe });


### PR DESCRIPTION
Closes #110 (the repo-side scope). Advances #65.

## Before / after

`qveris doctor` was a 4-check script that printed raw `err.message` on failure:

```
✓ Node.js v24
✓ API key configured
✓ Region global
✘ API connectivity failed: HTTP 402: ...
```

Now it's a real first-call diagnostic with actionable, knowledge-base hints:

```
✓ Node.js v24.2.0
✓ API key configured (sk-aYg...xHkY via env)
✓ Region global (auto (key prefix)) → https://qveris.ai/api/v1
✓ API reachable — free discover probe, no credits used
✓ 904817 credits remaining
✓ Response conforms to contract 2026-05-12
```

## What

- **`src/client/preflight.mjs`** — a shared diagnostic with an injectable probe. Checks Node version → API key presence → region resolution → a **free `discover` probe** covering connectivity, API-key validity, credits, and contract-shape conformance. Every failure carries an actionable hint pulled from the existing error knowledge base (`errors/codes.mjs`): invalid key, insufficient credits (with pricing link), rate limit, timeout, etc.
- **`doctor`** — renders the checks; adds `--json` for agents; reports remaining credits + the CLI contract version. Diagnostics consume **no credits** (discover is free) and say so.
- **`init`** — fails fast on an unsupported Node version with the same check before any network work (key/region were already handled with hints via the error KB).

## Acceptance criteria (#110)

- ✅ Each check failure pinpoints the stage with a fix suggestion (from the error KB).
- ✅ Diagnostics don't consume credits — the probe is `discover` (free), stated in the output.
- ✅ `init` reuses the checks (Node guard up front; key/region/connectivity already actionable).
- ⏳ True contract-**version** match depends on the backend exposing a runtime version — filed as WonderfulValley/qveris-website#1684. Until then the check verifies response-shape conformance + reports the CLI contract version (honest, not a false guarantee).

## Test plan

- `test/preflight.test.mjs` (8 tests): healthy probe, zero-credits warn, invalid-key fail, insufficient-credits fail, timeout fail, contract-drift warn, missing-key-no-probe — all via an injected probe (no network).
- Full CLI suite: **69 passed**.
- Live: `qveris doctor` and `qveris doctor --json` verified against production (6 checks, credits + contract shown).

No version bump — released via a later `cli-v*` tag.