### PR TITLE
feat(js-sdk): Vercel AI SDK framework adapter (#109)

### DIFF
--- a/docs/cn/zh-CN/js-sdk.md
+++ b/docs/cn/zh-CN/js-sdk.md
@@ -126,6 +126,33 @@ function explain(result: ExecuteResponse): string {
 
 类型化客户端天然可作为任何 LLM Agent 框架的工具后端：把 `discover` / `inspect` / `call` 作为工具暴露给模型，再把工具调用路由回客户端。由于 `discover` 返回 `why_recommended` 和 `expected_cost`，你的 Agent 可以在调用前对能力进行排序和预算控制。
 
+## 框架集成
+
+### Vercel AI SDK
+
+把 QVeris 工作流暴露为 [Vercel AI SDK](https://sdk.vercel.ai) 工具。`ai` 和 `zod` 是 peer 依赖（从 `@qverisai/sdk/ai` 子路径导入）：
+
+```bash
+npm install @qverisai/sdk ai zod
+```
+
+```typescript
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { Qveris } from '@qverisai/sdk';
+import { getQverisTools } from '@qverisai/sdk/ai';
+
+const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools: getQverisTools(qveris), // qveris_discover / qveris_inspect / qveris_call
+  maxSteps: 6,
+  prompt: 'Find a stock quote capability and quote AAPL.',
+});
+```
+
+[Python SDK](python-sdk.md) 还提供 LangChain 和 OpenAI Agents SDK 适配器。
+
 ## 错误处理
 
 每个失败请求都会抛出 `QverisApiError`——一个 `Error` 子类，携带：

--- a/docs/en-US/js-sdk.md
+++ b/docs/en-US/js-sdk.md
@@ -126,6 +126,33 @@ function explain(result: ExecuteResponse): string {
 
 The typed client is a natural tool backend for any LLM agent framework: expose `discover` / `inspect` / `call` as tools to your model, then route the tool calls back through the client. Because `discover` returns `why_recommended` and `expected_cost`, your agent can rank and budget capabilities before calling them.
 
+## Framework integrations
+
+### Vercel AI SDK
+
+Expose the QVeris workflow as [Vercel AI SDK](https://sdk.vercel.ai) tools. `ai` and `zod` are peer dependencies (import from the `@qverisai/sdk/ai` subpath):
+
+```bash
+npm install @qverisai/sdk ai zod
+```
+
+```typescript
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { Qveris } from '@qverisai/sdk';
+import { getQverisTools } from '@qverisai/sdk/ai';
+
+const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools: getQverisTools(qveris), // qveris_discover / qveris_inspect / qveris_call
+  maxSteps: 6,
+  prompt: 'Find a stock quote capability and quote AAPL.',
+});
+```
+
+The [Python SDK](python-sdk.md) ships LangChain and OpenAI Agents SDK adapters as well.
+
 ## Error handling
 
 Every failed request throws `QverisApiError` — an `Error` subclass carrying:

--- a/docs/zh-CN/js-sdk.md
+++ b/docs/zh-CN/js-sdk.md
@@ -126,6 +126,33 @@ function explain(result: ExecuteResponse): string {
 
 类型化客户端天然可作为任何 LLM 智能体框架的工具后端：把 `discover` / `inspect` / `call` 作为工具暴露给模型，再把工具调用路由回客户端。由于 `discover` 返回 `why_recommended` 和 `expected_cost`，你的智能体可以在调用前对能力进行排序和预算控制。
 
+## 框架集成
+
+### Vercel AI SDK
+
+把 QVeris 工作流暴露为 [Vercel AI SDK](https://sdk.vercel.ai) 工具。`ai` 和 `zod` 是 peer 依赖（从 `@qverisai/sdk/ai` 子路径导入）：
+
+```bash
+npm install @qverisai/sdk ai zod
+```
+
+```typescript
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { Qveris } from '@qverisai/sdk';
+import { getQverisTools } from '@qverisai/sdk/ai';
+
+const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools: getQverisTools(qveris), // qveris_discover / qveris_inspect / qveris_call
+  maxSteps: 6,
+  prompt: 'Find a stock quote capability and quote AAPL.',
+});
+```
+
+[Python SDK](python-sdk.md) 还提供 LangChain 和 OpenAI Agents SDK 适配器。
+
 ## 错误处理
 
 每个失败请求都会抛出 `QverisApiError`——一个 `Error` 子类，携带：

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -87,12 +87,13 @@ npm install @qverisai/sdk ai zod
 
 ```typescript
 import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
 import { Qveris } from '@qverisai/sdk';
 import { getQverisTools } from '@qverisai/sdk/ai';
 
 const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
 const { text } = await generateText({
-  model,
+  model: openai('gpt-4o'),
   tools: getQverisTools(qveris), // qveris_discover / qveris_inspect / qveris_call
   maxSteps: 6,
   prompt: 'Find a stock quote capability and quote AAPL.',

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -77,6 +77,28 @@ try {
 }
 ```
 
+## Framework integrations
+
+Expose the QVeris workflow as [Vercel AI SDK](https://sdk.vercel.ai) tools. `ai` and `zod` are peer dependencies:
+
+```bash
+npm install @qverisai/sdk ai zod
+```
+
+```typescript
+import { generateText } from 'ai';
+import { Qveris } from '@qverisai/sdk';
+import { getQverisTools } from '@qverisai/sdk/ai';
+
+const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+const { text } = await generateText({
+  model,
+  tools: getQverisTools(qveris), // qveris_discover / qveris_inspect / qveris_call
+  maxSteps: 6,
+  prompt: 'Find a stock quote capability and quote AAPL.',
+});
+```
+
 ## Version history note
 
 Versions `0.1.x` of this npm package were an early MCP-focused SDK, since superseded by [`@qverisai/mcp`](https://www.npmjs.com/package/@qverisai/mcp). The typed REST client documented here starts at **`0.2.0`**.

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -10,11 +10,75 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.1",
+        "ai": "^7.0.0",
         "typescript": "^5.7.2",
-        "vitest": "^2.1.0"
+        "vitest": "^2.1.0",
+        "zod": "^4.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "ai": ">=4.0.0",
+        "zod": ">=3.23.0"
+      },
+      "peerDependenciesMeta": {
+        "ai": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.13.tgz",
+      "integrity": "sha512-EIiMZZMEAc3yZ3nywrJfKigrkaNwqrQgGsj0QbQ6x3Y73MlQe68EElR2cm/8I5dvBci3PFyahMRe3NwR8OOb9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.2.tgz",
+      "integrity": "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.5.tgz",
+      "integrity": "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -765,6 +829,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -780,6 +851,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vitest/expect": {
@@ -893,6 +974,31 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/ai": {
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.17.tgz",
+      "integrity": "sha512-kpIjNtN0tyUaxzkAs7b8YF48WZzc71dKu0HqFPSAWg/avu1Ogv50UPE9hpVMr+kb33zsEa6LrAU9DZHMNscvzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.13",
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/assertion-error": {
@@ -1026,6 +1132,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -1050,6 +1166,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1452,6 +1575,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -29,6 +29,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./ai": {
+      "types": "./dist/integrations/ai.d.ts",
+      "default": "./dist/integrations/ai.js"
     }
   },
   "files": [
@@ -42,10 +46,24 @@
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit"
   },
+  "peerDependencies": {
+    "ai": ">=4.0.0",
+    "zod": ">=3.23.0"
+  },
+  "peerDependenciesMeta": {
+    "ai": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^22.10.1",
+    "ai": "^7.0.0",
     "typescript": "^5.7.2",
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.0",
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/js-sdk/src/integrations/ai.test.ts
+++ b/packages/js-sdk/src/integrations/ai.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { getQverisTools } from './ai.js';
+
+class FakeQveris {
+  calls: Array<Record<string, unknown>> = [];
+
+  async discover(query: string, options: Record<string, unknown> = {}) {
+    this.calls.push({ method: 'discover', query, options });
+    return { search_id: 's1', total: 1, results: [{ tool_id: 't1' }] };
+  }
+
+  async inspect(toolIds: string | string[], options: Record<string, unknown> = {}) {
+    this.calls.push({ method: 'inspect', toolIds, options });
+    return { search_id: 's1', total: 1, results: [{ tool_id: 't1' }] };
+  }
+
+  async call(toolId: string, options: Record<string, unknown>) {
+    this.calls.push({ method: 'call', toolId, options });
+    return { execution_id: 'e1', success: true };
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const invoke = (t: any, args: Record<string, unknown>) =>
+  t.execute(args, { toolCallId: 'c1', messages: [] });
+
+describe('getQverisTools (Vercel AI SDK)', () => {
+  it('exposes three named tools', () => {
+    const tools = getQverisTools(new FakeQveris() as never);
+    expect(Object.keys(tools)).toEqual(['qveris_discover', 'qveris_inspect', 'qveris_call']);
+    for (const key of Object.keys(tools) as Array<keyof typeof tools>) {
+      expect(tools[key].description).toBeTruthy();
+    }
+  });
+
+  it('discover routes to client.discover with limit and sessionId', async () => {
+    const client = new FakeQveris();
+    const tools = getQverisTools(client as never, { sessionId: 'sess-1' });
+
+    const out = await invoke(tools.qveris_discover, { query: 'weather forecast API', limit: 3 });
+
+    expect(client.calls[0]).toEqual({
+      method: 'discover',
+      query: 'weather forecast API',
+      options: { limit: 3, sessionId: 'sess-1' },
+    });
+    expect(out.search_id).toBe('s1');
+  });
+
+  it('call maps params_to_tool/search_id and omits max_response_size when absent', async () => {
+    const client = new FakeQveris();
+    const tools = getQverisTools(client as never);
+
+    const out = await invoke(tools.qveris_call, {
+      tool_id: 't1',
+      search_id: 's1',
+      params_to_tool: { city: 'London' },
+    });
+
+    expect(client.calls[0]).toEqual({
+      method: 'call',
+      toolId: 't1',
+      options: { parameters: { city: 'London' }, searchId: 's1' },
+    });
+    expect('maxResponseSize' in (client.calls[0].options as object)).toBe(false);
+    expect(out.execution_id).toBe('e1');
+  });
+
+  it('inspect passes tool_ids and searchId', async () => {
+    const client = new FakeQveris();
+    const tools = getQverisTools(client as never);
+
+    await invoke(tools.qveris_inspect, { tool_ids: ['t1', 't2'], search_id: 's1' });
+
+    expect(client.calls[0]).toEqual({
+      method: 'inspect',
+      toolIds: ['t1', 't2'],
+      options: { searchId: 's1' },
+    });
+  });
+});

--- a/packages/js-sdk/src/integrations/ai.test.ts
+++ b/packages/js-sdk/src/integrations/ai.test.ts
@@ -67,6 +67,25 @@ describe('getQverisTools (Vercel AI SDK)', () => {
     expect(out.execution_id).toBe('e1');
   });
 
+  it('throws when given no valid client', () => {
+    expect(() => getQverisTools(undefined as never)).toThrow(TypeError);
+    expect(() => getQverisTools({} as never)).toThrow(/valid Qveris client/);
+  });
+
+  it('call omits search_id when absent and defaults params to {}', async () => {
+    const client = new FakeQveris();
+    const tools = getQverisTools(client as never);
+
+    await invoke(tools.qveris_call, { tool_id: 't1' });
+
+    expect(client.calls[0]).toEqual({
+      method: 'call',
+      toolId: 't1',
+      options: { parameters: {} },
+    });
+    expect('searchId' in (client.calls[0].options as object)).toBe(false);
+  });
+
   it('inspect passes tool_ids and searchId', async () => {
     const client = new FakeQveris();
     const tools = getQverisTools(client as never);

--- a/packages/js-sdk/src/integrations/ai.ts
+++ b/packages/js-sdk/src/integrations/ai.ts
@@ -40,6 +40,14 @@ import type { Qveris } from '../client.js';
  *   `qveris_call`, ready to pass to `generateText`/`streamText`.
  */
 export function getQverisTools(qveris: Qveris, options: { sessionId?: string } = {}) {
+  if (
+    !qveris ||
+    typeof qveris.discover !== 'function' ||
+    typeof qveris.inspect !== 'function' ||
+    typeof qveris.call !== 'function'
+  ) {
+    throw new TypeError('getQverisTools requires a valid Qveris client instance.');
+  }
   const { sessionId } = options;
 
   return {
@@ -68,18 +76,21 @@ export function getQverisTools(qveris: Qveris, options: { sessionId?: string } =
       description: 'Call a selected QVeris capability with parameters. May consume credits.',
       inputSchema: z.object({
         tool_id: z.string().describe('The capability tool_id, from discover or inspect.'),
-        search_id: z.string().describe('The search_id from the discover response.'),
-        params_to_tool: z.record(z.string(), z.unknown()).describe('Parameters to pass to the capability.'),
+        params_to_tool: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe('Parameters to pass to the capability.'),
+        search_id: z.string().optional().describe('The search_id from the discover response, if available.'),
         max_response_size: z
           .number()
           .int()
           .optional()
           .describe('Max response size in bytes; -1 means unlimited.'),
       }),
-      execute: async ({ tool_id, search_id, params_to_tool, max_response_size }) =>
+      execute: async ({ tool_id, search_id, params_to_tool = {}, max_response_size }) =>
         qveris.call(tool_id, {
           parameters: params_to_tool,
-          searchId: search_id,
+          ...(search_id && { searchId: search_id }),
           ...(max_response_size !== undefined && { maxResponseSize: max_response_size }),
           ...(sessionId && { sessionId }),
         }),

--- a/packages/js-sdk/src/integrations/ai.ts
+++ b/packages/js-sdk/src/integrations/ai.ts
@@ -1,0 +1,88 @@
+/**
+ * Vercel AI SDK adapter for QVeris.
+ *
+ * Exposes the QVeris discover / inspect / call workflow as Vercel AI SDK tools,
+ * so an agent built with the `ai` package can find and invoke thousands of
+ * external capabilities through one QVeris API key.
+ *
+ * `ai` and `zod` are peer dependencies — install them alongside `@qverisai/sdk`.
+ *
+ * @example
+ * ```typescript
+ * import { generateText } from 'ai';
+ * import { openai } from '@ai-sdk/openai';
+ * import { Qveris } from '@qverisai/sdk';
+ * import { getQverisTools } from '@qverisai/sdk/ai';
+ *
+ * const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+ * const { text } = await generateText({
+ *   model: openai('gpt-4o'),
+ *   tools: getQverisTools(qveris),
+ *   maxSteps: 6,
+ *   prompt: 'Find a stock quote capability and quote AAPL.',
+ * });
+ * ```
+ *
+ * @module @qverisai/sdk/ai
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+
+import type { Qveris } from '../client.js';
+
+/**
+ * Build Vercel AI SDK tools for the QVeris discover/inspect/call workflow.
+ *
+ * @param qveris - The Qveris client to route calls through.
+ * @param options - Optional `sessionId` for correlation/pricing context.
+ * @returns A tools object keyed by `qveris_discover` / `qveris_inspect` /
+ *   `qveris_call`, ready to pass to `generateText`/`streamText`.
+ */
+export function getQverisTools(qveris: Qveris, options: { sessionId?: string } = {}) {
+  const { sessionId } = options;
+
+  return {
+    qveris_discover: tool({
+      description:
+        'Discover QVeris capabilities from a natural-language query. Free; returns candidates and a search_id.',
+      inputSchema: z.object({
+        query: z.string().describe("Capability query, e.g. 'weather forecast API'."),
+        limit: z.number().int().min(1).max(100).optional().describe('Number of results (1-100).'),
+      }),
+      execute: async ({ query, limit }) =>
+        qveris.discover(query, { ...(limit !== undefined && { limit }), ...(sessionId && { sessionId }) }),
+    }),
+
+    qveris_inspect: tool({
+      description: 'Inspect one or more QVeris capabilities by tool_id before calling them. Free.',
+      inputSchema: z.object({
+        tool_ids: z.array(z.string()).describe('Tool IDs returned by discover.'),
+        search_id: z.string().optional().describe('The search_id from the discover response, if available.'),
+      }),
+      execute: async ({ tool_ids, search_id }) =>
+        qveris.inspect(tool_ids, { ...(search_id && { searchId: search_id }), ...(sessionId && { sessionId }) }),
+    }),
+
+    qveris_call: tool({
+      description: 'Call a selected QVeris capability with parameters. May consume credits.',
+      inputSchema: z.object({
+        tool_id: z.string().describe('The capability tool_id, from discover or inspect.'),
+        search_id: z.string().describe('The search_id from the discover response.'),
+        params_to_tool: z.record(z.string(), z.unknown()).describe('Parameters to pass to the capability.'),
+        max_response_size: z
+          .number()
+          .int()
+          .optional()
+          .describe('Max response size in bytes; -1 means unlimited.'),
+      }),
+      execute: async ({ tool_id, search_id, params_to_tool, max_response_size }) =>
+        qveris.call(tool_id, {
+          parameters: params_to_tool,
+          searchId: search_id,
+          ...(max_response_size !== undefined && { maxResponseSize: max_response_size }),
+          ...(sessionId && { sessionId }),
+        }),
+    }),
+  };
+}


### PR DESCRIPTION
Advances #109 — the third framework adapter and the **first in the TypeScript SDK**. Independent of the stacked Python adapters (#132/#133); branches off `main`.

## What

`@qverisai/sdk/ai` exposes `getQverisTools(qveris)` → `{ qveris_discover, qveris_inspect, qveris_call }` for the [Vercel AI SDK](https://sdk.vercel.ai), so an `ai`-based agent can find and call thousands of capabilities through one QVeris key.

```typescript
import { generateText } from 'ai';
import { openai } from '@ai-sdk/openai';
import { Qveris } from '@qverisai/sdk';
import { getQverisTools } from '@qverisai/sdk/ai';

const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
const { text } = await generateText({
  model: openai('gpt-4o'),
  tools: getQverisTools(qveris),
  maxSteps: 6,
  prompt: 'Find a stock quote capability and quote AAPL.',
});
```

## Design (verified against `ai` 7.x / `zod` 4.x)

- **New `./ai` subpath export** so the main `@qverisai/sdk` entry stays **zero-dependency** — only consumers who import `@qverisai/sdk/ai` pull in `ai`/`zod`.
- `ai` and `zod` are **optional peer dependencies** (`peerDependenciesMeta`), with devDeps for this package's build/test.
- Uses the current **`inputSchema`** key (I verified both `inputSchema` and the legacy `parameters` alias build, and used the modern one).
- Tools wrap `qveris.discover/inspect/call`, thread `search_id`, and omit `maxResponseSize` when absent; `execute` returns the typed response (the AI SDK serializes it).

## Test plan

- `src/integrations/ai.test.ts` (vitest): 3 named tools + discover/inspect/call routing through `tool.execute(args, ...)` with a fake client (asserts option mapping incl. `searchId`, `sessionId`, and `maxResponseSize` omission). `tsc --noEmit` clean, `tsc` build emits `dist/integrations/ai.js`. Full js-sdk suite **21 passed**.
- **Live**: built `./ai` subpath imported and `qveris_discover.execute(...)` run against production — returns real capabilities with `why_recommended`.

## Follow-ups (kept under #109)

CrewAI (Python). With LangChain (#132), OpenAI Agents SDK (#133), and Vercel AI SDK here, the three biggest agent frameworks are covered.