### PR TITLE
feat(python-sdk): LangChain framework adapter (#109)

### DIFF
--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -259,6 +259,27 @@ if handled and not is_error:
     ...  # 把 result 回传给模型
 ```
 
+### 框架集成
+
+把 QVeris 的 discover/inspect/call 工作流暴露为主流 Agent 框架的工具。适配器惰性导入各自框架，因此基础 `qveris` 包不依赖它们。
+
+**LangChain**
+
+```bash
+pip install qveris[langchain]
+```
+
+```python
+from qveris import QverisClient
+from qveris.integrations.langchain import get_qveris_tools
+
+client = QverisClient()
+tools = get_qveris_tools(client)  # 3 个异步工具：qveris_discover / qveris_inspect / qveris_call
+# 把 `tools` 绑定到 LangChain 或 LangGraph agent，用完 `await client.close()`
+```
+
+工具是异步的（用 `ainvoke` / 异步 agent executor）。更多适配器（CrewAI、OpenAI Agents SDK）在路线图中。
+
 ### 自定义 LLM provider
 
 默认 `Agent()` 使用内置的 OpenAI 兼容 provider。如需对接其他模型 API，实现 `LLMProvider` 并传入：
@@ -300,6 +321,7 @@ agent = Agent(llm_provider=MyProvider())
 | `explainable_routing.py` | 基于 `why_recommended` / `expected_cost` 的成本感知能力选型 |
 | `budget_guard.py` | 用 `Agent(budget_credits=...)` 设置会话级积分预算 |
 | `agent_loop_integration.py` | LLM agent 循环集成 |
+| `langchain_integration.py` | 把 QVeris 能力作为 LangChain 工具（`qveris[langchain]`） |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。运行前请确保已设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1`。
 

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -253,6 +253,27 @@ if handled and not is_error:
     ...  # feed result back to your model
 ```
 
+### Framework integrations
+
+Expose the QVeris discover/inspect/call workflow as tools for popular agent frameworks. Adapters import their framework lazily, so the base `qveris` package never depends on them.
+
+**LangChain**
+
+```bash
+pip install qveris[langchain]
+```
+
+```python
+from qveris import QverisClient
+from qveris.integrations.langchain import get_qveris_tools
+
+client = QverisClient()
+tools = get_qveris_tools(client)  # 3 async tools: qveris_discover / qveris_inspect / qveris_call
+# bind `tools` to a LangChain or LangGraph agent, then `await client.close()` when done
+```
+
+The tools are async (use `ainvoke` / an async agent executor). More adapters (CrewAI, OpenAI Agents SDK) are on the roadmap.
+
 ### Custom LLM providers
 
 The default `Agent()` uses the built-in OpenAI-compatible provider. For other model APIs, implement `LLMProvider` and pass it in:
@@ -294,6 +315,7 @@ Runnable examples live under [`packages/python-sdk/examples/`](https://github.co
 | `explainable_routing.py` | Cost-aware capability selection with `why_recommended` / `expected_cost` |
 | `budget_guard.py` | Per-session credit budget with `Agent(budget_credits=...)` |
 | `agent_loop_integration.py` | LLM agent loop integration |
+| `langchain_integration.py` | QVeris capabilities as LangChain tools (`qveris[langchain]`) |
 
 Capability examples run `discover`/`inspect` when `QVERIS_API_KEY` is set, and only execute `call` when `RUN_QVERIS_CALLS=1`.
 

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -253,6 +253,27 @@ if handled and not is_error:
     ...  # 把 result 回传给模型
 ```
 
+### 框架集成
+
+把 QVeris 的 discover/inspect/call 工作流暴露为主流 Agent 框架的工具。适配器惰性导入各自框架，因此基础 `qveris` 包不依赖它们。
+
+**LangChain**
+
+```bash
+pip install qveris[langchain]
+```
+
+```python
+from qveris import QverisClient
+from qveris.integrations.langchain import get_qveris_tools
+
+client = QverisClient()
+tools = get_qveris_tools(client)  # 3 个异步工具：qveris_discover / qveris_inspect / qveris_call
+# 把 `tools` 绑定到 LangChain 或 LangGraph agent，用完 `await client.close()`
+```
+
+工具是异步的（用 `ainvoke` / 异步 agent executor）。更多适配器（CrewAI、OpenAI Agents SDK）在路线图中。
+
 ### 自定义 LLM provider
 
 默认 `Agent()` 使用内置的 OpenAI 兼容 provider。如需对接其他模型 API，实现 `LLMProvider` 并传入：
@@ -294,6 +315,7 @@ agent = Agent(llm_provider=MyProvider())
 | `explainable_routing.py` | 基于 `why_recommended` / `expected_cost` 的成本感知能力选型 |
 | `budget_guard.py` | 用 `Agent(budget_credits=...)` 设置会话级积分预算 |
 | `agent_loop_integration.py` | LLM agent 循环集成 |
+| `langchain_integration.py` | 把 QVeris 能力作为 LangChain 工具（`qveris[langchain]`） |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -153,7 +153,7 @@ agent = Agent(llm_provider=MyProvider())
 
 ## Examples
 
-Seven runnable examples are included under [`examples/`](examples):
+Eight runnable examples are included under [`examples/`](examples):
 
 | Example | Scenario |
 |---------|----------|
@@ -164,6 +164,7 @@ Seven runnable examples are included under [`examples/`](examples):
 | `explainable_routing.py` | Cost-aware capability selection with `why_recommended` / `expected_cost` |
 | `budget_guard.py` | Per-session credit budget with `Agent(budget_credits=...)` |
 | `agent_loop_integration.py` | LLM agent loop integration |
+| `langchain_integration.py` | QVeris capabilities as LangChain tools (`qveris[langchain]`) |
 
 The capability examples run `discover` and `inspect` when `QVERIS_API_KEY` is set. They only execute `call` when `RUN_QVERIS_CALLS=1` is set.
 

--- a/packages/python-sdk/examples/langchain_integration.py
+++ b/packages/python-sdk/examples/langchain_integration.py
@@ -1,0 +1,46 @@
+"""Use QVeris capabilities as LangChain tools.
+
+    pip install qveris[langchain]
+    export QVERIS_API_KEY="sk-..."
+    python langchain_integration.py
+
+`get_qveris_tools(client)` returns three async LangChain tools
+(qveris_discover / qveris_inspect / qveris_call). Bind them to any
+LangChain or LangGraph agent, e.g.:
+
+    from langgraph.prebuilt import create_react_agent
+    agent = create_react_agent(model, get_qveris_tools(client))
+
+This example invokes the discover tool directly (no LLM required) to show the
+tools work end to end.
+"""
+
+import asyncio
+import json
+import os
+
+from qveris import QverisClient
+from qveris.integrations.langchain import get_qveris_tools
+
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        tools = get_qveris_tools(client)
+        print("QVeris LangChain tools:", [t.name for t in tools])
+
+        if not os.getenv("QVERIS_API_KEY"):
+            print("Set QVERIS_API_KEY to invoke the tools.")
+            return
+
+        discover = next(t for t in tools if t.name == "qveris_discover")
+        result = json.loads(await discover.ainvoke({"query": "stock price market data API", "limit": 3}))
+        print(f"search_id: {result.get('search_id')}")
+        for r in (result.get("results") or [])[:3]:
+            print(f" - {r.get('tool_id')} | {(r.get('why_recommended') or '')[:60]}")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -19,11 +19,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# langchain-core requires Python >=3.9; the marker keeps the package resolvable
+# on 3.8 (the integration and its tests are simply unavailable there).
+langchain = [
+    "langchain-core>=0.3.0; python_version >= '3.9'",
+]
 dev = [
     "pytest",
     "pytest-asyncio",
     "python-dotenv",
     "rich>=13.0.0",
+    "langchain-core>=0.3.0; python_version >= '3.9'",  # for the LangChain integration tests
     # Pinned so regenerated models stay byte-stable with the checked-in
     # qveris/generated/openapi_models.py and the drift CI (issue #37 phase 2).
     "datamodel-code-generator==0.26.3",

--- a/packages/python-sdk/qveris/integrations/__init__.py
+++ b/packages/python-sdk/qveris/integrations/__init__.py
@@ -1,0 +1,10 @@
+"""Framework adapters for the QVeris SDK.
+
+Each adapter exposes the QVeris ``discover`` / ``inspect`` / ``call`` workflow as
+native tools for a third-party agent framework, backed by a ``QverisClient``.
+Adapters are optional and import their framework lazily, so the base ``qveris``
+package never depends on them.
+
+Available:
+    - :mod:`qveris.integrations.langchain` — LangChain tools (``pip install qveris[langchain]``)
+"""

--- a/packages/python-sdk/qveris/integrations/langchain.py
+++ b/packages/python-sdk/qveris/integrations/langchain.py
@@ -1,0 +1,127 @@
+"""LangChain adapter for QVeris.
+
+Exposes the QVeris ``discover`` / ``inspect`` / ``call`` workflow as LangChain
+tools, so an agent built on LangChain (or LangGraph) can find and invoke
+thousands of external capabilities through one QVeris API key.
+
+    pip install qveris[langchain]
+
+    from qveris import QverisClient
+    from qveris.integrations.langchain import get_qveris_tools
+
+    client = QverisClient()
+    tools = get_qveris_tools(client)   # 3 async LangChain tools
+    # bind `tools` to a LangChain / LangGraph agent, then close the client when done
+
+The tools are async (use ``ainvoke`` / an async agent executor). They return
+JSON strings — the same payloads the model sees in the built-in QVeris agent —
+and thread ``search_id`` from discover into inspect/call the way the tool
+descriptions instruct.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from ..client.api import QverisClient
+
+_INSTALL_HINT = (
+    "The LangChain integration requires 'langchain-core'. "
+    "Install it with: pip install qveris[langchain]"
+)
+
+
+class _DiscoverArgs(BaseModel):
+    query: str = Field(description="Capability query in natural language, e.g. 'weather forecast API'.")
+    limit: int = Field(default=20, description="Number of results to return (1-100).")
+
+
+class _InspectArgs(BaseModel):
+    tool_ids: List[str] = Field(description="Tool IDs returned by discover.")
+    search_id: Optional[str] = Field(default=None, description="The search_id from the discover response, if available.")
+
+
+class _CallArgs(BaseModel):
+    tool_id: str = Field(description="The capability tool_id, from discover or inspect.")
+    search_id: str = Field(description="The search_id from the discover response.")
+    params_to_tool: Dict[str, Any] = Field(description="Parameters to pass to the capability.")
+    max_response_size: Optional[int] = Field(
+        default=None, description="Max response size in bytes; -1 means unlimited."
+    )
+
+
+def get_qveris_tools(
+    client: Optional[QverisClient] = None,
+    *,
+    session_id: Optional[str] = None,
+) -> List[Any]:
+    """Return LangChain tools for the QVeris discover/inspect/call workflow.
+
+    Args:
+        client: A ``QverisClient`` to route calls through. If omitted, one is
+            created from the environment (``QVERIS_API_KEY``); you are then
+            responsible for closing it (``await client.close()``).
+        session_id: Optional session id for correlation/pricing context.
+
+    Returns:
+        A list of three async LangChain ``StructuredTool`` objects named
+        ``qveris_discover``, ``qveris_inspect``, and ``qveris_call``.
+
+    Raises:
+        ImportError: if ``langchain-core`` is not installed.
+    """
+    try:
+        from langchain_core.tools import StructuredTool
+    except ImportError as exc:  # pragma: no cover - exercised via install extras
+        raise ImportError(_INSTALL_HINT) from exc
+
+    qveris = client or QverisClient()
+
+    async def _route(name: str, args: Dict[str, Any]) -> str:
+        result, _is_error, _handled = await qveris.handle_tool_call(name, args, session_id=session_id)
+        return json.dumps(result, default=str)
+
+    async def _discover(query: str, limit: int = 20) -> str:
+        return await _route("discover", {"query": query, "limit": limit})
+
+    async def _inspect(tool_ids: List[str], search_id: Optional[str] = None) -> str:
+        return await _route("inspect", {"tool_ids": tool_ids, "search_id": search_id})
+
+    async def _call(
+        tool_id: str,
+        search_id: str,
+        params_to_tool: Dict[str, Any],
+        max_response_size: Optional[int] = None,
+    ) -> str:
+        args: Dict[str, Any] = {
+            "tool_id": tool_id,
+            "search_id": search_id,
+            "params_to_tool": params_to_tool,
+        }
+        if max_response_size is not None:
+            args["max_response_size"] = max_response_size
+        return await _route("call", args)
+
+    return [
+        StructuredTool.from_function(
+            coroutine=_discover,
+            name="qveris_discover",
+            description="Discover QVeris capabilities from a natural-language query. Free; returns candidates and a search_id.",
+            args_schema=_DiscoverArgs,
+        ),
+        StructuredTool.from_function(
+            coroutine=_inspect,
+            name="qveris_inspect",
+            description="Inspect one or more QVeris capabilities by tool_id before calling them. Free.",
+            args_schema=_InspectArgs,
+        ),
+        StructuredTool.from_function(
+            coroutine=_call,
+            name="qveris_call",
+            description="Call a selected QVeris capability with parameters. May consume credits.",
+            args_schema=_CallArgs,
+        ),
+    ]

--- a/packages/python-sdk/qveris/integrations/langchain.py
+++ b/packages/python-sdk/qveris/integrations/langchain.py
@@ -54,16 +54,16 @@ class _CallArgs(BaseModel):
 
 
 def get_qveris_tools(
-    client: Optional[QverisClient] = None,
+    client: QverisClient,
     *,
     session_id: Optional[str] = None,
 ) -> List[Any]:
     """Return LangChain tools for the QVeris discover/inspect/call workflow.
 
     Args:
-        client: A ``QverisClient`` to route calls through. If omitted, one is
-            created from the environment (``QVERIS_API_KEY``); you are then
-            responsible for closing it (``await client.close()``).
+        client: The ``QverisClient`` to route calls through. You own its
+            lifecycle — the tools hold a reference to it, so keep it open for
+            as long as the tools are used and ``await client.close()`` when done.
         session_id: Optional session id for correlation/pricing context.
 
     Returns:
@@ -78,7 +78,7 @@ def get_qveris_tools(
     except ImportError as exc:  # pragma: no cover - exercised via install extras
         raise ImportError(_INSTALL_HINT) from exc
 
-    qveris = client or QverisClient()
+    qveris = client
 
     async def _route(name: str, args: Dict[str, Any]) -> str:
         result, _is_error, _handled = await qveris.handle_tool_call(name, args, session_id=session_id)

--- a/packages/python-sdk/tests/test_langchain_integration.py
+++ b/packages/python-sdk/tests/test_langchain_integration.py
@@ -1,0 +1,75 @@
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+pytest.importorskip("langchain_core", reason="LangChain integration requires langchain-core (Python >=3.9)")
+
+from qveris.integrations.langchain import get_qveris_tools  # noqa: E402
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def handle_tool_call(
+        self, func_name: str, func_args: Dict[str, Any], session_id: Optional[str] = None
+    ) -> Tuple[Any, bool, bool]:
+        self.calls.append({"name": func_name, "args": func_args, "session_id": session_id})
+        if func_name == "discover":
+            return {"search_id": "s1", "results": [{"tool_id": "t1"}]}, False, True
+        if func_name == "inspect":
+            return {"results": [{"tool_id": "t1", "name": "T"}]}, False, True
+        return {"execution_id": "e1", "success": True}, False, True
+
+
+def test_get_qveris_tools_exposes_three_named_tools() -> None:
+    tools = get_qveris_tools(FakeClient())
+    assert [t.name for t in tools] == ["qveris_discover", "qveris_inspect", "qveris_call"]
+    for tool in tools:
+        assert tool.description
+        assert tool.args_schema is not None
+
+
+@pytest.mark.asyncio
+async def test_discover_tool_routes_to_handle_tool_call_and_returns_json() -> None:
+    client = FakeClient()
+    discover = next(t for t in get_qveris_tools(client, session_id="sess-1") if t.name == "qveris_discover")
+
+    out = await discover.ainvoke({"query": "weather forecast API", "limit": 3})
+
+    assert client.calls == [
+        {"name": "discover", "args": {"query": "weather forecast API", "limit": 3}, "session_id": "sess-1"}
+    ]
+    parsed = json.loads(out)
+    assert parsed["search_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_threads_ids_and_omits_absent_max_response_size() -> None:
+    client = FakeClient()
+    call = next(t for t in get_qveris_tools(client) if t.name == "qveris_call")
+
+    out = await call.ainvoke(
+        {"tool_id": "t1", "search_id": "s1", "params_to_tool": {"city": "London"}}
+    )
+
+    assert client.calls[0]["name"] == "call"
+    assert client.calls[0]["args"] == {
+        "tool_id": "t1",
+        "search_id": "s1",
+        "params_to_tool": {"city": "London"},
+    }
+    assert "max_response_size" not in client.calls[0]["args"]
+    assert json.loads(out)["execution_id"] == "e1"
+
+
+@pytest.mark.asyncio
+async def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
+    client = FakeClient()
+    inspect = next(t for t in get_qveris_tools(client) if t.name == "qveris_inspect")
+
+    await inspect.ainvoke({"tool_ids": ["t1", "t2"], "search_id": "s1"})
+
+    assert client.calls[0]["name"] == "inspect"
+    assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}


### PR DESCRIPTION
Advances #109 — the first framework adapter. Framework integrations are the main acquisition path for comparable platforms (Composio etc.); this makes QVeris a one-line tool backend for LangChain/LangGraph agents.

## What

`qveris.integrations.langchain.get_qveris_tools(client)` returns three **async** LangChain tools — `qveris_discover` / `qveris_inspect` / `qveris_call` — backed by a `QverisClient`. Bind them to a LangChain or LangGraph agent and the model can discover and call thousands of external capabilities through one QVeris key.

```python
from qveris import QverisClient
from qveris.integrations.langchain import get_qveris_tools

client = QverisClient()
tools = get_qveris_tools(client)
# create_react_agent(model, tools) ... then await client.close()
```

## Design

- **Lazy framework import** — the base `qveris` package never depends on langchain. `get_qveris_tools` imports `langchain_core` inside the call and raises an actionable `ImportError` (with the `pip install qveris[langchain]` hint) if it's missing. New optional extra: `[langchain]`.
- **Python floor preserved** — `langchain-core` requires 3.9+, but the SDK declares `>=3.8`. The extra pins `langchain-core>=0.3.0; python_version >= '3.9'` so uv/pip resolution stays valid on 3.8 (the integration is simply unavailable there); the tests `importorskip("langchain_core")`.
- **Reuses the proven bridge** — tools route through `client.handle_tool_call(...)` (same path as the built-in agent and the openclaw plugin), return JSON strings, and thread `search_id` from discover into inspect/call per the tool descriptions.

## Test plan

- `tests/test_langchain_integration.py` (importorskip): asserts the 3 named tools, and that discover/inspect/call route to `handle_tool_call` with correct args (incl. `search_id` threading and `max_response_size` omission when absent). Full suite **49 passed**.
- `compileall qveris examples` clean (adapter uses `from __future__ import annotations`; lazy import keeps 3.8 byte-compile safe).
- **Live**: `examples/langchain_integration.py` run against production — 3 tools created, `qveris_discover.ainvoke(...)` returns real capabilities with `why_recommended`.

## Follow-ups (kept under #109)

CrewAI, OpenAI Agents SDK, and Vercel AI SDK (TS, now that `@qverisai/sdk` exists) adapters in later PRs.