### PR TITLE
feat(python-sdk): optional OpenTelemetry tracing for discover/inspect/call (#112)

### DIFF
--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -153,10 +153,12 @@ agent = Agent(llm_provider=MyProvider())
 
 ## Observability (OpenTelemetry)
 
-`discover` / `inspect` / `call` emit one OpenTelemetry span each, so you can trace QVeris activity and correlate it with the usage/ledger records. Tracing is **opt-in and dependency-free**:
+`discover` / `inspect` / `call` emit one OpenTelemetry span each, so you can trace QVeris activity and correlate it with the usage/ledger records. Tracing is **dependency-free and best-effort**:
 
-- Without the extra, the spans are a no-op — zero overhead, zero behavior change.
-- Install `pip install qveris[otel]` (adds `opentelemetry-api`) and configure any OTLP exporter to see them.
+- If `opentelemetry-api` is not importable (install it with `pip install qveris[otel]`), the helpers are a no-op — no overhead, no behavior change.
+- If it is importable but no tracer provider is configured, spans go to OpenTelemetry's default no-op provider (near-zero cost, nothing exported).
+- Configure a provider + OTLP exporter and the spans flow to Jaeger/Tempo/any OTLP backend.
+- A fault in the tracer itself (broken provider/sampler/exporter) degrades to a no-op — it never breaks a `discover`/`inspect`/`call`.
 
 Span attributes live under a `qveris.` namespace: `operation`, `tool_id` / `tool_id_count`, `search_id`, `execution_id`, `elapsed_time_ms`, `success`, and `credits` (pre-settlement). The natural-language query and tool parameters are intentionally **not** recorded. A failed `call` is marked as an error span.
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -151,9 +151,34 @@ class MyProvider(LLMProvider):
 agent = Agent(llm_provider=MyProvider())
 ```
 
+## Observability (OpenTelemetry)
+
+`discover` / `inspect` / `call` emit one OpenTelemetry span each, so you can trace QVeris activity and correlate it with the usage/ledger records. Tracing is **opt-in and dependency-free**:
+
+- Without the extra, the spans are a no-op — zero overhead, zero behavior change.
+- Install `pip install qveris[otel]` (adds `opentelemetry-api`) and configure any OTLP exporter to see them.
+
+Span attributes live under a `qveris.` namespace: `operation`, `tool_id` / `tool_id_count`, `search_id`, `execution_id`, `elapsed_time_ms`, `success`, and `credits` (pre-settlement). The natural-language query and tool parameters are intentionally **not** recorded. A failed `call` is marked as an error span.
+
+```python
+# pip install qveris[otel] opentelemetry-sdk opentelemetry-exporter-otlp
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))  # e.g. OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+trace.set_tracer_provider(provider)
+
+# ... now use QverisClient / Agent as usual; spans flow to your collector (Jaeger, Tempo, ...).
+```
+
+See [`examples/otel_tracing.py`](examples/otel_tracing.py) for a runnable end-to-end example.
+
 ## Examples
 
-Ten runnable examples are included under [`examples/`](examples):
+Eleven runnable examples are included under [`examples/`](examples):
 
 | Example | Scenario |
 |---------|----------|
@@ -167,6 +192,7 @@ Ten runnable examples are included under [`examples/`](examples):
 | `langchain_integration.py` | QVeris capabilities as LangChain tools (`qveris[langchain]`) |
 | `openai_agents_integration.py` | QVeris capabilities as OpenAI Agents SDK tools (`qveris[openai-agents]`) |
 | `crewai_integration.py` | QVeris capabilities as CrewAI tools (`qveris[crewai]`) |
+| `otel_tracing.py` | OpenTelemetry spans for discover/call (`qveris[otel]`) |
 
 The capability examples run `discover` and `inspect` when `QVERIS_API_KEY` is set. They only execute `call` when `RUN_QVERIS_CALLS=1` is set.
 

--- a/packages/python-sdk/examples/otel_tracing.py
+++ b/packages/python-sdk/examples/otel_tracing.py
@@ -1,0 +1,64 @@
+"""Trace QVeris discover/call with OpenTelemetry.
+
+    pip install qveris[otel] opentelemetry-sdk
+    export QVERIS_API_KEY="sk-..."
+    python otel_tracing.py
+
+This wires a console span exporter so you can see the spans locally. To send
+them to Jaeger/Tempo/any OTLP backend instead, swap ConsoleSpanExporter for the
+OTLP exporter:
+
+    # pip install opentelemetry-exporter-otlp
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+
+Spans carry qveris.* attributes (operation, tool_id, search_id, execution_id,
+elapsed_time_ms, success, credits) — enough to correlate a trace with the
+QVeris usage/ledger records. The query text and tool params are not recorded.
+"""
+
+import asyncio
+import os
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+from qveris import QverisClient
+
+
+def setup_tracing() -> None:
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+
+async def main() -> None:
+    setup_tracing()
+
+    if not os.getenv("QVERIS_API_KEY"):
+        print("Set QVERIS_API_KEY to run a real traced discover/call.")
+        return
+
+    client = QverisClient()
+    try:
+        found = await client.discover("stock quote API", limit=5)
+        if not found.results:
+            print("No capabilities found.")
+            return
+
+        tool = found.results[0]
+        result = await client.call(
+            tool.tool_id,
+            {"symbol": "AAPL"},
+            search_id=found.search_id,
+        )
+        print(f"execution_id={result.execution_id} success={result.success}")
+        # Two spans (qveris.discover, qveris.call) are printed to the console above.
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -35,6 +35,11 @@ openai-agents = [
 crewai = [
     "crewai>=0.80.0; python_version >= '3.10'",
 ]
+# OpenTelemetry tracing for discover/inspect/call. Only the API is needed; bring
+# your own SDK + exporter in the app. Absent this extra, tracing is a no-op.
+otel = [
+    "opentelemetry-api>=1.20.0",
+]
 dev = [
     "pytest",
     "pytest-asyncio",
@@ -42,6 +47,8 @@ dev = [
     "rich>=13.0.0",
     "langchain-core>=0.3.0; python_version >= '3.9'",  # for the LangChain integration tests
     "openai-agents>=0.1.0; python_version >= '3.10'",  # for the OpenAI Agents integration tests
+    "opentelemetry-api>=1.20.0",  # for the observability tests
+    "opentelemetry-sdk>=1.20.0",  # in-memory span exporter used by the tests
     # Pinned so regenerated models stay byte-stable with the checked-in
     # qveris/generated/openapi_models.py and the drift CI (issue #37 phase 2).
     "datamodel-code-generator==0.26.3",

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -171,7 +171,7 @@ class QverisClient:
                 span,
                 {
                     ATTR_SEARCH_ID: result.search_id,
-                    ATTR_RESULT_COUNT: result.total if result.total is not None else len(result.results),
+                    ATTR_RESULT_COUNT: result.total if result.total is not None else len(result.results or []),
                     ATTR_ELAPSED_MS: result.elapsed_time_ms,
                 },
             )
@@ -228,7 +228,7 @@ class QverisClient:
             data = self._unwrap_envelope(self._parse_response_json(response))
             response.raise_for_status()
             result = SearchResponse(**data)
-            set_span_attributes(span, {ATTR_RESULT_COUNT: len(result.results)})
+            set_span_attributes(span, {ATTR_RESULT_COUNT: len(result.results or [])})
             return result
 
     async def get_tools_by_ids(

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -30,7 +30,29 @@ from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 import httpx
 
 from ..config import QverisConfig
+from ..observability import (
+    ATTR_CREDITS,
+    ATTR_ELAPSED_MS,
+    ATTR_EXECUTION_ID,
+    ATTR_LIMIT,
+    ATTR_OPERATION,
+    ATTR_RESULT_COUNT,
+    ATTR_SEARCH_ID,
+    ATTR_SESSION_ID,
+    ATTR_SUCCESS,
+    ATTR_TOOL_ID,
+    ATTR_TOOL_ID_COUNT,
+    set_span_attributes,
+    start_span,
+)
 from ..types import CreditsLedgerResponse, SearchResponse, ToolExecutionResponse, UsageHistoryResponse
+
+
+def _pre_settlement_credits(response: ToolExecutionResponse) -> Optional[float]:
+    """Best pre-settlement credit figure from a call response, for a span attribute."""
+    if response.billing is not None and response.billing.list_amount_credits is not None:
+        return response.billing.list_amount_credits
+    return response.cost
 
 
 class QverisClient:
@@ -131,16 +153,29 @@ class QverisClient:
         if session_id:
             payload["session_id"] = session_id
 
-        self._debug(f"[Qveris API] POST {url}")
-        self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
-        self._debug_headers()
+        with start_span(
+            "qveris.discover",
+            {ATTR_OPERATION: "discover", ATTR_LIMIT: limit, ATTR_SESSION_ID: session_id},
+        ) as span:
+            self._debug(f"[Qveris API] POST {url}")
+            self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
+            self._debug_headers()
 
-        response = await self.client.post("search", json=payload)
+            response = await self.client.post("search", json=payload)
 
-        self._debug(f"[Qveris API] Response status: {response.status_code}")
-        data = self._unwrap_envelope(self._parse_response_json(response))
-        response.raise_for_status()
-        return SearchResponse(**data)
+            self._debug(f"[Qveris API] Response status: {response.status_code}")
+            data = self._unwrap_envelope(self._parse_response_json(response))
+            response.raise_for_status()
+            result = SearchResponse(**data)
+            set_span_attributes(
+                span,
+                {
+                    ATTR_SEARCH_ID: result.search_id,
+                    ATTR_RESULT_COUNT: result.total if result.total is not None else len(result.results),
+                    ATTR_ELAPSED_MS: result.elapsed_time_ms,
+                },
+            )
+            return result
 
     async def search_tools(self, query: str, limit: int = 20, session_id: Optional[str] = None) -> SearchResponse:
         """Deprecated alias for `discover(...)`."""
@@ -174,16 +209,27 @@ class QverisClient:
         if session_id:
             payload["session_id"] = session_id
 
-        self._debug(f"[Qveris API] POST {url}")
-        self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
-        self._debug_headers()
+        with start_span(
+            "qveris.inspect",
+            {
+                ATTR_OPERATION: "inspect",
+                ATTR_TOOL_ID_COUNT: len(ids),
+                ATTR_SEARCH_ID: search_id,
+                ATTR_SESSION_ID: session_id,
+            },
+        ) as span:
+            self._debug(f"[Qveris API] POST {url}")
+            self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
+            self._debug_headers()
 
-        response = await self.client.post("tools/by-ids", json=payload)
+            response = await self.client.post("tools/by-ids", json=payload)
 
-        self._debug(f"[Qveris API] Response status: {response.status_code}")
-        data = self._unwrap_envelope(self._parse_response_json(response))
-        response.raise_for_status()
-        return SearchResponse(**data)
+            self._debug(f"[Qveris API] Response status: {response.status_code}")
+            data = self._unwrap_envelope(self._parse_response_json(response))
+            response.raise_for_status()
+            result = SearchResponse(**data)
+            set_span_attributes(span, {ATTR_RESULT_COUNT: len(result.results)})
+            return result
 
     async def get_tools_by_ids(
         self,
@@ -229,20 +275,39 @@ class QverisClient:
         if max_response_size is not None:
             payload["max_response_size"] = max_response_size
 
-        self._debug(f"[Qveris API] POST {url}")
-        self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
-        self._debug_headers()
+        with start_span(
+            "qveris.call",
+            {
+                ATTR_OPERATION: "call",
+                ATTR_TOOL_ID: tool_id,
+                ATTR_SEARCH_ID: search_id,
+                ATTR_SESSION_ID: session_id,
+            },
+        ) as span:
+            self._debug(f"[Qveris API] POST {url}")
+            self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
+            self._debug_headers()
 
-        response = await self.client.post(
-            "tools/execute",
-            params={"tool_id": tool_id},
-            json=payload,
-        )
+            response = await self.client.post(
+                "tools/execute",
+                params={"tool_id": tool_id},
+                json=payload,
+            )
 
-        self._debug(f"[Qveris API] Response status: {response.status_code}")
-        data = self._unwrap_envelope(self._parse_response_json(response))
-        response.raise_for_status()
-        return ToolExecutionResponse(**data)
+            self._debug(f"[Qveris API] Response status: {response.status_code}")
+            data = self._unwrap_envelope(self._parse_response_json(response))
+            response.raise_for_status()
+            result = ToolExecutionResponse(**data)
+            set_span_attributes(
+                span,
+                {
+                    ATTR_EXECUTION_ID: result.execution_id,
+                    ATTR_SUCCESS: result.success,
+                    ATTR_ELAPSED_MS: result.elapsed_time_ms,
+                    ATTR_CREDITS: _pre_settlement_credits(result),
+                },
+            )
+            return result
 
     async def execute_tool(
         self,

--- a/packages/python-sdk/qveris/observability.py
+++ b/packages/python-sdk/qveris/observability.py
@@ -25,20 +25,22 @@ from typing import Any, Dict, Iterator, Optional
 try:  # opentelemetry-api is an optional extra (qveris[otel]).
     from opentelemetry import trace as _otel_trace
     from opentelemetry.trace import Status, StatusCode
-
+except ImportError:  # opentelemetry not installed -> fully no-op
+    _otel_trace = None  # type: ignore[assignment]
+    Status = None  # type: ignore[assignment]
+    StatusCode = None  # type: ignore[assignment]
+    _tracer: Any = None
+else:
     try:  # keep the instrumenting-library version on the tracer when available.
         from importlib.metadata import version as _pkg_version
 
         _QVERIS_VERSION: Optional[str] = _pkg_version("qveris")
     except Exception:  # pragma: no cover - metadata missing in odd installs
         _QVERIS_VERSION = None
-
-    _tracer: Any = _otel_trace.get_tracer("qveris", _QVERIS_VERSION)
-except ImportError:  # opentelemetry not installed -> fully no-op
-    _otel_trace = None  # type: ignore[assignment]
-    Status = None  # type: ignore[assignment]
-    StatusCode = None  # type: ignore[assignment]
-    _tracer = None
+    try:
+        _tracer = _otel_trace.get_tracer("qveris", _QVERIS_VERSION)
+    except Exception:  # pragma: no cover - a broken otel install must not break import
+        _tracer = None
 
 
 # Span attribute keys (kept under a `qveris.` namespace).
@@ -61,31 +63,62 @@ def is_tracing_enabled() -> bool:
 
 
 def set_span_attributes(span: Any, attributes: Dict[str, Any]) -> None:
-    """Set non-``None`` attributes on ``span`` (no-op when tracing is off)."""
+    """Set non-``None`` attributes on ``span``, best-effort.
+
+    No-op when tracing is off, and swallows any tracer error — instrumentation
+    must never break the traced operation.
+    """
     if span is None:
         return
     for key, value in attributes.items():
         if value is not None:
-            span.set_attribute(key, value)
+            try:
+                span.set_attribute(key, value)
+            except Exception:  # pragma: no cover - defensive
+                pass
 
 
 @contextmanager
 def start_span(name: str, attributes: Optional[Dict[str, Any]] = None) -> Iterator[Any]:
     """Start a span for a QVeris operation.
 
-    Yields the span (or ``None`` when tracing is disabled). On an exception the
-    span is marked ``ERROR`` and the exception recorded before re-raising, so a
-    failed ``call`` still shows up as a failed span.
+    Yields the span (or ``None`` when tracing is disabled/unavailable). On an
+    exception from the traced body the span is marked ``ERROR`` and the exception
+    recorded before re-raising, so a failed ``call`` shows up as a failed span.
+
+    Tracing is strictly best-effort: any fault in the tracer itself (a broken
+    provider, sampler, or exporter) degrades to a no-op rather than propagating
+    into — and breaking — the traced operation.
     """
     if _tracer is None:
         yield None
         return
 
-    with _tracer.start_as_current_span(name) as span:
-        set_span_attributes(span, attributes or {})
+    try:
+        # Disable the SDK's own exception recording; we record once, manually.
+        span_cm = _tracer.start_as_current_span(
+            name, record_exception=False, set_status_on_exception=False
+        )
+        span = span_cm.__enter__()
+    except Exception:  # pragma: no cover - tracer setup fault -> run untraced
+        yield None
+        return
+
+    set_span_attributes(span, attributes or {})
+    exc_info: Any = (None, None, None)
+    try:
+        yield span
+    except BaseException as exc:  # noqa: BLE001 - record then re-raise the ORIGINAL error
+        exc_info = (type(exc), exc, exc.__traceback__)
         try:
-            yield span
-        except BaseException as exc:  # noqa: BLE001 - record then re-raise
             span.record_exception(exc)
             span.set_status(Status(StatusCode.ERROR, str(exc)))
-            raise
+        except Exception:  # pragma: no cover - defensive
+            pass
+        raise
+    finally:
+        # End the span; guard so an exporter/exit fault can't mask the result.
+        try:
+            span_cm.__exit__(*exc_info)
+        except Exception:  # pragma: no cover - defensive
+            pass

--- a/packages/python-sdk/qveris/observability.py
+++ b/packages/python-sdk/qveris/observability.py
@@ -1,0 +1,91 @@
+"""Optional OpenTelemetry tracing for the QVeris SDK.
+
+Instrumenting ``discover`` / ``inspect`` / ``call`` emits one span each, with
+attributes (``tool_id``, ``search_id``, ``execution_id``, ``elapsed_time_ms``,
+``credits``) so a trace can be correlated with the QVeris usage/ledger records.
+
+Tracing is **opt-in and dependency-free by default**:
+
+- If ``opentelemetry-api`` is not installed (``pip install qveris[otel]`` adds it),
+  every helper here is a no-op — zero overhead, zero behaviour change.
+- If it is installed but no tracer provider/exporter is configured, spans are
+  created against OpenTelemetry's default no-op provider (still effectively free).
+- Configure an OTLP exporter in your app and the spans flow to Jaeger, Tempo,
+  or any OTLP backend.
+
+Nothing here records the natural-language ``query`` or tool parameters, to avoid
+leaking user input into traces.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional
+
+try:  # opentelemetry-api is an optional extra (qveris[otel]).
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.trace import Status, StatusCode
+
+    try:  # keep the instrumenting-library version on the tracer when available.
+        from importlib.metadata import version as _pkg_version
+
+        _QVERIS_VERSION: Optional[str] = _pkg_version("qveris")
+    except Exception:  # pragma: no cover - metadata missing in odd installs
+        _QVERIS_VERSION = None
+
+    _tracer: Any = _otel_trace.get_tracer("qveris", _QVERIS_VERSION)
+except ImportError:  # opentelemetry not installed -> fully no-op
+    _otel_trace = None  # type: ignore[assignment]
+    Status = None  # type: ignore[assignment]
+    StatusCode = None  # type: ignore[assignment]
+    _tracer = None
+
+
+# Span attribute keys (kept under a `qveris.` namespace).
+ATTR_OPERATION = "qveris.operation"
+ATTR_TOOL_ID = "qveris.tool_id"
+ATTR_TOOL_ID_COUNT = "qveris.tool_id_count"
+ATTR_SEARCH_ID = "qveris.search_id"
+ATTR_EXECUTION_ID = "qveris.execution_id"
+ATTR_SESSION_ID = "qveris.session_id"
+ATTR_LIMIT = "qveris.limit"
+ATTR_RESULT_COUNT = "qveris.result_count"
+ATTR_ELAPSED_MS = "qveris.elapsed_time_ms"
+ATTR_SUCCESS = "qveris.success"
+ATTR_CREDITS = "qveris.credits"
+
+
+def is_tracing_enabled() -> bool:
+    """True when opentelemetry-api is importable and a tracer is available."""
+    return _tracer is not None
+
+
+def set_span_attributes(span: Any, attributes: Dict[str, Any]) -> None:
+    """Set non-``None`` attributes on ``span`` (no-op when tracing is off)."""
+    if span is None:
+        return
+    for key, value in attributes.items():
+        if value is not None:
+            span.set_attribute(key, value)
+
+
+@contextmanager
+def start_span(name: str, attributes: Optional[Dict[str, Any]] = None) -> Iterator[Any]:
+    """Start a span for a QVeris operation.
+
+    Yields the span (or ``None`` when tracing is disabled). On an exception the
+    span is marked ``ERROR`` and the exception recorded before re-raising, so a
+    failed ``call`` still shows up as a failed span.
+    """
+    if _tracer is None:
+        yield None
+        return
+
+    with _tracer.start_as_current_span(name) as span:
+        set_span_attributes(span, attributes or {})
+        try:
+            yield span
+        except BaseException as exc:  # noqa: BLE001 - record then re-raise
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise

--- a/packages/python-sdk/tests/test_observability.py
+++ b/packages/python-sdk/tests/test_observability.py
@@ -115,6 +115,27 @@ async def test_call_span_marked_error_on_http_failure(spans: InMemorySpanExporte
 
 
 @pytest.mark.asyncio
+async def test_broken_tracer_does_not_break_the_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A misbehaving tracer provider must never break the traced operation.
+    class BrokenTracer:
+        def start_as_current_span(self, *args, **kwargs):
+            raise RuntimeError("sampler exploded")
+
+    monkeypatch.setattr(observability, "_tracer", BrokenTracer())
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"execution_id": "e1", "success": True})
+
+    client = make_client(handler)
+    try:
+        result = await client.call("t1", {"x": 1}, search_id="s1")
+    finally:
+        await client.close()
+
+    assert result.execution_id == "e1"  # call succeeded despite the broken tracer
+
+
+@pytest.mark.asyncio
 async def test_tracing_disabled_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     # Simulate opentelemetry not installed: the client must still work unchanged.
     monkeypatch.setattr(observability, "_tracer", None)

--- a/packages/python-sdk/tests/test_observability.py
+++ b/packages/python-sdk/tests/test_observability.py
@@ -1,0 +1,132 @@
+import json
+from typing import Callable
+
+import httpx
+import pytest
+
+pytest.importorskip("opentelemetry", reason="observability tests require qveris[otel]")
+
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # noqa: E402
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter  # noqa: E402
+
+from qveris import observability  # noqa: E402
+from qveris.client.api import QverisClient  # noqa: E402
+from qveris.config import QverisConfig  # noqa: E402
+
+
+def make_client(handler: Callable[[httpx.Request], httpx.Response]) -> QverisClient:
+    client = QverisClient(QverisConfig(api_key="sk-test", base_url="https://qveris.ai/api/v1"))
+    client.client = httpx.AsyncClient(
+        base_url=client.base_url,
+        headers=client.headers,
+        transport=httpx.MockTransport(handler),
+        timeout=60.0,
+    )
+    return client
+
+
+@pytest.fixture()
+def spans(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    """Route qveris spans into an isolated in-memory exporter for the test."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(observability, "_tracer", provider.get_tracer("qveris-test"))
+    return exporter
+
+
+def _span_by_name(exporter: InMemorySpanExporter, name: str):
+    return next(s for s in exporter.get_finished_spans() if s.name == name)
+
+
+@pytest.mark.asyncio
+async def test_discover_emits_span_with_attributes(spans: InMemorySpanExporter) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"search_id": "s1", "total": 2, "results": [{"tool_id": "t1"}, {"tool_id": "t2"}], "elapsed_time_ms": 12.5},
+        )
+
+    client = make_client(handler)
+    try:
+        await client.discover("weather", limit=5, session_id="sess-1")
+    finally:
+        await client.close()
+
+    span = _span_by_name(spans, "qveris.discover")
+    attrs = dict(span.attributes)
+    assert attrs["qveris.operation"] == "discover"
+    assert attrs["qveris.limit"] == 5
+    assert attrs["qveris.session_id"] == "sess-1"
+    assert attrs["qveris.search_id"] == "s1"
+    assert attrs["qveris.result_count"] == 2
+    assert attrs["qveris.elapsed_time_ms"] == 12.5
+    # The natural-language query must NOT be recorded.
+    assert "weather" not in json.dumps(attrs)
+
+
+@pytest.mark.asyncio
+async def test_call_emits_span_with_execution_id_and_credits(spans: InMemorySpanExporter) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "execution_id": "exec-9",
+                "tool_id": "t1",
+                "success": True,
+                "elapsed_time_ms": 210.5,
+                "billing": {"summary": "3 credits", "list_amount_credits": 3},
+            },
+        )
+
+    client = make_client(handler)
+    try:
+        await client.call("t1", {"city": "London"}, search_id="s1")
+    finally:
+        await client.close()
+
+    attrs = dict(_span_by_name(spans, "qveris.call").attributes)
+    assert attrs["qveris.operation"] == "call"
+    assert attrs["qveris.tool_id"] == "t1"
+    assert attrs["qveris.search_id"] == "s1"
+    assert attrs["qveris.execution_id"] == "exec-9"
+    assert attrs["qveris.success"] is True
+    assert attrs["qveris.elapsed_time_ms"] == 210.5
+    assert attrs["qveris.credits"] == 3
+
+
+@pytest.mark.asyncio
+async def test_call_span_marked_error_on_http_failure(spans: InMemorySpanExporter) -> None:
+    from opentelemetry.trace import StatusCode
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    client = make_client(handler)
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.call("t1", {}, search_id="s1")
+    finally:
+        await client.close()
+
+    span = _span_by_name(spans, "qveris.call")
+    assert span.status.status_code == StatusCode.ERROR
+
+
+@pytest.mark.asyncio
+async def test_tracing_disabled_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate opentelemetry not installed: the client must still work unchanged.
+    monkeypatch.setattr(observability, "_tracer", None)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"search_id": "s1", "total": 0, "results": []})
+
+    client = make_client(handler)
+    try:
+        result = await client.discover("weather", limit=3)
+    finally:
+        await client.close()
+
+    assert result.search_id == "s1"
+    assert observability.is_tracing_enabled() is False


### PR DESCRIPTION
First slice of #112 (OpenTelemetry observability): the **Python SDK**. Adds one OTel span per `discover` / `inspect` / `call` so a trace can be correlated with the QVeris usage/ledger records.

## Behavior

- **Dependency-free & best-effort.** With no `opentelemetry-api` on the path the helpers are a no-op (verified in a clean venv: `_tracer is None`, import and call behavior unchanged). Install `pip install qveris[otel]` and configure a provider/OTLP exporter to see spans.
- **Tracing never breaks the operation.** A fault in the tracer itself (broken provider/sampler/exporter) degrades to a no-op; the traced body's own exception is recorded and re-raised unchanged. A failed `call` is marked an error span.
- **No PII.** The natural-language query and tool parameters are never recorded.

## Span attributes (`qveris.` namespace)

`operation`, `tool_id` / `tool_id_count`, `search_id`, `execution_id`, `elapsed_time_ms`, `success`, `credits` (pre-settlement, from `billing.list_amount_credits` → `cost`).

## Changes

- `qveris/observability.py` — guarded optional import, `start_span` context manager, `set_span_attributes`.
- `qveris/client/api.py` — instrument `discover`/`inspect`/`call` (behavior-preserving; empty-`inspect` still short-circuits without a span).
- `pyproject.toml` — new `qveris[otel]` extra (api-only); dev adds otel-sdk for the tests.
- Tests (in-memory exporter asserts spans/attributes, error status, broken-tracer resilience, no-op path), `examples/otel_tracing.py`, README section with an OTLP/Jaeger snippet.

Reviewed by a staff-engineer agent; the one substantive finding (tracer faults must not break calls) is fixed here. **61 tests pass**; verified against pydantic and the no-otel path.

## Remaining on #112

MCP-server spans (same semantics, env toggle) as a follow-up PR.