### PR TITLE
feat(python-sdk): CrewAI framework adapter (#109)

### DIFF
--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -306,14 +306,15 @@ pip install qveris[crewai]
 ```python
 from crewai import Agent
 from qveris import QverisClient
-from qveris.integrations.crewai import get_qveris_tools
+from qveris.integrations.crewai import get_qveris_tools, aclose
 
 client = QverisClient()
 agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
-# 运行你的 crew，然后 await client.close()
+# 同步运行你的 crew（crew.kickoff()），然后：
+aclose(client)
 ```
 
-CrewAI 同步执行工具；适配器内部桥接到异步 client。TypeScript SDK 提供 Vercel AI SDK 适配器。
+CrewAI 同步执行工具；适配器在一个专用事件循环上桥接到异步 client。由于 client 的连接绑定在该循环上，请用 `aclose(client)` 关闭（而非 `await client.close()`）。TypeScript SDK 提供 Vercel AI SDK 适配器。
 
 ### 自定义 LLM provider
 

--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -297,7 +297,23 @@ result = await Runner.run(agent, "Find a stock quote capability and quote AAPL."
 await client.close()
 ```
 
-更多适配器（CrewAI、Vercel AI SDK）在路线图中。
+**CrewAI**
+
+```bash
+pip install qveris[crewai]
+```
+
+```python
+from crewai import Agent
+from qveris import QverisClient
+from qveris.integrations.crewai import get_qveris_tools
+
+client = QverisClient()
+agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
+# 运行你的 crew，然后 await client.close()
+```
+
+CrewAI 同步执行工具；适配器内部桥接到异步 client。TypeScript SDK 提供 Vercel AI SDK 适配器。
 
 ### 自定义 LLM provider
 
@@ -342,6 +358,7 @@ agent = Agent(llm_provider=MyProvider())
 | `agent_loop_integration.py` | LLM agent 循环集成 |
 | `langchain_integration.py` | 把 QVeris 能力作为 LangChain 工具（`qveris[langchain]`） |
 | `openai_agents_integration.py` | 把 QVeris 能力作为 OpenAI Agents SDK 工具（`qveris[openai-agents]`） |
+| `crewai_integration.py` | 把 QVeris 能力作为 CrewAI 工具（`qveris[crewai]`） |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。运行前请确保已设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1`。
 

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -300,14 +300,15 @@ pip install qveris[crewai]
 ```python
 from crewai import Agent
 from qveris import QverisClient
-from qveris.integrations.crewai import get_qveris_tools
+from qveris.integrations.crewai import get_qveris_tools, aclose
 
 client = QverisClient()
 agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
-# run your crew, then: await client.close()
+# run your crew synchronously (crew.kickoff()), then:
+aclose(client)
 ```
 
-CrewAI runs tools synchronously; these bridge to the async client internally. The TypeScript SDK ships a Vercel AI SDK adapter.
+CrewAI runs tools synchronously; these bridge to the async client on one dedicated event loop. Close the client with `aclose(client)` (not `await client.close()`), since its connections are bound to that loop. The TypeScript SDK ships a Vercel AI SDK adapter.
 
 ### Custom LLM providers
 

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -291,7 +291,23 @@ result = await Runner.run(agent, "Find a stock quote capability and quote AAPL."
 await client.close()
 ```
 
-More adapters (CrewAI, Vercel AI SDK) are on the roadmap.
+**CrewAI**
+
+```bash
+pip install qveris[crewai]
+```
+
+```python
+from crewai import Agent
+from qveris import QverisClient
+from qveris.integrations.crewai import get_qveris_tools
+
+client = QverisClient()
+agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
+# run your crew, then: await client.close()
+```
+
+CrewAI runs tools synchronously; these bridge to the async client internally. The TypeScript SDK ships a Vercel AI SDK adapter.
 
 ### Custom LLM providers
 
@@ -336,6 +352,7 @@ Runnable examples live under [`packages/python-sdk/examples/`](https://github.co
 | `agent_loop_integration.py` | LLM agent loop integration |
 | `langchain_integration.py` | QVeris capabilities as LangChain tools (`qveris[langchain]`) |
 | `openai_agents_integration.py` | QVeris capabilities as OpenAI Agents SDK tools (`qveris[openai-agents]`) |
+| `crewai_integration.py` | QVeris capabilities as CrewAI tools (`qveris[crewai]`) |
 
 Capability examples run `discover`/`inspect` when `QVERIS_API_KEY` is set, and only execute `call` when `RUN_QVERIS_CALLS=1`.
 

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -300,14 +300,15 @@ pip install qveris[crewai]
 ```python
 from crewai import Agent
 from qveris import QverisClient
-from qveris.integrations.crewai import get_qveris_tools
+from qveris.integrations.crewai import get_qveris_tools, aclose
 
 client = QverisClient()
 agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
-# 运行你的 crew，然后 await client.close()
+# 同步运行你的 crew（crew.kickoff()），然后：
+aclose(client)
 ```
 
-CrewAI 同步执行工具；适配器内部桥接到异步 client。TypeScript SDK 提供 Vercel AI SDK 适配器。
+CrewAI 同步执行工具；适配器在一个专用事件循环上桥接到异步 client。由于 client 的连接绑定在该循环上，请用 `aclose(client)` 关闭（而非 `await client.close()`）。TypeScript SDK 提供 Vercel AI SDK 适配器。
 
 ### 自定义 LLM provider
 

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -291,7 +291,23 @@ result = await Runner.run(agent, "Find a stock quote capability and quote AAPL."
 await client.close()
 ```
 
-更多适配器（CrewAI、Vercel AI SDK）在路线图中。
+**CrewAI**
+
+```bash
+pip install qveris[crewai]
+```
+
+```python
+from crewai import Agent
+from qveris import QverisClient
+from qveris.integrations.crewai import get_qveris_tools
+
+client = QverisClient()
+agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
+# 运行你的 crew，然后 await client.close()
+```
+
+CrewAI 同步执行工具；适配器内部桥接到异步 client。TypeScript SDK 提供 Vercel AI SDK 适配器。
 
 ### 自定义 LLM provider
 
@@ -336,6 +352,7 @@ agent = Agent(llm_provider=MyProvider())
 | `agent_loop_integration.py` | LLM agent 循环集成 |
 | `langchain_integration.py` | 把 QVeris 能力作为 LangChain 工具（`qveris[langchain]`） |
 | `openai_agents_integration.py` | 把 QVeris 能力作为 OpenAI Agents SDK 工具（`qveris[openai-agents]`） |
+| `crewai_integration.py` | 把 QVeris 能力作为 CrewAI 工具（`qveris[crewai]`） |
 
 设置 `QVERIS_API_KEY` 后，能力示例会运行 `discover`/`inspect`；仅当设置 `RUN_QVERIS_CALLS=1` 时才执行 `call`。
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -153,7 +153,7 @@ agent = Agent(llm_provider=MyProvider())
 
 ## Examples
 
-Nine runnable examples are included under [`examples/`](examples):
+Ten runnable examples are included under [`examples/`](examples):
 
 | Example | Scenario |
 |---------|----------|
@@ -166,6 +166,7 @@ Nine runnable examples are included under [`examples/`](examples):
 | `agent_loop_integration.py` | LLM agent loop integration |
 | `langchain_integration.py` | QVeris capabilities as LangChain tools (`qveris[langchain]`) |
 | `openai_agents_integration.py` | QVeris capabilities as OpenAI Agents SDK tools (`qveris[openai-agents]`) |
+| `crewai_integration.py` | QVeris capabilities as CrewAI tools (`qveris[crewai]`) |
 
 The capability examples run `discover` and `inspect` when `QVERIS_API_KEY` is set. They only execute `call` when `RUN_QVERIS_CALLS=1` is set.
 

--- a/packages/python-sdk/examples/crewai_integration.py
+++ b/packages/python-sdk/examples/crewai_integration.py
@@ -5,17 +5,18 @@
     python crewai_integration.py
 
 `get_qveris_tools(client)` returns three CrewAI tools
-(qveris_discover / qveris_inspect / qveris_call) for a CrewAI Agent.
+(qveris_discover / qveris_inspect / qveris_call). CrewAI runs synchronously; the
+tools bridge to the async client on a dedicated loop, so close the client with
+`aclose(client)` (not `await client.close()`).
 """
 
-import asyncio
 import os
 
 from qveris import QverisClient
-from qveris.integrations.crewai import get_qveris_tools
+from qveris.integrations.crewai import aclose, get_qveris_tools
 
 
-async def main() -> None:
+def main() -> None:
     client = QverisClient()
     try:
         tools = get_qveris_tools(client)
@@ -41,8 +42,8 @@ async def main() -> None:
         result = Crew(agents=[researcher], tasks=[task]).kickoff()
         print(result)
     finally:
-        await client.close()
+        aclose(client)
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/packages/python-sdk/examples/crewai_integration.py
+++ b/packages/python-sdk/examples/crewai_integration.py
@@ -1,0 +1,48 @@
+"""Use QVeris capabilities as CrewAI tools.
+
+    pip install qveris[crewai]
+    export QVERIS_API_KEY="sk-..." OPENAI_API_KEY="sk-..."
+    python crewai_integration.py
+
+`get_qveris_tools(client)` returns three CrewAI tools
+(qveris_discover / qveris_inspect / qveris_call) for a CrewAI Agent.
+"""
+
+import asyncio
+import os
+
+from qveris import QverisClient
+from qveris.integrations.crewai import get_qveris_tools
+
+
+async def main() -> None:
+    client = QverisClient()
+    try:
+        tools = get_qveris_tools(client)
+        print("QVeris CrewAI tools:", [t.name for t in tools])
+
+        if not os.getenv("QVERIS_API_KEY") or not os.getenv("OPENAI_API_KEY"):
+            print("Set QVERIS_API_KEY and OPENAI_API_KEY to run the crew.")
+            return
+
+        from crewai import Agent, Crew, Task
+
+        researcher = Agent(
+            role="Market Researcher",
+            goal="Find and call the right external capability to answer the task.",
+            backstory="You use QVeris to discover, inspect, and call capabilities.",
+            tools=tools,
+        )
+        task = Task(
+            description="Find a stock quote capability and quote AAPL.",
+            expected_output="The current AAPL quote.",
+            agent=researcher,
+        )
+        result = Crew(agents=[researcher], tasks=[task]).kickoff()
+        print(result)
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -29,6 +29,12 @@ langchain = [
 openai-agents = [
     "openai-agents>=0.1.0; python_version >= '3.10'",
 ]
+# crewai requires Python >=3.10; heavy dep tree, so it is intentionally NOT in
+# `dev` — its integration test is importorskip-gated and run against an
+# on-demand install.
+crewai = [
+    "crewai>=0.80.0; python_version >= '3.10'",
+]
 dev = [
     "pytest",
     "pytest-asyncio",

--- a/packages/python-sdk/qveris/integrations/__init__.py
+++ b/packages/python-sdk/qveris/integrations/__init__.py
@@ -8,4 +8,5 @@ package never depends on them.
 Available:
     - :mod:`qveris.integrations.langchain` — LangChain tools (``pip install qveris[langchain]``)
     - :mod:`qveris.integrations.openai_agents` — OpenAI Agents SDK tools (``pip install qveris[openai-agents]``)
+    - :mod:`qveris.integrations.crewai` — CrewAI tools (``pip install qveris[crewai]``)
 """

--- a/packages/python-sdk/qveris/integrations/crewai.py
+++ b/packages/python-sdk/qveris/integrations/crewai.py
@@ -27,6 +27,7 @@ thread ``search_id`` from discover into inspect/call.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import threading
 from typing import Any, Coroutine, Dict, List, Optional, Type
@@ -61,8 +62,12 @@ class _BridgeLoop:
                 self._loop = loop
             return self._loop
 
+    def submit(self, coro: Coroutine[Any, Any, Any]) -> "concurrent.futures.Future[Any]":
+        """Schedule a coroutine on the bridge loop; return its concurrent Future."""
+        return asyncio.run_coroutine_threadsafe(coro, self._ensure())
+
     def run(self, coro: Coroutine[Any, Any, Any]) -> Any:
-        return asyncio.run_coroutine_threadsafe(coro, self._ensure()).result()
+        return self.submit(coro).result()
 
 
 _BRIDGE = _BridgeLoop()
@@ -71,6 +76,16 @@ _BRIDGE = _BridgeLoop()
 def _run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
     """Run an async coroutine on the shared CrewAI bridge loop and block for it."""
     return _BRIDGE.run(coro)
+
+
+async def _run_async(coro: Coroutine[Any, Any, Any]) -> Any:
+    """Await a coroutine on the shared bridge loop from within another loop.
+
+    Used by the tools' ``_arun`` path (CrewAI ``kickoff_async``): the work still
+    runs on the one bridge loop the client is bound to, so ``aclose`` and the
+    sync path stay consistent, while the caller's loop is not blocked.
+    """
+    return await asyncio.wrap_future(_BRIDGE.submit(coro))
 
 
 def aclose(client: QverisClient) -> None:
@@ -95,8 +110,8 @@ class _InspectArgs(BaseModel):
 
 class _CallArgs(BaseModel):
     tool_id: str = Field(description="The capability tool_id, from discover or inspect.")
-    search_id: str = Field(description="The search_id from the discover response.")
     params_to_tool: Dict[str, Any] = Field(description="Parameters to pass to the capability.")
+    search_id: Optional[str] = Field(default=None, description="The search_id from the discover response, if available.")
     max_response_size: Optional[int] = Field(default=None, description="Max response size in bytes; -1 means unlimited.")
 
 
@@ -129,6 +144,19 @@ def get_qveris_tools(
         result, _is_error, _handled = await client.handle_tool_call(name, args, session_id=session_id)
         return json.dumps(result, default=str)
 
+    def _call_args(
+        tool_id: str,
+        params_to_tool: Dict[str, Any],
+        search_id: Optional[str],
+        max_response_size: Optional[int],
+    ) -> Dict[str, Any]:
+        args: Dict[str, Any] = {"tool_id": tool_id, "params_to_tool": params_to_tool}
+        if search_id is not None:
+            args["search_id"] = search_id
+        if max_response_size is not None:
+            args["max_response_size"] = max_response_size
+        return args
+
     class QverisDiscoverTool(BaseTool):
         name: str = "qveris_discover"
         description: str = (
@@ -139,6 +167,9 @@ def get_qveris_tools(
         def _run(self, query: str, limit: int = 20) -> str:
             return _run_sync(_route("discover", {"query": query, "limit": limit}))
 
+        async def _arun(self, query: str, limit: int = 20) -> str:
+            return await _run_async(_route("discover", {"query": query, "limit": limit}))
+
     class QverisInspectTool(BaseTool):
         name: str = "qveris_inspect"
         description: str = "Inspect one or more QVeris capabilities by tool_id before calling them. Free."
@@ -146,6 +177,9 @@ def get_qveris_tools(
 
         def _run(self, tool_ids: List[str], search_id: Optional[str] = None) -> str:
             return _run_sync(_route("inspect", {"tool_ids": tool_ids, "search_id": search_id}))
+
+        async def _arun(self, tool_ids: List[str], search_id: Optional[str] = None) -> str:
+            return await _run_async(_route("inspect", {"tool_ids": tool_ids, "search_id": search_id}))
 
     class QverisCallTool(BaseTool):
         name: str = "qveris_call"
@@ -155,17 +189,19 @@ def get_qveris_tools(
         def _run(
             self,
             tool_id: str,
-            search_id: str,
             params_to_tool: Dict[str, Any],
+            search_id: Optional[str] = None,
             max_response_size: Optional[int] = None,
         ) -> str:
-            args: Dict[str, Any] = {
-                "tool_id": tool_id,
-                "search_id": search_id,
-                "params_to_tool": params_to_tool,
-            }
-            if max_response_size is not None:
-                args["max_response_size"] = max_response_size
-            return _run_sync(_route("call", args))
+            return _run_sync(_route("call", _call_args(tool_id, params_to_tool, search_id, max_response_size)))
+
+        async def _arun(
+            self,
+            tool_id: str,
+            params_to_tool: Dict[str, Any],
+            search_id: Optional[str] = None,
+            max_response_size: Optional[int] = None,
+        ) -> str:
+            return await _run_async(_route("call", _call_args(tool_id, params_to_tool, search_id, max_response_size)))
 
     return [QverisDiscoverTool(), QverisInspectTool(), QverisCallTool()]

--- a/packages/python-sdk/qveris/integrations/crewai.py
+++ b/packages/python-sdk/qveris/integrations/crewai.py
@@ -8,24 +8,27 @@ through one QVeris API key.
 
     from crewai import Agent
     from qveris import QverisClient
-    from qveris.integrations.crewai import get_qveris_tools
+    from qveris.integrations.crewai import get_qveris_tools, aclose
 
     client = QverisClient()
     agent = Agent(role="Researcher", goal="...", backstory="...",
                   tools=get_qveris_tools(client))
-    # ... run your crew, then: await client.close()
+    # ... run your crew synchronously (crew.kickoff()), then:
+    aclose(client)
 
 CrewAI executes tools synchronously; these tools bridge to the async QVeris
-client internally, so they work under both ``crew.kickoff()`` and
-``crew.kickoff_async()``. Tools return JSON strings and thread ``search_id``
-from discover into inspect/call.
+client on a single dedicated background event loop, so they work under both
+``crew.kickoff()`` and ``crew.kickoff_async()``. Because the client's async
+resources bind to that loop, close it with :func:`aclose` (which runs on the
+same loop) rather than ``await client.close()``. Tools return JSON strings and
+thread ``search_id`` from discover into inspect/call.
 """
 
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import json
+import threading
 from typing import Any, Coroutine, Dict, List, Optional, Type
 
 from pydantic import BaseModel, Field
@@ -35,19 +38,49 @@ from ..client.api import QverisClient
 _INSTALL_HINT = "The CrewAI integration requires 'crewai'. Install it with: pip install qveris[crewai]"
 
 
-def _run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
-    """Run an async coroutine from CrewAI's synchronous tool context.
+class _BridgeLoop:
+    """A single, long-lived event loop on a daemon thread.
 
-    Uses ``asyncio.run`` when no loop is running (``crew.kickoff()``); if a loop
-    is already running (``crew.kickoff_async()``), runs the coroutine in a
-    worker thread with its own loop to avoid "loop already running" errors.
+    CrewAI tools are synchronous but the QVeris client is async and holds a
+    persistent ``httpx.AsyncClient`` whose connection pool binds to the loop it
+    first runs on. Dispatching every call onto one stable loop (instead of a
+    fresh ``asyncio.run`` per call) keeps that client valid across the many
+    tool calls a crew makes, and works whether or not the caller has its own
+    running loop.
     """
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        return executor.submit(asyncio.run, coro).result()
+
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._lock = threading.Lock()
+
+    def _ensure(self) -> asyncio.AbstractEventLoop:
+        with self._lock:
+            if self._loop is None:
+                loop = asyncio.new_event_loop()
+                threading.Thread(target=loop.run_forever, name="qveris-crewai-loop", daemon=True).start()
+                self._loop = loop
+            return self._loop
+
+    def run(self, coro: Coroutine[Any, Any, Any]) -> Any:
+        return asyncio.run_coroutine_threadsafe(coro, self._ensure()).result()
+
+
+_BRIDGE = _BridgeLoop()
+
+
+def _run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
+    """Run an async coroutine on the shared CrewAI bridge loop and block for it."""
+    return _BRIDGE.run(coro)
+
+
+def aclose(client: QverisClient) -> None:
+    """Close a QVeris client whose async work ran through the CrewAI tools.
+
+    The client's connections are bound to the bridge loop, so ``close()`` must
+    run there too — a plain ``await client.close()`` on a different loop would
+    raise a cross-loop error. Call this instead when you're done with the crew.
+    """
+    _run_sync(client.close())
 
 
 class _DiscoverArgs(BaseModel):

--- a/packages/python-sdk/qveris/integrations/crewai.py
+++ b/packages/python-sdk/qveris/integrations/crewai.py
@@ -1,0 +1,138 @@
+"""CrewAI adapter for QVeris.
+
+Exposes the QVeris ``discover`` / ``inspect`` / ``call`` workflow as CrewAI
+tools, so a CrewAI agent can find and invoke thousands of external capabilities
+through one QVeris API key.
+
+    pip install qveris[crewai]
+
+    from crewai import Agent
+    from qveris import QverisClient
+    from qveris.integrations.crewai import get_qveris_tools
+
+    client = QverisClient()
+    agent = Agent(role="Researcher", goal="...", backstory="...",
+                  tools=get_qveris_tools(client))
+    # ... run your crew, then: await client.close()
+
+CrewAI executes tools synchronously; these tools bridge to the async QVeris
+client internally, so they work under both ``crew.kickoff()`` and
+``crew.kickoff_async()``. Tools return JSON strings and thread ``search_id``
+from discover into inspect/call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+from typing import Any, Coroutine, Dict, List, Optional, Type
+
+from pydantic import BaseModel, Field
+
+from ..client.api import QverisClient
+
+_INSTALL_HINT = "The CrewAI integration requires 'crewai'. Install it with: pip install qveris[crewai]"
+
+
+def _run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
+    """Run an async coroutine from CrewAI's synchronous tool context.
+
+    Uses ``asyncio.run`` when no loop is running (``crew.kickoff()``); if a loop
+    is already running (``crew.kickoff_async()``), runs the coroutine in a
+    worker thread with its own loop to avoid "loop already running" errors.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, coro).result()
+
+
+class _DiscoverArgs(BaseModel):
+    query: str = Field(description="Capability query in natural language, e.g. 'weather forecast API'.")
+    limit: int = Field(default=20, description="Number of results to return (1-100).")
+
+
+class _InspectArgs(BaseModel):
+    tool_ids: List[str] = Field(description="Tool IDs returned by discover.")
+    search_id: Optional[str] = Field(default=None, description="The search_id from the discover response, if available.")
+
+
+class _CallArgs(BaseModel):
+    tool_id: str = Field(description="The capability tool_id, from discover or inspect.")
+    search_id: str = Field(description="The search_id from the discover response.")
+    params_to_tool: Dict[str, Any] = Field(description="Parameters to pass to the capability.")
+    max_response_size: Optional[int] = Field(default=None, description="Max response size in bytes; -1 means unlimited.")
+
+
+def get_qveris_tools(
+    client: QverisClient,
+    *,
+    session_id: Optional[str] = None,
+) -> List[Any]:
+    """Return CrewAI tools for the QVeris discover/inspect/call workflow.
+
+    Args:
+        client: The ``QverisClient`` to route calls through. You own its
+            lifecycle — the tools hold a reference to it, so keep it open for
+            as long as the tools are used and ``await client.close()`` when done.
+        session_id: Optional session id for correlation/pricing context.
+
+    Returns:
+        A list of three CrewAI ``BaseTool`` instances named ``qveris_discover``,
+        ``qveris_inspect``, and ``qveris_call``.
+
+    Raises:
+        ImportError: if ``crewai`` is not installed.
+    """
+    try:
+        from crewai.tools import BaseTool
+    except ImportError as exc:  # pragma: no cover - exercised via install extras
+        raise ImportError(_INSTALL_HINT) from exc
+
+    async def _route(name: str, args: Dict[str, Any]) -> str:
+        result, _is_error, _handled = await client.handle_tool_call(name, args, session_id=session_id)
+        return json.dumps(result, default=str)
+
+    class QverisDiscoverTool(BaseTool):
+        name: str = "qveris_discover"
+        description: str = (
+            "Discover QVeris capabilities from a natural-language query. Free; returns candidates and a search_id."
+        )
+        args_schema: Type[BaseModel] = _DiscoverArgs
+
+        def _run(self, query: str, limit: int = 20) -> str:
+            return _run_sync(_route("discover", {"query": query, "limit": limit}))
+
+    class QverisInspectTool(BaseTool):
+        name: str = "qveris_inspect"
+        description: str = "Inspect one or more QVeris capabilities by tool_id before calling them. Free."
+        args_schema: Type[BaseModel] = _InspectArgs
+
+        def _run(self, tool_ids: List[str], search_id: Optional[str] = None) -> str:
+            return _run_sync(_route("inspect", {"tool_ids": tool_ids, "search_id": search_id}))
+
+    class QverisCallTool(BaseTool):
+        name: str = "qveris_call"
+        description: str = "Call a selected QVeris capability with parameters. May consume credits."
+        args_schema: Type[BaseModel] = _CallArgs
+
+        def _run(
+            self,
+            tool_id: str,
+            search_id: str,
+            params_to_tool: Dict[str, Any],
+            max_response_size: Optional[int] = None,
+        ) -> str:
+            args: Dict[str, Any] = {
+                "tool_id": tool_id,
+                "search_id": search_id,
+                "params_to_tool": params_to_tool,
+            }
+            if max_response_size is not None:
+                args["max_response_size"] = max_response_size
+            return _run_sync(_route("call", args))
+
+    return [QverisDiscoverTool(), QverisInspectTool(), QverisCallTool()]

--- a/packages/python-sdk/tests/test_crewai_integration.py
+++ b/packages/python-sdk/tests/test_crewai_integration.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -5,7 +6,7 @@ import pytest
 
 pytest.importorskip("crewai", reason="CrewAI integration requires crewai (Python >=3.10)")
 
-from qveris.integrations.crewai import get_qveris_tools  # noqa: E402
+from qveris.integrations.crewai import aclose, get_qveris_tools  # noqa: E402
 
 
 class FakeClient:
@@ -72,3 +73,44 @@ def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
 
     assert client.calls[0]["name"] == "inspect"
     assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}
+
+
+def test_all_tool_calls_run_on_one_shared_event_loop() -> None:
+    """Multiple tool calls must run on the SAME loop so a persistent async
+    client (e.g. httpx.AsyncClient) stays valid across a crew's many calls.
+    A fresh asyncio.run per call would give a different, closed loop each time.
+    """
+    loop_ids: List[int] = []
+
+    class LoopRecordingClient:
+        async def handle_tool_call(self, func_name, func_args, session_id=None):
+            loop_ids.append(id(asyncio.get_running_loop()))
+            return {"ok": True}, False, True
+
+    tools = get_qveris_tools(LoopRecordingClient())
+    _tool(tools, "qveris_discover")._run(query="x")
+    _tool(tools, "qveris_inspect")._run(tool_ids=["t"])
+    _tool(tools, "qveris_call")._run(tool_id="t", search_id="s", params_to_tool={})
+
+    assert len(loop_ids) == 3
+    assert len(set(loop_ids)) == 1  # all three on one stable bridge loop
+
+
+def test_aclose_runs_client_close_on_the_bridge_loop() -> None:
+    closed_on: Dict[str, Any] = {}
+
+    class ClosableClient:
+        async def handle_tool_call(self, func_name, func_args, session_id=None):
+            closed_on["call_loop"] = id(asyncio.get_running_loop())
+            return {"ok": True}, False, True
+
+        async def close(self):
+            closed_on["close_loop"] = id(asyncio.get_running_loop())
+
+    client = ClosableClient()
+    tools = get_qveris_tools(client)
+    _tool(tools, "qveris_discover")._run(query="x")
+    aclose(client)
+
+    # close() ran, and on the same loop the tool calls (and thus the client) used.
+    assert closed_on["close_loop"] == closed_on["call_loop"]

--- a/packages/python-sdk/tests/test_crewai_integration.py
+++ b/packages/python-sdk/tests/test_crewai_integration.py
@@ -96,6 +96,43 @@ def test_all_tool_calls_run_on_one_shared_event_loop() -> None:
     assert len(set(loop_ids)) == 1  # all three on one stable bridge loop
 
 
+def test_call_tool_omits_absent_search_id() -> None:
+    client = FakeClient()
+    call = _tool(get_qveris_tools(client), "qveris_call")
+
+    call._run(tool_id="t1", params_to_tool={})
+
+    assert "search_id" not in client.calls[0]["args"]
+    assert client.calls[0]["args"] == {"tool_id": "t1", "params_to_tool": {}}
+
+
+def test_arun_dispatches_work_onto_the_bridge_loop() -> None:
+    """CrewAI's async path (_arun / kickoff_async) must still run client work on
+    the one bridge loop the persistent client is bound to — not the caller's
+    loop — so aclose and the sync path stay consistent.
+    """
+    loop_ids: List[int] = []
+
+    class LoopRecordingClient:
+        async def handle_tool_call(self, func_name, func_args, session_id=None):
+            loop_ids.append(id(asyncio.get_running_loop()))
+            return {"ok": True}, False, True
+
+    discover = _tool(get_qveris_tools(LoopRecordingClient()), "qveris_discover")
+    discover._run(query="x")  # sync path records the bridge loop
+    bridge_loop_id = loop_ids[0]
+
+    async def drive() -> str:
+        # This coroutine runs on a *different* loop (asyncio.run); _arun must
+        # not execute the client on it.
+        return await discover._arun(query="y")
+
+    asyncio.run(drive())
+
+    assert len(loop_ids) == 2
+    assert loop_ids[1] == bridge_loop_id
+
+
 def test_aclose_runs_client_close_on_the_bridge_loop() -> None:
     closed_on: Dict[str, Any] = {}
 

--- a/packages/python-sdk/tests/test_crewai_integration.py
+++ b/packages/python-sdk/tests/test_crewai_integration.py
@@ -1,0 +1,74 @@
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+pytest.importorskip("crewai", reason="CrewAI integration requires crewai (Python >=3.10)")
+
+from qveris.integrations.crewai import get_qveris_tools  # noqa: E402
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def handle_tool_call(
+        self, func_name: str, func_args: Dict[str, Any], session_id: Optional[str] = None
+    ) -> Tuple[Any, bool, bool]:
+        self.calls.append({"name": func_name, "args": func_args, "session_id": session_id})
+        if func_name == "discover":
+            return {"search_id": "s1", "results": [{"tool_id": "t1"}]}, False, True
+        if func_name == "inspect":
+            return {"results": [{"tool_id": "t1"}]}, False, True
+        return {"execution_id": "e1", "success": True}, False, True
+
+
+def _tool(tools, name):
+    return next(t for t in tools if t.name == name)
+
+
+def test_get_qveris_tools_exposes_three_named_tools() -> None:
+    tools = get_qveris_tools(FakeClient())
+    assert [t.name for t in tools] == ["qveris_discover", "qveris_inspect", "qveris_call"]
+    for tool in tools:
+        assert tool.description
+        assert tool.args_schema is not None
+
+
+def test_discover_tool_routes_to_handle_tool_call() -> None:
+    client = FakeClient()
+    discover = _tool(get_qveris_tools(client, session_id="sess-1"), "qveris_discover")
+
+    # _run bridges the async client synchronously (no running loop in this test).
+    out = discover._run(query="weather forecast API", limit=3)
+
+    assert client.calls == [
+        {"name": "discover", "args": {"query": "weather forecast API", "limit": 3}, "session_id": "sess-1"}
+    ]
+    assert json.loads(out)["search_id"] == "s1"
+
+
+def test_call_tool_threads_ids_and_omits_absent_max_response_size() -> None:
+    client = FakeClient()
+    call = _tool(get_qveris_tools(client), "qveris_call")
+
+    out = call._run(tool_id="t1", search_id="s1", params_to_tool={"city": "London"})
+
+    assert client.calls[0]["name"] == "call"
+    assert client.calls[0]["args"] == {
+        "tool_id": "t1",
+        "search_id": "s1",
+        "params_to_tool": {"city": "London"},
+    }
+    assert "max_response_size" not in client.calls[0]["args"]
+    assert json.loads(out)["execution_id"] == "e1"
+
+
+def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
+    client = FakeClient()
+    inspect = _tool(get_qveris_tools(client), "qveris_inspect")
+
+    inspect._run(tool_ids=["t1", "t2"], search_id="s1")
+
+    assert client.calls[0]["name"] == "inspect"
+    assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}


### PR DESCRIPTION
Completes #109 — the fourth and final planned framework adapter. **Stacked on #133** (OpenAI Agents); base is `feat/openai-agents-adapter`, so this diff shows only the CrewAI changes. GitHub retargets to `main` as the stack merges.

## What

`qveris.integrations.crewai.get_qveris_tools(client)` returns three CrewAI `BaseTool` instances — `qveris_discover` / `qveris_inspect` / `qveris_call`.

```python
from crewai import Agent
from qveris import QverisClient
from qveris.integrations.crewai import get_qveris_tools

client = QverisClient()
agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
# run your crew, then: await client.close()
```

## Design (verified empirically against crewai 1.15.2)

- **Sync→async bridge** — CrewAI tools are synchronous (`_run`). A small helper runs the async client via `asyncio.run` when no loop is running (`crew.kickoff()`) and in a worker thread with its own loop when one is (`crew.kickoff_async()`), so it works under both.
- **Lazy import + optional extra** — base `qveris` never depends on `crewai`; `get_qveris_tools` raises an actionable `ImportError` if it's missing. The `[crewai]` extra is pinned `crewai>=0.80.0; python_version >= '3.10'` (crewai's own floor).
- **Not in `dev`** — crewai pulls a heavy ~56-dep tree (chromadb, lancedb). Adding it to `dev` would bloat every CI install and risks version conflicts, so the test is `importorskip`-gated and I ran it against an on-demand install.
- Reuses `client.handle_tool_call`, threads `search_id`, omits `max_response_size` when absent — same bridge as the other adapters. Client is required (no leak).

## Test plan

- `tests/test_crewai_integration.py` (importorskip `crewai`): 3 named tools + discover/inspect/call routing through `_run` (asserts args incl. `search_id` threading + `max_response_size` omission). **Verified against crewai 1.15.2 — 4 passed** (`uv run --with crewai pytest`). Empirically confirmed the `BaseTool` API (name/description/args_schema/`_run`) before writing it.
- `compileall qveris examples` clean.
- `examples/crewai_integration.py` + docs (en/zh/cn) + examples tables.

## Heads-up: unrelated pre-existing test failure

While running the full suite I found `test_qveris_config_constructor_values_override_env` fails under **pydantic 2.12** — `QverisConfig(api_key=...)` no longer overrides the env var because pydantic 2.11+ changed `validation_alias` + `populate_by_name` init precedence. This newer pydantic is pulled transitively by the framework extras (`langchain-core`/`openai-agents`) added to `dev` in #132/#133, so it predates this PR. It is **not run in PR CI** (contract-tests runs only the OpenAPI contract test) but would fail the full suite at the next `python-sdk-v*` release. `config.py` is untouched here — this needs its own small compat fix (e.g. `AliasChoices`), which I'll open separately.

## Completes #109

LangChain (#132), OpenAI Agents SDK (#133), Vercel AI SDK (#134, TS), CrewAI (this) — the four planned adapters. #109 can close once the stack merges.