### PR TITLE
feat(python-sdk): OpenAI Agents SDK framework adapter (#109)

### DIFF
--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -278,7 +278,26 @@ tools = get_qveris_tools(client)  # 3 个异步工具：qveris_discover / qveris
 # 把 `tools` 绑定到 LangChain 或 LangGraph agent，用完 `await client.close()`
 ```
 
-工具是异步的（用 `ainvoke` / 异步 agent executor）。更多适配器（CrewAI、OpenAI Agents SDK）在路线图中。
+工具是异步的（用 `ainvoke` / 异步 agent executor）。
+
+**OpenAI Agents SDK**
+
+```bash
+pip install qveris[openai-agents]
+```
+
+```python
+from agents import Agent, Runner
+from qveris import QverisClient
+from qveris.integrations.openai_agents import get_qveris_tools
+
+client = QverisClient()
+agent = Agent(name="Assistant", tools=get_qveris_tools(client))
+result = await Runner.run(agent, "Find a stock quote capability and quote AAPL.")
+await client.close()
+```
+
+更多适配器（CrewAI、Vercel AI SDK）在路线图中。
 
 ### 自定义 LLM provider
 
@@ -322,6 +341,7 @@ agent = Agent(llm_provider=MyProvider())
 | `budget_guard.py` | 用 `Agent(budget_credits=...)` 设置会话级积分预算 |
 | `agent_loop_integration.py` | LLM agent 循环集成 |
 | `langchain_integration.py` | 把 QVeris 能力作为 LangChain 工具（`qveris[langchain]`） |
+| `openai_agents_integration.py` | 把 QVeris 能力作为 OpenAI Agents SDK 工具（`qveris[openai-agents]`） |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。运行前请确保已设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1`。
 

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -272,7 +272,26 @@ tools = get_qveris_tools(client)  # 3 async tools: qveris_discover / qveris_insp
 # bind `tools` to a LangChain or LangGraph agent, then `await client.close()` when done
 ```
 
-The tools are async (use `ainvoke` / an async agent executor). More adapters (CrewAI, OpenAI Agents SDK) are on the roadmap.
+The tools are async (use `ainvoke` / an async agent executor).
+
+**OpenAI Agents SDK**
+
+```bash
+pip install qveris[openai-agents]
+```
+
+```python
+from agents import Agent, Runner
+from qveris import QverisClient
+from qveris.integrations.openai_agents import get_qveris_tools
+
+client = QverisClient()
+agent = Agent(name="Assistant", tools=get_qveris_tools(client))
+result = await Runner.run(agent, "Find a stock quote capability and quote AAPL.")
+await client.close()
+```
+
+More adapters (CrewAI, Vercel AI SDK) are on the roadmap.
 
 ### Custom LLM providers
 
@@ -316,6 +335,7 @@ Runnable examples live under [`packages/python-sdk/examples/`](https://github.co
 | `budget_guard.py` | Per-session credit budget with `Agent(budget_credits=...)` |
 | `agent_loop_integration.py` | LLM agent loop integration |
 | `langchain_integration.py` | QVeris capabilities as LangChain tools (`qveris[langchain]`) |
+| `openai_agents_integration.py` | QVeris capabilities as OpenAI Agents SDK tools (`qveris[openai-agents]`) |
 
 Capability examples run `discover`/`inspect` when `QVERIS_API_KEY` is set, and only execute `call` when `RUN_QVERIS_CALLS=1`.
 

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -272,7 +272,26 @@ tools = get_qveris_tools(client)  # 3 个异步工具：qveris_discover / qveris
 # 把 `tools` 绑定到 LangChain 或 LangGraph agent，用完 `await client.close()`
 ```
 
-工具是异步的（用 `ainvoke` / 异步 agent executor）。更多适配器（CrewAI、OpenAI Agents SDK）在路线图中。
+工具是异步的（用 `ainvoke` / 异步 agent executor）。
+
+**OpenAI Agents SDK**
+
+```bash
+pip install qveris[openai-agents]
+```
+
+```python
+from agents import Agent, Runner
+from qveris import QverisClient
+from qveris.integrations.openai_agents import get_qveris_tools
+
+client = QverisClient()
+agent = Agent(name="Assistant", tools=get_qveris_tools(client))
+result = await Runner.run(agent, "Find a stock quote capability and quote AAPL.")
+await client.close()
+```
+
+更多适配器（CrewAI、Vercel AI SDK）在路线图中。
 
 ### 自定义 LLM provider
 
@@ -316,6 +335,7 @@ agent = Agent(llm_provider=MyProvider())
 | `budget_guard.py` | 用 `Agent(budget_credits=...)` 设置会话级积分预算 |
 | `agent_loop_integration.py` | LLM agent 循环集成 |
 | `langchain_integration.py` | 把 QVeris 能力作为 LangChain 工具（`qveris[langchain]`） |
+| `openai_agents_integration.py` | 把 QVeris 能力作为 OpenAI Agents SDK 工具（`qveris[openai-agents]`） |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -153,7 +153,7 @@ agent = Agent(llm_provider=MyProvider())
 
 ## Examples
 
-Eight runnable examples are included under [`examples/`](examples):
+Nine runnable examples are included under [`examples/`](examples):
 
 | Example | Scenario |
 |---------|----------|
@@ -165,6 +165,7 @@ Eight runnable examples are included under [`examples/`](examples):
 | `budget_guard.py` | Per-session credit budget with `Agent(budget_credits=...)` |
 | `agent_loop_integration.py` | LLM agent loop integration |
 | `langchain_integration.py` | QVeris capabilities as LangChain tools (`qveris[langchain]`) |
+| `openai_agents_integration.py` | QVeris capabilities as OpenAI Agents SDK tools (`qveris[openai-agents]`) |
 
 The capability examples run `discover` and `inspect` when `QVERIS_API_KEY` is set. They only execute `call` when `RUN_QVERIS_CALLS=1` is set.
 

--- a/packages/python-sdk/examples/openai_agents_integration.py
+++ b/packages/python-sdk/examples/openai_agents_integration.py
@@ -1,0 +1,42 @@
+"""Use QVeris capabilities as OpenAI Agents SDK tools.
+
+    pip install qveris[openai-agents]
+    export QVERIS_API_KEY="sk-..." OPENAI_API_KEY="sk-..."
+    python openai_agents_integration.py
+
+`get_qveris_tools(client)` returns three FunctionTools
+(qveris_discover / qveris_inspect / qveris_call) for an `agents.Agent`.
+"""
+
+import asyncio
+import os
+
+from qveris import QverisClient
+from qveris.integrations.openai_agents import get_qveris_tools
+
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        tools = get_qveris_tools(client)
+        print("QVeris OpenAI Agents tools:", [t.name for t in tools])
+
+        if not os.getenv("QVERIS_API_KEY") or not os.getenv("OPENAI_API_KEY"):
+            print("Set QVERIS_API_KEY and OPENAI_API_KEY to run the agent.")
+            return
+
+        from agents import Agent, Runner
+
+        agent = Agent(
+            name="QVeris Assistant",
+            instructions="Use the QVeris tools to discover, inspect, and call external capabilities.",
+            tools=tools,
+        )
+        result = await Runner.run(agent, "Find a stock quote capability and quote AAPL.")
+        print(result.final_output)
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -24,12 +24,18 @@ dependencies = [
 langchain = [
     "langchain-core>=0.3.0; python_version >= '3.9'",
 ]
+# openai-agents requires Python >=3.10; the marker keeps the package resolvable
+# on older interpreters (the integration and its tests are unavailable there).
+openai-agents = [
+    "openai-agents>=0.1.0; python_version >= '3.10'",
+]
 dev = [
     "pytest",
     "pytest-asyncio",
     "python-dotenv",
     "rich>=13.0.0",
     "langchain-core>=0.3.0; python_version >= '3.9'",  # for the LangChain integration tests
+    "openai-agents>=0.1.0; python_version >= '3.10'",  # for the OpenAI Agents integration tests
     # Pinned so regenerated models stay byte-stable with the checked-in
     # qveris/generated/openapi_models.py and the drift CI (issue #37 phase 2).
     "datamodel-code-generator==0.26.3",

--- a/packages/python-sdk/qveris/integrations/__init__.py
+++ b/packages/python-sdk/qveris/integrations/__init__.py
@@ -7,4 +7,5 @@ package never depends on them.
 
 Available:
     - :mod:`qveris.integrations.langchain` — LangChain tools (``pip install qveris[langchain]``)
+    - :mod:`qveris.integrations.openai_agents` — OpenAI Agents SDK tools (``pip install qveris[openai-agents]``)
 """

--- a/packages/python-sdk/qveris/integrations/openai_agents.py
+++ b/packages/python-sdk/qveris/integrations/openai_agents.py
@@ -86,23 +86,24 @@ def get_qveris_tools(
     @function_tool(strict_mode=False)
     async def qveris_call(
         tool_id: str,
-        search_id: str,
         params_to_tool: Dict[str, Any],
+        search_id: Optional[str] = None,
         max_response_size: Optional[int] = None,
     ) -> str:
         """Call a selected QVeris capability with parameters. May consume credits.
 
         Args:
             tool_id: The capability tool_id, from discover or inspect.
-            search_id: The search_id from the discover response.
             params_to_tool: Parameters to pass to the capability.
+            search_id: The search_id from the discover response, if available.
             max_response_size: Max response size in bytes; -1 means unlimited.
         """
         args: Dict[str, Any] = {
             "tool_id": tool_id,
-            "search_id": search_id,
             "params_to_tool": params_to_tool,
         }
+        if search_id is not None:
+            args["search_id"] = search_id
         if max_response_size is not None:
             args["max_response_size"] = max_response_size
         return await _route("call", args)

--- a/packages/python-sdk/qveris/integrations/openai_agents.py
+++ b/packages/python-sdk/qveris/integrations/openai_agents.py
@@ -1,0 +1,110 @@
+"""OpenAI Agents SDK adapter for QVeris.
+
+Exposes the QVeris ``discover`` / ``inspect`` / ``call`` workflow as OpenAI
+Agents SDK function tools, so an ``agents.Agent`` can find and invoke thousands
+of external capabilities through one QVeris API key.
+
+    pip install qveris[openai-agents]
+
+    from agents import Agent, Runner
+    from qveris import QverisClient
+    from qveris.integrations.openai_agents import get_qveris_tools
+
+    client = QverisClient()
+    agent = Agent(name="Assistant", tools=get_qveris_tools(client))
+    result = await Runner.run(agent, "Find a stock quote capability and quote AAPL.")
+    await client.close()
+
+Tool arguments and results mirror the built-in QVeris agent: discover returns a
+``search_id`` that inspect/call thread through. Tools return JSON strings.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from ..client.api import QverisClient
+
+_INSTALL_HINT = (
+    "The OpenAI Agents integration requires 'openai-agents'. "
+    "Install it with: pip install qveris[openai-agents]"
+)
+
+
+def get_qveris_tools(
+    client: QverisClient,
+    *,
+    session_id: Optional[str] = None,
+) -> List[Any]:
+    """Return OpenAI Agents SDK function tools for the QVeris workflow.
+
+    Args:
+        client: The ``QverisClient`` to route calls through. You own its
+            lifecycle — the tools hold a reference to it, so keep it open for
+            as long as the tools are used and ``await client.close()`` when done.
+        session_id: Optional session id for correlation/pricing context.
+
+    Returns:
+        A list of three ``FunctionTool`` objects named ``qveris_discover``,
+        ``qveris_inspect``, and ``qveris_call``.
+
+    Raises:
+        ImportError: if ``openai-agents`` is not installed.
+    """
+    try:
+        from agents import function_tool
+    except ImportError as exc:  # pragma: no cover - exercised via install extras
+        raise ImportError(_INSTALL_HINT) from exc
+
+    async def _route(name: str, args: Dict[str, Any]) -> str:
+        result, _is_error, _handled = await client.handle_tool_call(name, args, session_id=session_id)
+        return json.dumps(result, default=str)
+
+    @function_tool
+    async def qveris_discover(query: str, limit: int = 20) -> str:
+        """Discover QVeris capabilities from a natural-language query. Free.
+
+        Args:
+            query: Capability query in natural language, e.g. 'weather forecast API'.
+            limit: Number of results to return (1-100).
+        """
+        return await _route("discover", {"query": query, "limit": limit})
+
+    # strict_mode=False: these expose a free-form dict / optional params that a
+    # strict JSON schema cannot represent.
+    @function_tool(strict_mode=False)
+    async def qveris_inspect(tool_ids: List[str], search_id: Optional[str] = None) -> str:
+        """Inspect one or more QVeris capabilities by tool_id before calling them. Free.
+
+        Args:
+            tool_ids: Tool IDs returned by discover.
+            search_id: The search_id from the discover response, if available.
+        """
+        return await _route("inspect", {"tool_ids": tool_ids, "search_id": search_id})
+
+    @function_tool(strict_mode=False)
+    async def qveris_call(
+        tool_id: str,
+        search_id: str,
+        params_to_tool: Dict[str, Any],
+        max_response_size: Optional[int] = None,
+    ) -> str:
+        """Call a selected QVeris capability with parameters. May consume credits.
+
+        Args:
+            tool_id: The capability tool_id, from discover or inspect.
+            search_id: The search_id from the discover response.
+            params_to_tool: Parameters to pass to the capability.
+            max_response_size: Max response size in bytes; -1 means unlimited.
+        """
+        args: Dict[str, Any] = {
+            "tool_id": tool_id,
+            "search_id": search_id,
+            "params_to_tool": params_to_tool,
+        }
+        if max_response_size is not None:
+            args["max_response_size"] = max_response_size
+        return await _route("call", args)
+
+    return [qveris_discover, qveris_inspect, qveris_call]

--- a/packages/python-sdk/tests/test_openai_agents_integration.py
+++ b/packages/python-sdk/tests/test_openai_agents_integration.py
@@ -79,6 +79,17 @@ async def test_call_tool_threads_ids_and_omits_absent_max_response_size() -> Non
 
 
 @pytest.mark.asyncio
+async def test_call_tool_omits_absent_search_id() -> None:
+    client = FakeClient()
+    call = _tool(get_qveris_tools(client), "qveris_call")
+
+    await _invoke(call, {"tool_id": "t1", "params_to_tool": {}})
+
+    assert "search_id" not in client.calls[0]["args"]
+    assert client.calls[0]["args"] == {"tool_id": "t1", "params_to_tool": {}}
+
+
+@pytest.mark.asyncio
 async def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
     client = FakeClient()
     inspect = _tool(get_qveris_tools(client), "qveris_inspect")

--- a/packages/python-sdk/tests/test_openai_agents_integration.py
+++ b/packages/python-sdk/tests/test_openai_agents_integration.py
@@ -1,0 +1,89 @@
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+pytest.importorskip("agents", reason="OpenAI Agents integration requires openai-agents (Python >=3.10)")
+
+from agents.tool_context import ToolContext  # noqa: E402
+
+from qveris.integrations.openai_agents import get_qveris_tools  # noqa: E402
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def handle_tool_call(
+        self, func_name: str, func_args: Dict[str, Any], session_id: Optional[str] = None
+    ) -> Tuple[Any, bool, bool]:
+        self.calls.append({"name": func_name, "args": func_args, "session_id": session_id})
+        if func_name == "discover":
+            return {"search_id": "s1", "results": [{"tool_id": "t1"}]}, False, True
+        if func_name == "inspect":
+            return {"results": [{"tool_id": "t1"}]}, False, True
+        return {"execution_id": "e1", "success": True}, False, True
+
+
+def _tool(tools, name):
+    return next(t for t in tools if t.name == name)
+
+
+async def _invoke(tool, args: Dict[str, Any]) -> str:
+    ctx = ToolContext(
+        context=None,
+        tool_name=tool.name,
+        tool_call_id="call-1",
+        tool_arguments=json.dumps(args),
+    )
+    return await tool.on_invoke_tool(ctx, json.dumps(args))
+
+
+def test_get_qveris_tools_exposes_three_named_function_tools() -> None:
+    tools = get_qveris_tools(FakeClient())
+    assert [t.name for t in tools] == ["qveris_discover", "qveris_inspect", "qveris_call"]
+    props = {t.name: set(t.params_json_schema.get("properties", {})) for t in tools}
+    assert props["qveris_discover"] == {"query", "limit"}
+    assert props["qveris_inspect"] == {"tool_ids", "search_id"}
+    assert props["qveris_call"] == {"tool_id", "search_id", "params_to_tool", "max_response_size"}
+
+
+@pytest.mark.asyncio
+async def test_discover_tool_routes_to_handle_tool_call() -> None:
+    client = FakeClient()
+    discover = _tool(get_qveris_tools(client, session_id="sess-1"), "qveris_discover")
+
+    out = await _invoke(discover, {"query": "weather forecast API", "limit": 3})
+
+    assert client.calls == [
+        {"name": "discover", "args": {"query": "weather forecast API", "limit": 3}, "session_id": "sess-1"}
+    ]
+    assert json.loads(out)["search_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_threads_ids_and_omits_absent_max_response_size() -> None:
+    client = FakeClient()
+    call = _tool(get_qveris_tools(client), "qveris_call")
+
+    out = await _invoke(call, {"tool_id": "t1", "search_id": "s1", "params_to_tool": {"city": "London"}})
+
+    assert client.calls[0]["name"] == "call"
+    assert client.calls[0]["args"] == {
+        "tool_id": "t1",
+        "search_id": "s1",
+        "params_to_tool": {"city": "London"},
+    }
+    assert "max_response_size" not in client.calls[0]["args"]
+    assert json.loads(out)["execution_id"] == "e1"
+
+
+@pytest.mark.asyncio
+async def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
+    client = FakeClient()
+    inspect = _tool(get_qveris_tools(client), "qveris_inspect")
+
+    await _invoke(inspect, {"tool_ids": ["t1", "t2"], "search_id": "s1"})
+
+    assert client.calls[0]["name"] == "inspect"
+    assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}


### PR DESCRIPTION
Advances #109 — the second framework adapter. **Stacked on #132** (LangChain); base is `feat/langchain-adapter` so this diff shows only the OpenAI Agents changes. GitHub will retarget to `main` once #132 merges.

## What

`qveris.integrations.openai_agents.get_qveris_tools(client)` returns three async `FunctionTool`s — `qveris_discover` / `qveris_inspect` / `qveris_call` — for the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python).

```python
from agents import Agent, Runner
from qveris import QverisClient
from qveris.integrations.openai_agents import get_qveris_tools

client = QverisClient()
agent = Agent(name="Assistant", tools=get_qveris_tools(client))
result = await Runner.run(agent, "Find a stock quote capability and quote AAPL.")
await client.close()
```

## Design (verified empirically against `agents` 0.18)

- **Async-native** via `@function_tool`, which derives the JSON schema from the signature + docstring.
- **Strict-mode split** — `qveris_discover` (only `str`/`int`) uses the default strict schema; `qveris_inspect` / `qveris_call` use `strict_mode=False` because a free-form `params_to_tool: dict` / optional params can't be expressed in a strict JSON schema (strict mode raises `additionalProperties should not be set for object types` — I reproduced this before choosing the split).
- **Lazy import + optional extra** — base `qveris` never depends on `openai-agents`; `get_qveris_tools` raises an actionable `ImportError` if it's missing. The `[openai-agents]` extra is pinned `openai-agents>=0.1.0; python_version >= '3.10'` (the package's own floor is 3.10), keeping the SDK resolvable on its declared `>=3.8`.
- Reuses `client.handle_tool_call` and threads `search_id` — same proven bridge as the LangChain adapter and the built-in agent. Client is a **required** param (no leak, matching the #132 fix).

## Test plan

- `tests/test_openai_agents_integration.py` (importorskip `agents`): asserts the 3 named tools, their schema properties, and that discover/inspect/call route to `handle_tool_call` with correct args (incl. `search_id` threading + `max_response_size` omission), invoked through a real `ToolContext`. Full suite **53 passed**.
- `compileall qveris examples` clean (adapter uses `from __future__ import annotations`; lazy import → 3.8 byte-compile safe).
- `examples/openai_agents_integration.py` + Framework-integrations docs (en/zh/cn) + examples tables.

## Follow-ups (kept under #109)

CrewAI and Vercel AI SDK (TS) adapters.