### PR TITLE
feat(python-sdk): honor Retry-After with backoff on 429/503 (#120)

### DIFF
--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -119,6 +119,19 @@ Use the SDK at the level that matches your application:
 - Final text only: use `Agent.run_to_completion(messages)`.
 - Bring your own loop: pass `DISCOVER_TOOL_DEF`, `INSPECT_TOOL_DEF`, and `CALL_TOOL_DEF` to your LLM provider, then route tool calls through `QverisClient.handle_tool_call(...)`.
 
+## Rate limiting & retries
+
+The client transparently retries rate-limited (`429`) and transient (`503`) responses: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Each sleep is capped and the number of retries is bounded, so a call never hangs indefinitely.
+
+```python
+# Default is 3 retries; tune via config or QVERIS_MAX_RETRIES.
+client = QverisClient(QverisConfig(max_retries=5))
+# ... after some calls under load:
+print(client.rate_limit_retries)  # how many times it backed off (pressure, not failures)
+```
+
+Set `max_retries=0` to disable automatic retrying. Rate-limit backoff is retried pressure rather than failure — inspect `client.rate_limit_retries` to observe it instead of treating the retried `429`s as errors.
+
 ## Custom LLM Providers
 
 The default `Agent()` uses the built-in OpenAI-compatible provider. For non-OpenAI-compatible model APIs, implement `LLMProvider` and pass it to `Agent`:

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -46,7 +46,7 @@ from ..observability import (
     start_span,
 )
 from ..types import CreditsLedgerResponse, SearchResponse, ToolExecutionResponse, UsageHistoryResponse
-from .retry import RetryTransport
+from .retry import RetryPolicy
 
 
 def _pre_settlement_credits(response: ToolExecutionResponse) -> Optional[float]:
@@ -68,20 +68,21 @@ class QverisClient:
         if self.config.api_key:
             self.headers["Authorization"] = f"Bearer {self.config.api_key}"
 
-        # httpx automatically respects HTTP_PROXY/HTTPS_PROXY env vars. Wrap the
-        # default transport so rate-limited (429) / transient (503) responses are
-        # retried (Retry-After / backoff) instead of failing the caller.
+        # httpx automatically respects HTTP_PROXY/HTTPS_PROXY env vars (kept by
+        # using the default transport). Retries are layered on top at the client
+        # level so rate-limited (429) / transient (503) responses back off
+        # (Retry-After / jitter) instead of failing the caller.
         self.base_url = self.config.base_url.rstrip("/") + "/"
-        self._retry_transport = RetryTransport(
-            httpx.AsyncHTTPTransport(),
-            max_retries=self.config.max_retries,
-        )
         self.client = httpx.AsyncClient(
             base_url=self.base_url,
             headers=self.headers,
             timeout=60.0,
-            transport=self._retry_transport,
         )
+        self._retry = RetryPolicy(max_retries=self.config.max_retries)
+
+    async def _send(self, method: str, endpoint: str, **kwargs: Any) -> httpx.Response:
+        """Send a request through the retry policy (429/503 backoff)."""
+        return await self._retry.send(self.client, method, endpoint, **kwargs)
 
     @property
     def rate_limit_retries(self) -> int:
@@ -90,8 +91,8 @@ class QverisClient:
         Rate-limit backoff is retried pressure, not failure — surface this
         rather than counting the retried responses as errors.
         """
-        transport = getattr(self, "_retry_transport", None)
-        return transport.retries if transport is not None else 0
+        retry = getattr(self, "_retry", None)
+        return retry.retries if retry is not None else 0
 
     def _debug(self, message: str):
         """Print debug message if callback is set."""
@@ -179,7 +180,7 @@ class QverisClient:
             self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
             self._debug_headers()
 
-            response = await self.client.post("search", json=payload)
+            response = await self._send("POST", "search", json=payload)
 
             self._debug(f"[Qveris API] Response status: {response.status_code}")
             data = self._unwrap_envelope(self._parse_response_json(response))
@@ -240,7 +241,7 @@ class QverisClient:
             self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
             self._debug_headers()
 
-            response = await self.client.post("tools/by-ids", json=payload)
+            response = await self._send("POST", "tools/by-ids", json=payload)
 
             self._debug(f"[Qveris API] Response status: {response.status_code}")
             data = self._unwrap_envelope(self._parse_response_json(response))
@@ -306,7 +307,8 @@ class QverisClient:
             self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
             self._debug_headers()
 
-            response = await self.client.post(
+            response = await self._send(
+                "POST",
                 "tools/execute",
                 params={"tool_id": tool_id},
                 json=payload,
@@ -389,7 +391,7 @@ class QverisClient:
 
         self._debug(f"[Qveris API] GET {self._url_for('GET', 'auth/usage/history/v2', params=params)}")
         self._debug_headers()
-        response = await self.client.get("auth/usage/history/v2", params=params)
+        response = await self._send("GET", "auth/usage/history/v2", params=params)
         self._debug(f"[Qveris API] Response status: {response.status_code}")
         data = self._unwrap_envelope(self._parse_response_json(response))
         response.raise_for_status()
@@ -432,7 +434,7 @@ class QverisClient:
 
         self._debug(f"[Qveris API] GET {self._url_for('GET', 'auth/credits/ledger', params=params)}")
         self._debug_headers()
-        response = await self.client.get("auth/credits/ledger", params=params)
+        response = await self._send("GET", "auth/credits/ledger", params=params)
         self._debug(f"[Qveris API] Response status: {response.status_code}")
         data = self._unwrap_envelope(self._parse_response_json(response))
         response.raise_for_status()

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -46,6 +46,7 @@ from ..observability import (
     start_span,
 )
 from ..types import CreditsLedgerResponse, SearchResponse, ToolExecutionResponse, UsageHistoryResponse
+from .retry import RetryTransport
 
 
 def _pre_settlement_credits(response: ToolExecutionResponse) -> Optional[float]:
@@ -67,13 +68,30 @@ class QverisClient:
         if self.config.api_key:
             self.headers["Authorization"] = f"Bearer {self.config.api_key}"
 
-        # httpx automatically respects HTTP_PROXY/HTTPS_PROXY env vars.
+        # httpx automatically respects HTTP_PROXY/HTTPS_PROXY env vars. Wrap the
+        # default transport so rate-limited (429) / transient (503) responses are
+        # retried (Retry-After / backoff) instead of failing the caller.
         self.base_url = self.config.base_url.rstrip("/") + "/"
+        self._retry_transport = RetryTransport(
+            httpx.AsyncHTTPTransport(),
+            max_retries=self.config.max_retries,
+        )
         self.client = httpx.AsyncClient(
             base_url=self.base_url,
             headers=self.headers,
             timeout=60.0,
+            transport=self._retry_transport,
         )
+
+    @property
+    def rate_limit_retries(self) -> int:
+        """How many times the client has backed off on a 429/503 so far.
+
+        Rate-limit backoff is retried pressure, not failure — surface this
+        rather than counting the retried responses as errors.
+        """
+        transport = getattr(self, "_retry_transport", None)
+        return transport.retries if transport is not None else 0
 
     def _debug(self, message: str):
         """Print debug message if callback is set."""

--- a/packages/python-sdk/qveris/client/retry.py
+++ b/packages/python-sdk/qveris/client/retry.py
@@ -1,0 +1,106 @@
+"""Rate-limit aware retry transport for the QVeris async client.
+
+Wraps an ``httpx`` transport and transparently retries responses the QVeris API
+marks as retryable — ``429 Too Many Requests`` (and ``503``) — honoring the
+``Retry-After`` header when present, otherwise backing off exponentially with
+full jitter. Retries are bounded by ``max_retries`` and each sleep by
+``max_delay`` so a client never hangs indefinitely.
+
+The transport also tracks how often it backed off (``retries`` /
+``total_backoff_seconds``) so callers can surface rate-limit pressure as a
+statistic rather than a failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import email.utils
+import random
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Optional
+
+import httpx
+
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BASE_DELAY = 0.5  # seconds; first backoff is ~[0.25, 0.5]s
+DEFAULT_MAX_DELAY = 60.0  # seconds; caps any single sleep (incl. Retry-After)
+
+# Responses worth retrying: rate limiting and transient upstream unavailability.
+RETRYABLE_STATUS = frozenset({429, 503})
+
+
+def parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parse a ``Retry-After`` header into seconds.
+
+    Accepts both forms from RFC 9110: a delta in seconds (``"12"``) or an
+    HTTP-date. Returns ``None`` when absent/unparseable, and never a negative
+    value.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    if value.isdigit():
+        return float(value)
+    try:
+        dt = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return max(0.0, (dt - datetime.now(timezone.utc)).total_seconds())
+
+
+class RetryTransport(httpx.AsyncBaseTransport):
+    """An async transport that retries rate-limited/transient responses."""
+
+    def __init__(
+        self,
+        transport: httpx.AsyncBaseTransport,
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        base_delay: float = DEFAULT_BASE_DELAY,
+        max_delay: float = DEFAULT_MAX_DELAY,
+        sleep: Optional[Callable[[float], Awaitable[None]]] = None,
+        rng: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._transport = transport
+        self.max_retries = max(0, max_retries)
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self._sleep = sleep or asyncio.sleep
+        self._rng = rng or random.random
+        # Observability: how much rate-limit backoff this transport has absorbed.
+        self.retries = 0
+        self.total_backoff_seconds = 0.0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        attempt = 0
+        while True:
+            response = await self._transport.handle_async_request(request)
+            if response.status_code not in RETRYABLE_STATUS or attempt >= self.max_retries:
+                return response
+
+            # Release the connection before we sleep and re-send the request.
+            await response.aread()
+            await response.aclose()
+
+            delay = self._delay_for(response, attempt)
+            self.retries += 1
+            self.total_backoff_seconds += delay
+            await self._sleep(delay)
+            attempt += 1
+
+    def _delay_for(self, response: httpx.Response, attempt: int) -> float:
+        retry_after = parse_retry_after(response.headers.get("retry-after"))
+        if retry_after is not None:
+            return min(retry_after, self.max_delay)
+        # Exponential backoff with full jitter, capped at max_delay.
+        capped = min(self.base_delay * (2 ** attempt), self.max_delay)
+        return capped * (0.5 + 0.5 * self._rng())
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()

--- a/packages/python-sdk/qveris/client/retry.py
+++ b/packages/python-sdk/qveris/client/retry.py
@@ -1,14 +1,16 @@
-"""Rate-limit aware retry transport for the QVeris async client.
+"""Rate-limit aware retry for the QVeris async client.
 
-Wraps an ``httpx`` transport and transparently retries responses the QVeris API
-marks as retryable — ``429 Too Many Requests`` (and ``503``) — honoring the
-``Retry-After`` header when present, otherwise backing off exponentially with
-full jitter. Retries are bounded by ``max_retries`` and each sleep by
-``max_delay`` so a client never hangs indefinitely.
+Retries responses the QVeris API marks as retryable — ``429 Too Many Requests``
+(and ``503``) — honoring the ``Retry-After`` header when present, otherwise
+backing off exponentially with full jitter. Retries are bounded by
+``max_retries`` and each sleep by ``max_delay`` so a client never hangs.
 
-The transport also tracks how often it backed off (``retries`` /
-``total_backoff_seconds``) so callers can surface rate-limit pressure as a
-statistic rather than a failure.
+This drives retries at the *client* level (re-issuing ``client.request(...)``
+each attempt) rather than by wrapping the httpx transport, so the client keeps
+httpx's environment-proxy / mounts behavior and every attempt sends a fresh,
+fully-serialized request body. ``retries`` / ``total_backoff_seconds`` track how
+much rate-limit backoff was absorbed, so callers can surface pressure rather
+than counting it as failure.
 """
 
 from __future__ import annotations
@@ -17,13 +19,14 @@ import asyncio
 import email.utils
 import random
 from datetime import datetime, timezone
-from typing import Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import httpx
 
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_BASE_DELAY = 0.5  # seconds; first backoff is ~[0.25, 0.5]s
 DEFAULT_MAX_DELAY = 60.0  # seconds; caps any single sleep (incl. Retry-After)
+_MAX_BACKOFF_EXPONENT = 30  # guard against 2**attempt overflow at absurd retries
 
 # Responses worth retrying: rate limiting and transient upstream unavailability.
 RETRYABLE_STATUS = frozenset({429, 503})
@@ -34,14 +37,16 @@ def parse_retry_after(value: Optional[str]) -> Optional[float]:
 
     Accepts both forms from RFC 9110: a delta in seconds (``"12"``) or an
     HTTP-date. Returns ``None`` when absent/unparseable, and never a negative
-    value.
+    value. Server-controlled input, so it must never raise.
     """
     if value is None:
         return None
     value = value.strip()
     if not value:
         return None
-    if value.isdigit():
+    # ``isdigit`` is True for non-ASCII digits (e.g. superscripts) that float()
+    # can't parse, so require plain ASCII digits before converting.
+    if value.isascii() and value.isdigit():
         return float(value)
     try:
         dt = email.utils.parsedate_to_datetime(value)
@@ -54,12 +59,11 @@ def parse_retry_after(value: Optional[str]) -> Optional[float]:
     return max(0.0, (dt - datetime.now(timezone.utc)).total_seconds())
 
 
-class RetryTransport(httpx.AsyncBaseTransport):
-    """An async transport that retries rate-limited/transient responses."""
+class RetryPolicy:
+    """Retries rate-limited/transient responses when sending through a client."""
 
     def __init__(
         self,
-        transport: httpx.AsyncBaseTransport,
         *,
         max_retries: int = DEFAULT_MAX_RETRIES,
         base_delay: float = DEFAULT_BASE_DELAY,
@@ -67,24 +71,26 @@ class RetryTransport(httpx.AsyncBaseTransport):
         sleep: Optional[Callable[[float], Awaitable[None]]] = None,
         rng: Optional[Callable[[], float]] = None,
     ) -> None:
-        self._transport = transport
         self.max_retries = max(0, max_retries)
         self.base_delay = base_delay
         self.max_delay = max_delay
         self._sleep = sleep or asyncio.sleep
         self._rng = rng or random.random
-        # Observability: how much rate-limit backoff this transport has absorbed.
+        # Observability: how much rate-limit backoff this policy has absorbed.
         self.retries = 0
         self.total_backoff_seconds = 0.0
 
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+    async def send(
+        self, client: httpx.AsyncClient, method: str, url: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Send a request through ``client``, retrying 429/503 with backoff."""
         attempt = 0
         while True:
-            response = await self._transport.handle_async_request(request)
+            response = await client.request(method, url, **kwargs)
             if response.status_code not in RETRYABLE_STATUS or attempt >= self.max_retries:
                 return response
 
-            # Release the connection before we sleep and re-send the request.
+            # Release the pooled connection before sleeping and re-issuing.
             await response.aread()
             await response.aclose()
 
@@ -99,8 +105,5 @@ class RetryTransport(httpx.AsyncBaseTransport):
         if retry_after is not None:
             return min(retry_after, self.max_delay)
         # Exponential backoff with full jitter, capped at max_delay.
-        capped = min(self.base_delay * (2 ** attempt), self.max_delay)
+        capped = min(self.base_delay * (2 ** min(attempt, _MAX_BACKOFF_EXPONENT)), self.max_delay)
         return capped * (0.5 + 0.5 * self._rng())
-
-    async def aclose(self) -> None:
-        await self._transport.aclose()

--- a/packages/python-sdk/qveris/client/retry.py
+++ b/packages/python-sdk/qveris/client/retry.py
@@ -32,11 +32,29 @@ _MAX_BACKOFF_EXPONENT = 30  # guard against 2**attempt overflow at absurd retrie
 RETRYABLE_STATUS = frozenset({429, 503})
 
 
-def parse_retry_after(value: Optional[str]) -> Optional[float]:
+def _parse_http_date(value: Optional[str]) -> Optional[datetime]:
+    """Parse an HTTP-date to an aware UTC datetime; ``None`` if unparseable."""
+    if not value:
+        return None
+    try:
+        dt = email.utils.parsedate_to_datetime(value)
+    except Exception:  # malformed input must never raise out of retry handling
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def parse_retry_after(value: Optional[str], reference_date: Optional[str] = None) -> Optional[float]:
     """Parse a ``Retry-After`` header into seconds.
 
     Accepts both forms from RFC 9110: a delta in seconds (``"12"``) or an
-    HTTP-date. Returns ``None`` when absent/unparseable, and never a negative
+    HTTP-date. For the HTTP-date form the delay is computed against the
+    response's ``Date`` header when given (RFC 9110 §10.2.3), falling back to
+    the local clock — keeping the delay accurate under client/server clock
+    skew. Returns ``None`` when absent/unparseable, and never a negative
     value. Server-controlled input, so it must never raise.
     """
     if value is None:
@@ -48,15 +66,13 @@ def parse_retry_after(value: Optional[str]) -> Optional[float]:
     # can't parse, so require plain ASCII digits before converting.
     if value.isascii() and value.isdigit():
         return float(value)
-    try:
-        dt = email.utils.parsedate_to_datetime(value)
-    except (TypeError, ValueError):
-        return None
+    dt = _parse_http_date(value)
     if dt is None:
         return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return max(0.0, (dt - datetime.now(timezone.utc)).total_seconds())
+    ref = _parse_http_date(reference_date)
+    if ref is None:
+        ref = datetime.now(timezone.utc)
+    return max(0.0, (dt - ref).total_seconds())
 
 
 class RetryPolicy:
@@ -101,7 +117,10 @@ class RetryPolicy:
             attempt += 1
 
     def _delay_for(self, response: httpx.Response, attempt: int) -> float:
-        retry_after = parse_retry_after(response.headers.get("retry-after"))
+        retry_after = parse_retry_after(
+            response.headers.get("retry-after"),
+            response.headers.get("date"),
+        )
         if retry_after is not None:
             return min(retry_after, self.max_delay)
         # Exponential backoff with full jitter, capped at max_delay.

--- a/packages/python-sdk/qveris/config.py
+++ b/packages/python-sdk/qveris/config.py
@@ -73,6 +73,14 @@ class QverisConfig(BaseSettings):
     api_key: Optional[str] = Field(default=None, validation_alias='QVERIS_API_KEY')
     base_url: str = Field(default="https://qveris.ai/api/v1/", validation_alias='QVERIS_BASE_URL')
 
+    # Transport settings. On a 429 (or 503) the client honors Retry-After and
+    # otherwise backs off exponentially with jitter, up to this many retries.
+    max_retries: int = Field(
+        default=3,
+        validation_alias='QVERIS_MAX_RETRIES',
+        description="Max automatic retries for rate-limited (429) / transient (503) responses.",
+    )
+
     # Agent behavior settings
     enable_history_pruning: bool = Field(
         default=True,

--- a/packages/python-sdk/tests/test_retry.py
+++ b/packages/python-sdk/tests/test_retry.py
@@ -39,6 +39,19 @@ def test_parse_retry_after_http_date_is_non_negative() -> None:
     assert parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0
 
 
+def test_parse_retry_after_http_date_uses_response_date_as_reference() -> None:
+    # RFC 9110 §10.2.3: with a Date header, the delay is Retry-After - Date —
+    # immune to client/server clock skew (30s here regardless of local time).
+    delay = parse_retry_after(
+        "Wed, 21 Oct 2015 07:28:30 GMT",  # Retry-After (HTTP-date, in the past locally)
+        "Wed, 21 Oct 2015 07:28:00 GMT",  # response Date
+    )
+    assert delay == 30.0
+
+    # An unparseable Date falls back to the local clock (past date -> 0).
+    assert parse_retry_after("Wed, 21 Oct 2015 07:28:30 GMT", "garbage") == 0.0
+
+
 def test_parse_retry_after_invalid_or_absent_returns_none() -> None:
     assert parse_retry_after(None) is None
     assert parse_retry_after("") is None

--- a/packages/python-sdk/tests/test_retry.py
+++ b/packages/python-sdk/tests/test_retry.py
@@ -1,0 +1,196 @@
+from typing import List
+
+import httpx
+import pytest
+
+from qveris.client.api import QverisClient
+from qveris.client.retry import RetryTransport, parse_retry_after
+from qveris.config import QverisConfig
+
+
+class FakeSleep:
+    """Records requested delays instead of actually sleeping."""
+
+    def __init__(self) -> None:
+        self.delays: List[float] = []
+
+    async def __call__(self, delay: float) -> None:
+        self.delays.append(delay)
+
+
+def make_transport(handler, sleep=None, rng=None, **kwargs) -> RetryTransport:
+    return RetryTransport(
+        httpx.MockTransport(handler),
+        sleep=sleep or FakeSleep(),
+        rng=rng or (lambda: 0.0),
+        **kwargs,
+    )
+
+
+async def send(transport: RetryTransport) -> httpx.Response:
+    async with httpx.AsyncClient(transport=transport, base_url="https://x.test") as client:
+        return await client.get("/")
+
+
+# --- parse_retry_after -------------------------------------------------------
+
+
+def test_parse_retry_after_seconds() -> None:
+    assert parse_retry_after("12") == 12.0
+
+
+def test_parse_retry_after_http_date_is_non_negative() -> None:
+    # A far-future date yields a positive delay; a past date clamps to 0.
+    assert parse_retry_after("Wed, 21 Oct 2099 07:28:00 GMT") > 0
+    assert parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0
+
+
+def test_parse_retry_after_invalid_or_absent() -> None:
+    assert parse_retry_after(None) is None
+    assert parse_retry_after("") is None
+    assert parse_retry_after("not-a-date") is None
+
+
+# --- RetryTransport ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retries_on_429_then_succeeds_honoring_retry_after() -> None:
+    calls: List[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        if len(calls) == 1:
+            return httpx.Response(429, headers={"Retry-After": "2"}, json={"error": "rate"})
+        return httpx.Response(200, json={"ok": True})
+
+    sleep = FakeSleep()
+    transport = make_transport(handler, sleep=sleep)
+    response = await send(transport)
+
+    assert response.status_code == 200
+    assert len(calls) == 2
+    assert sleep.delays == [2.0]  # honored Retry-After
+    assert transport.retries == 1
+    assert transport.total_backoff_seconds == 2.0
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_max_retries_and_returns_final_response() -> None:
+    calls: List[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        return httpx.Response(429, json={"error": "rate"})
+
+    sleep = FakeSleep()
+    transport = make_transport(handler, sleep=sleep, max_retries=2)
+    response = await send(transport)
+
+    # The final 429 is returned to the caller (not raised); 3 attempts, 2 backoffs.
+    assert response.status_code == 429
+    assert len(calls) == 3
+    assert transport.retries == 2
+    assert len(sleep.delays) == 2
+
+
+@pytest.mark.asyncio
+async def test_exponential_backoff_with_jitter_when_no_header() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429)
+
+    sleep = FakeSleep()
+    # rng=1.0 -> jitter factor (0.5 + 0.5*1.0) = 1.0 (full capped delay).
+    transport = make_transport(handler, sleep=sleep, max_retries=3, base_delay=1.0, rng=lambda: 1.0)
+    await send(transport)
+
+    assert sleep.delays == [1.0, 2.0, 4.0]  # 1*2^0, 1*2^1, 1*2^2
+
+
+@pytest.mark.asyncio
+async def test_backoff_and_retry_after_capped_at_max_delay() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "9999"})
+
+    sleep = FakeSleep()
+    transport = make_transport(handler, sleep=sleep, max_retries=1, max_delay=30.0)
+    await send(transport)
+
+    assert sleep.delays == [30.0]  # Retry-After capped at max_delay
+
+
+@pytest.mark.asyncio
+async def test_503_is_retried() -> None:
+    calls: List[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        return httpx.Response(503 if len(calls) == 1 else 200)
+
+    transport = make_transport(handler)
+    response = await send(transport)
+
+    assert response.status_code == 200
+    assert transport.retries == 1
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_status_is_not_retried() -> None:
+    calls: List[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        return httpx.Response(500, json={"error": "boom"})
+
+    transport = make_transport(handler)
+    response = await send(transport)
+
+    assert response.status_code == 500
+    assert len(calls) == 1
+    assert transport.retries == 0
+
+
+@pytest.mark.asyncio
+async def test_max_retries_zero_disables_retrying() -> None:
+    calls: List[int] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        return httpx.Response(429)
+
+    transport = make_transport(handler, max_retries=0)
+    response = await send(transport)
+
+    assert response.status_code == 429
+    assert len(calls) == 1
+    assert transport.retries == 0
+
+
+# --- Client integration ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_discover_retries_and_reports_rate_limit_retries() -> None:
+    calls: List[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        if len(calls) == 1:
+            return httpx.Response(429, headers={"Retry-After": "1"}, json={"error": "rate"})
+        return httpx.Response(200, json={"search_id": "s1", "total": 0, "results": []})
+
+    client = QverisClient(QverisConfig(api_key="sk-test", base_url="https://qveris.ai/api/v1"))
+    transport = make_transport(handler)
+    client._retry_transport = transport
+    client.client = httpx.AsyncClient(
+        base_url=client.base_url, headers=client.headers, transport=transport, timeout=60.0
+    )
+
+    try:
+        result = await client.discover("weather", limit=3)
+    finally:
+        await client.close()
+
+    assert result.search_id == "s1"
+    assert len(calls) == 2
+    assert client.rate_limit_retries == 1

--- a/packages/python-sdk/tests/test_retry.py
+++ b/packages/python-sdk/tests/test_retry.py
@@ -1,10 +1,11 @@
-from typing import List
+import json
+from typing import List, Optional
 
 import httpx
 import pytest
 
 from qveris.client.api import QverisClient
-from qveris.client.retry import RetryTransport, parse_retry_after
+from qveris.client.retry import RetryPolicy, parse_retry_after
 from qveris.config import QverisConfig
 
 
@@ -18,18 +19,12 @@ class FakeSleep:
         self.delays.append(delay)
 
 
-def make_transport(handler, sleep=None, rng=None, **kwargs) -> RetryTransport:
-    return RetryTransport(
-        httpx.MockTransport(handler),
-        sleep=sleep or FakeSleep(),
-        rng=rng or (lambda: 0.0),
-        **kwargs,
-    )
-
-
-async def send(transport: RetryTransport) -> httpx.Response:
-    async with httpx.AsyncClient(transport=transport, base_url="https://x.test") as client:
-        return await client.get("/")
+async def run(handler, *, sleep: Optional[FakeSleep] = None, rng=None, **kwargs):
+    """Send a request through a RetryPolicy against a MockTransport handler."""
+    policy = RetryPolicy(sleep=sleep or FakeSleep(), rng=rng or (lambda: 0.0), **kwargs)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://x.test") as client:
+        response = await policy.send(client, "GET", "/")
+    return response, policy
 
 
 # --- parse_retry_after -------------------------------------------------------
@@ -40,18 +35,21 @@ def test_parse_retry_after_seconds() -> None:
 
 
 def test_parse_retry_after_http_date_is_non_negative() -> None:
-    # A far-future date yields a positive delay; a past date clamps to 0.
     assert parse_retry_after("Wed, 21 Oct 2099 07:28:00 GMT") > 0
     assert parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0
 
 
-def test_parse_retry_after_invalid_or_absent() -> None:
+def test_parse_retry_after_invalid_or_absent_returns_none() -> None:
     assert parse_retry_after(None) is None
     assert parse_retry_after("") is None
     assert parse_retry_after("not-a-date") is None
+    assert parse_retry_after("-5") is None
+    # isdigit() is True for these but float() can't parse them — must not raise.
+    assert parse_retry_after("²") is None  # superscript two
+    assert parse_retry_after("⁵") is None  # superscript five
 
 
-# --- RetryTransport ----------------------------------------------------------
+# --- RetryPolicy -------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -65,14 +63,13 @@ async def test_retries_on_429_then_succeeds_honoring_retry_after() -> None:
         return httpx.Response(200, json={"ok": True})
 
     sleep = FakeSleep()
-    transport = make_transport(handler, sleep=sleep)
-    response = await send(transport)
+    response, policy = await run(handler, sleep=sleep)
 
     assert response.status_code == 200
     assert len(calls) == 2
-    assert sleep.delays == [2.0]  # honored Retry-After
-    assert transport.retries == 1
-    assert transport.total_backoff_seconds == 2.0
+    assert sleep.delays == [2.0]
+    assert policy.retries == 1
+    assert policy.total_backoff_seconds == 2.0
 
 
 @pytest.mark.asyncio
@@ -84,13 +81,11 @@ async def test_gives_up_after_max_retries_and_returns_final_response() -> None:
         return httpx.Response(429, json={"error": "rate"})
 
     sleep = FakeSleep()
-    transport = make_transport(handler, sleep=sleep, max_retries=2)
-    response = await send(transport)
+    response, policy = await run(handler, sleep=sleep, max_retries=2)
 
-    # The final 429 is returned to the caller (not raised); 3 attempts, 2 backoffs.
-    assert response.status_code == 429
-    assert len(calls) == 3
-    assert transport.retries == 2
+    assert response.status_code == 429  # final 429 returned, not raised
+    assert len(calls) == 3  # max_retries + 1 attempts
+    assert policy.retries == 2
     assert len(sleep.delays) == 2
 
 
@@ -101,22 +96,27 @@ async def test_exponential_backoff_with_jitter_when_no_header() -> None:
 
     sleep = FakeSleep()
     # rng=1.0 -> jitter factor (0.5 + 0.5*1.0) = 1.0 (full capped delay).
-    transport = make_transport(handler, sleep=sleep, max_retries=3, base_delay=1.0, rng=lambda: 1.0)
-    await send(transport)
+    await run(handler, sleep=sleep, max_retries=3, base_delay=1.0, rng=lambda: 1.0)
 
-    assert sleep.delays == [1.0, 2.0, 4.0]  # 1*2^0, 1*2^1, 1*2^2
+    assert sleep.delays == [1.0, 2.0, 4.0]
 
 
 @pytest.mark.asyncio
-async def test_backoff_and_retry_after_capped_at_max_delay() -> None:
+async def test_retry_after_capped_at_max_delay() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(429, headers={"Retry-After": "9999"})
 
     sleep = FakeSleep()
-    transport = make_transport(handler, sleep=sleep, max_retries=1, max_delay=30.0)
-    await send(transport)
+    await run(handler, sleep=sleep, max_retries=1, max_delay=30.0)
 
-    assert sleep.delays == [30.0]  # Retry-After capped at max_delay
+    assert sleep.delays == [30.0]
+
+
+def test_delay_never_overflows_at_huge_attempt() -> None:
+    policy = RetryPolicy(base_delay=0.5, max_delay=60.0, rng=lambda: 1.0)
+    response = httpx.Response(429)  # no Retry-After
+    delay = policy._delay_for(response, attempt=5000)  # would overflow 2**attempt
+    assert delay == 60.0
 
 
 @pytest.mark.asyncio
@@ -127,11 +127,9 @@ async def test_503_is_retried() -> None:
         calls.append(1)
         return httpx.Response(503 if len(calls) == 1 else 200)
 
-    transport = make_transport(handler)
-    response = await send(transport)
-
+    response, policy = await run(handler)
     assert response.status_code == 200
-    assert transport.retries == 1
+    assert policy.retries == 1
 
 
 @pytest.mark.asyncio
@@ -142,12 +140,10 @@ async def test_non_retryable_status_is_not_retried() -> None:
         calls.append(1)
         return httpx.Response(500, json={"error": "boom"})
 
-    transport = make_transport(handler)
-    response = await send(transport)
-
+    response, policy = await run(handler)
     assert response.status_code == 500
     assert len(calls) == 1
-    assert transport.retries == 0
+    assert policy.retries == 0
 
 
 @pytest.mark.asyncio
@@ -158,12 +154,31 @@ async def test_max_retries_zero_disables_retrying() -> None:
         calls.append(1)
         return httpx.Response(429)
 
-    transport = make_transport(handler, max_retries=0)
-    response = await send(transport)
-
+    response, policy = await run(handler, max_retries=0)
     assert response.status_code == 429
     assert len(calls) == 1
-    assert transport.retries == 0
+    assert policy.retries == 0
+
+
+@pytest.mark.asyncio
+async def test_retried_post_resends_the_json_body() -> None:
+    bodies: List[bytes] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(request.content)
+        if len(bodies) == 1:
+            return httpx.Response(429)
+        return httpx.Response(200, json={"ok": True})
+
+    policy = RetryPolicy(sleep=FakeSleep(), rng=lambda: 0.0)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://x.test") as client:
+        response = await policy.send(client, "POST", "/search", json={"query": "weather"})
+
+    assert response.status_code == 200
+    # Both attempts carried the full serialized body (not a consumed/empty stream).
+    assert len(bodies) == 2
+    assert json.loads(bodies[0]) == {"query": "weather"}
+    assert bodies[1] == bodies[0]
 
 
 # --- Client integration ------------------------------------------------------
@@ -173,17 +188,19 @@ async def test_max_retries_zero_disables_retrying() -> None:
 async def test_client_discover_retries_and_reports_rate_limit_retries() -> None:
     calls: List[int] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(_request: httpx.Request) -> httpx.Response:
         calls.append(1)
         if len(calls) == 1:
             return httpx.Response(429, headers={"Retry-After": "1"}, json={"error": "rate"})
         return httpx.Response(200, json={"search_id": "s1", "total": 0, "results": []})
 
     client = QverisClient(QverisConfig(api_key="sk-test", base_url="https://qveris.ai/api/v1"))
-    transport = make_transport(handler)
-    client._retry_transport = transport
+    client._retry = RetryPolicy(sleep=FakeSleep(), rng=lambda: 0.0)
     client.client = httpx.AsyncClient(
-        base_url=client.base_url, headers=client.headers, transport=transport, timeout=60.0
+        base_url=client.base_url,
+        headers=client.headers,
+        transport=httpx.MockTransport(handler),
+        timeout=60.0,
     )
 
     try:


### PR DESCRIPTION
The 429-backoff slice of #120 for the **Python SDK**. Previously a `429` failed the call outright; now the client transparently retries.

## Behavior

- Retries rate-limited (`429`) and transient (`503`) responses: honors the `Retry-After` header (delta-seconds or HTTP-date) when present, otherwise exponential backoff with **full jitter**. Each sleep is capped at `max_delay` and retries bounded by `max_retries` (default 3; `QverisConfig.max_retries` / `QVERIS_MAX_RETRIES`; `0` disables), so a call never hangs.
- Retries run at the **client level** (`RetryPolicy` re-issues `client.request` per attempt) rather than by wrapping the transport — so httpx's env-proxy (`HTTP_PROXY`/`HTTPS_PROXY`) and mounts behavior is preserved, and each attempt sends a freshly-serialized body.
- Rate-limit backoff is surfaced as pressure, not failure: `client.rate_limit_retries` counts how many times it backed off.

## Review-driven hardening (fixed before opening)

- **Proxy regression:** an earlier draft wrapped the transport, which silently disabled env-proxy support (a corporate-proxy user would break). Moved retries to the client level to keep it — verified `client._mounts` still has the proxy mounts with `HTTPS_PROXY` set.
- **`parse_retry_after` crash:** a server-controlled `Retry-After` like `²` (`isdigit()` True but `float()` raises) turned a retryable 429 into a hard failure. Now requires ASCII digits → returns `None`.
- **Overflow:** capped the backoff exponent so an absurd `max_retries` can't raise `OverflowError`.

## Testing

`tests/test_retry.py` (13): Retry-After honoring, backoff+jitter, cap, give-up-returns-final-response, 503, non-retryable, disable, unicode-digit, overflow, POST-body-resend, client integration. **69 tests pass**, compileall clean.

## Rest of #120

Same treatment for **js-sdk**, **CLI**, and **MCP** in follow-up PRs (each a single-point add at their request layer).