### PR TITLE
feat(js-sdk): honor Retry-After with backoff on 429/503 (#120)

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -60,6 +60,19 @@ const credits = await qveris.credits();
 | `baseUrl` / `QVERIS_BASE_URL` | Override API base URL (highest priority) |
 | `QVERIS_REGION` | Force region: `global` or `cn`. Otherwise auto-detected from the key prefix (`sk-cn-…` → China) |
 | `timeoutMs` | Default request timeout (30s; `call` defaults to 120s) |
+| `maxRetries` | Retries for rate-limited (429) / transient (503) responses (default 3; `0` disables) |
+
+## Rate limiting & retries
+
+The client transparently retries rate-limited (`429`) and transient (`503`) responses: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Each wait is capped and retries are bounded by `maxRetries`, so a call never hangs.
+
+```ts
+const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY!, maxRetries: 5 });
+// ... after some calls under load:
+qveris.rateLimitRetryCount; // how many times it backed off (pressure, not failures)
+```
+
+Set `maxRetries: 0` to disable. Rate-limit backoff is retried pressure rather than failure — read `rateLimitRetryCount` to observe it instead of treating the retried `429`s as errors.
 
 ## Errors
 

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -347,4 +347,63 @@ describe('Qveris client', () => {
     expect(error).toBeInstanceOf(QverisApiError);
     expect((error as QverisApiError).observability?.error_type).toBe('invalid_json');
   });
+
+  describe('rate-limit retries', () => {
+    function rateLimited(retryAfter?: string): Response {
+      const headers = new Headers();
+      if (retryAfter) headers.set('Retry-After', retryAfter);
+      return {
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        json: () => Promise.resolve({ error: 'rate limited' }),
+        headers,
+      } as unknown as Response;
+    }
+
+    it('retries a 429 then succeeds, counting the backoff', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(rateLimited('1'))
+        .mockResolvedValueOnce(jsonResponse(SAMPLE_DISCOVER_RESPONSE));
+      globalThis.fetch = fetchMock;
+
+      const client = new Qveris({ apiKey: API_KEY });
+      vi.spyOn(client as unknown as { sleep: () => Promise<void> }, 'sleep').mockResolvedValue(undefined);
+
+      const result = await client.discover('weather');
+
+      expect(result.search_id).toBe('search-123');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(client.rateLimitRetryCount).toBe(1);
+    });
+
+    it('gives up after maxRetries and throws the final 429', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(rateLimited());
+      globalThis.fetch = fetchMock;
+
+      const client = new Qveris({ apiKey: API_KEY, maxRetries: 2 });
+      vi.spyOn(client as unknown as { sleep: () => Promise<void> }, 'sleep').mockResolvedValue(undefined);
+
+      const error = await client.discover('weather').catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QverisApiError);
+      expect((error as QverisApiError).status).toBe(429);
+      expect(fetchMock).toHaveBeenCalledTimes(3); // maxRetries + 1
+      expect(client.rateLimitRetryCount).toBe(2);
+    });
+
+    it('maxRetries=0 disables retrying', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(rateLimited());
+      globalThis.fetch = fetchMock;
+
+      const client = new Qveris({ apiKey: API_KEY, maxRetries: 0 });
+
+      const error = await client.discover('weather').catch((e: unknown) => e);
+
+      expect((error as QverisApiError).status).toBe(429);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(client.rateLimitRetryCount).toBe(0);
+    });
+  });
 });

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -12,6 +12,14 @@
  */
 
 import { QverisApiError } from './errors.js';
+import {
+  computeRetryDelayMs,
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_MAX_DELAY_MS,
+  parseRetryAfterMs,
+  resolveMaxRetries,
+  RETRYABLE_STATUS,
+} from './retry.js';
 import type {
   ApiEnvelope,
   ApiError,
@@ -117,6 +125,8 @@ export class Qveris {
   private readonly apiKey: string;
   private readonly baseUrl: string;
   private readonly defaultTimeoutMs: number;
+  private readonly maxRetries: number;
+  private rateLimitRetries = 0;
 
   constructor(config: QverisClientConfig) {
     if (!config.apiKey) {
@@ -129,6 +139,22 @@ export class Qveris {
     this.apiKey = config.apiKey;
     this.baseUrl = resolveBaseUrl(config.apiKey, config.baseUrl);
     this.defaultTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = resolveMaxRetries(config.maxRetries);
+  }
+
+  /**
+   * How many times the client has backed off on a rate-limited (429) /
+   * transient (503) response so far. Rate-limit backoff is retried pressure,
+   * not failure — observe this rather than counting the retried responses.
+   */
+  get rateLimitRetryCount(): number {
+    return this.rateLimitRetries;
+  }
+
+  /** Sleep for `ms` (a seam so tests can stub out the wait). */
+  private async sleep(ms: number): Promise<void> {
+    if (ms <= 0) return;
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /**
@@ -256,7 +282,6 @@ export class Qveris {
         }
       }
     }
-    const controller = new AbortController();
     const resolvedTimeoutMs = timeoutMs ?? this.defaultTimeoutMs;
     const queryParams = Object.fromEntries(url.searchParams.entries());
     const requestContext: ApiObservability = {
@@ -268,93 +293,113 @@ export class Qveris {
       ...(Object.keys(queryParams).length > 0 && { query_params: queryParams }),
       timeout_ms: resolvedTimeoutMs,
     };
-    const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
 
-    try {
-      const response = await fetch(url.toString(), {
-        method,
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: body ? JSON.stringify(body) : undefined,
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        const status = response.status;
-        let errorMessage: string;
-        let errorDetails: unknown;
-
-        try {
-          const errorBody = (await response.json()) as Record<string, unknown>;
-          errorMessage =
-            (errorBody.error_message as string) ||
-            (errorBody.message as string) ||
-            (errorBody.error as string) ||
-            response.statusText;
-          errorDetails = errorBody;
-        } catch {
-          errorMessage = response.statusText || `HTTP ${status}`;
-        }
-
-        if (status === 402) {
-          const pricingHost = this.baseUrl.includes('qveris.cn')
-            ? 'https://qveris.cn'
-            : 'https://qveris.ai';
-          errorMessage = `Insufficient credits. ${errorMessage}. Purchase credits at ${pricingHost}/pricing`;
-        }
-
-        throw new QverisApiError({
-          status,
-          message: errorMessage,
-          ...(errorDetails !== undefined && { details: errorDetails }),
-          observability: withErrorContext(
-            requestContext,
-            'http_error',
-            status,
-            extractRequestId(response),
-          ),
-        });
-      }
-
-      let payload: unknown;
+    // Retry rate-limited (429) / transient (503) responses: honor Retry-After,
+    // otherwise exponential backoff with jitter, bounded by maxRetries. Each
+    // attempt is a fresh fetch with its own timeout.
+    for (let attempt = 0; ; attempt++) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
+      let retryDelayMs: number | null = null;
       try {
-        payload = await response.json();
-      } catch {
-        throw new QverisApiError({
-          status: response.status,
-          message: 'Invalid or empty JSON response from API',
-          observability: withErrorContext(
-            requestContext,
-            'invalid_json',
-            response.status,
-            extractRequestId(response),
-          ),
+        const response = await fetch(url.toString(), {
+          method,
+          headers: {
+            'Authorization': `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
         });
-      }
 
-      return this.unwrapEnvelope<T>(payload, requestContext);
-    } catch (err: unknown) {
-      if (err instanceof QverisApiError) {
-        throw err;
-      }
-      if (err instanceof Error && err.name === 'AbortError') {
+        if (RETRYABLE_STATUS.has(response.status) && attempt < this.maxRetries) {
+          retryDelayMs = computeRetryDelayMs({
+            retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
+            attempt,
+            baseDelayMs: DEFAULT_BASE_DELAY_MS,
+            maxDelayMs: DEFAULT_MAX_DELAY_MS,
+          });
+          // Discard the body so the connection is released before we retry.
+          await response.body?.cancel().catch(() => undefined);
+          this.rateLimitRetries++;
+        } else if (!response.ok) {
+          const status = response.status;
+          let errorMessage: string;
+          let errorDetails: unknown;
+
+          try {
+            const errorBody = (await response.json()) as Record<string, unknown>;
+            errorMessage =
+              (errorBody.error_message as string) ||
+              (errorBody.message as string) ||
+              (errorBody.error as string) ||
+              response.statusText;
+            errorDetails = errorBody;
+          } catch {
+            errorMessage = response.statusText || `HTTP ${status}`;
+          }
+
+          if (status === 402) {
+            const pricingHost = this.baseUrl.includes('qveris.cn')
+              ? 'https://qveris.cn'
+              : 'https://qveris.ai';
+            errorMessage = `Insufficient credits. ${errorMessage}. Purchase credits at ${pricingHost}/pricing`;
+          }
+
+          throw new QverisApiError({
+            status,
+            message: errorMessage,
+            ...(errorDetails !== undefined && { details: errorDetails }),
+            observability: withErrorContext(
+              requestContext,
+              'http_error',
+              status,
+              extractRequestId(response),
+            ),
+          });
+        } else {
+          let payload: unknown;
+          try {
+            payload = await response.json();
+          } catch {
+            throw new QverisApiError({
+              status: response.status,
+              message: 'Invalid or empty JSON response from API',
+              observability: withErrorContext(
+                requestContext,
+                'invalid_json',
+                response.status,
+                extractRequestId(response),
+              ),
+            });
+          }
+
+          return this.unwrapEnvelope<T>(payload, requestContext);
+        }
+      } catch (err: unknown) {
+        if (err instanceof QverisApiError) {
+          throw err;
+        }
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw new QverisApiError({
+            status: 408,
+            message: 'Request timed out. Check connectivity or increase timeout.',
+            observability: withErrorContext(requestContext, 'timeout', 0),
+            ...(errorCause(err) && { cause: errorCause(err) }),
+          });
+        }
         throw new QverisApiError({
-          status: 408,
-          message: 'Request timed out. Check connectivity or increase timeout.',
-          observability: withErrorContext(requestContext, 'timeout', 0),
+          status: 0,
+          message: err instanceof Error && err.message ? err.message : 'Network request failed',
+          observability: withErrorContext(requestContext, 'network_error', 0),
           ...(errorCause(err) && { cause: errorCause(err) }),
         });
+      } finally {
+        clearTimeout(timeout);
       }
-      throw new QverisApiError({
-        status: 0,
-        message: err instanceof Error && err.message ? err.message : 'Network request failed',
-        observability: withErrorContext(requestContext, 'network_error', 0),
-        ...(errorCause(err) && { cause: errorCause(err) }),
-      });
-    } finally {
-      clearTimeout(timeout);
+
+      // Only reached on the retry path (success returns, errors throw above).
+      await this.sleep(retryDelayMs ?? 0);
     }
   }
 

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -320,7 +320,9 @@ export class Qveris {
             maxDelayMs: DEFAULT_MAX_DELAY_MS,
           });
           // Discard the body so the connection is released before we retry.
-          await response.body?.cancel().catch(() => undefined);
+          // (`.cancel?.()` so a body without cancel — e.g. a test double —
+          // can't throw here and mask the rate-limit as a network error.)
+          await response.body?.cancel?.().catch(() => undefined);
           this.rateLimitRetries++;
         } else if (!response.ok) {
           const status = response.status;

--- a/packages/js-sdk/src/retry.test.ts
+++ b/packages/js-sdk/src/retry.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeRetryDelayMs,
+  DEFAULT_MAX_RETRIES,
+  parseRetryAfterMs,
+  resolveMaxRetries,
+} from './retry.js';
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds into milliseconds', () => {
+    expect(parseRetryAfterMs('12')).toBe(12_000);
+    expect(parseRetryAfterMs('0')).toBe(0);
+  });
+
+  it('parses an HTTP-date relative to now, clamped at 0', () => {
+    const now = Date.parse('2026-01-01T00:00:00Z');
+    expect(parseRetryAfterMs('Thu, 01 Jan 2026 00:00:30 GMT', now)).toBe(30_000);
+    expect(parseRetryAfterMs('Thu, 01 Jan 2020 00:00:00 GMT', now)).toBe(0); // past -> 0
+  });
+
+  it('returns null for absent/invalid values (never throws)', () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs(undefined)).toBeNull();
+    expect(parseRetryAfterMs('')).toBeNull();
+    expect(parseRetryAfterMs('not-a-date')).toBeNull();
+    expect(parseRetryAfterMs('-5')).toBeNull();
+    expect(parseRetryAfterMs('12.5')).toBeNull();
+    expect(parseRetryAfterMs('²')).toBeNull(); // non-ASCII digit
+  });
+});
+
+describe('computeRetryDelayMs', () => {
+  const base = { baseDelayMs: 500, maxDelayMs: 60_000 };
+
+  it('honors Retry-After, capped at maxDelayMs', () => {
+    expect(computeRetryDelayMs({ ...base, retryAfterMs: 2_000, attempt: 0 })).toBe(2_000);
+    expect(computeRetryDelayMs({ ...base, retryAfterMs: 999_999, attempt: 0 })).toBe(60_000);
+  });
+
+  it('backs off exponentially with full jitter when no Retry-After', () => {
+    // random()=1 -> factor (0.5 + 0.5*1) = 1 (full capped delay).
+    const full = (attempt: number) =>
+      computeRetryDelayMs({ ...base, retryAfterMs: null, attempt, random: () => 1 });
+    expect(full(0)).toBe(500);
+    expect(full(1)).toBe(1_000);
+    expect(full(2)).toBe(2_000);
+
+    // random()=0 -> factor 0.5 (half the capped delay).
+    expect(computeRetryDelayMs({ ...base, retryAfterMs: null, attempt: 0, random: () => 0 })).toBe(250);
+  });
+
+  it('never overflows at a huge attempt', () => {
+    expect(
+      computeRetryDelayMs({ ...base, retryAfterMs: null, attempt: 5000, random: () => 1 }),
+    ).toBe(60_000);
+  });
+});
+
+describe('resolveMaxRetries', () => {
+  it('defaults, clamps, and floors', () => {
+    expect(resolveMaxRetries(undefined)).toBe(DEFAULT_MAX_RETRIES);
+    expect(resolveMaxRetries(5)).toBe(5);
+    expect(resolveMaxRetries(0)).toBe(0);
+    expect(resolveMaxRetries(-3)).toBe(0);
+    expect(resolveMaxRetries(2.9)).toBe(2);
+    expect(resolveMaxRetries(Number.NaN)).toBe(DEFAULT_MAX_RETRIES);
+  });
+});

--- a/packages/js-sdk/src/retry.ts
+++ b/packages/js-sdk/src/retry.ts
@@ -1,0 +1,75 @@
+/**
+ * Rate-limit aware retry helpers for the QVeris client.
+ *
+ * Pure functions the client uses to decide whether and how long to wait before
+ * retrying a rate-limited (`429`) or transient (`503`) response — honoring the
+ * `Retry-After` header when present, otherwise exponential backoff with full
+ * jitter. Kept separate from the client so the delay math is unit-testable.
+ *
+ * @module @qverisai/sdk/retry
+ */
+
+export const DEFAULT_MAX_RETRIES = 3;
+export const DEFAULT_BASE_DELAY_MS = 500;
+export const DEFAULT_MAX_DELAY_MS = 60_000;
+const MAX_BACKOFF_EXPONENT = 30; // guards 2**attempt against overflow
+
+/** HTTP statuses worth retrying: rate limiting + transient unavailability. */
+export const RETRYABLE_STATUS = new Set([429, 503]);
+
+/**
+ * Parse a `Retry-After` header into milliseconds.
+ *
+ * Accepts both RFC 9110 forms — a delta in seconds (`"12"`) or an HTTP-date.
+ * Returns `null` when absent/unparseable, and never a negative value.
+ */
+export function parseRetryAfterMs(value: string | null | undefined, now: number = Date.now()): number | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+
+  // Delta-seconds form: a non-negative integer.
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+
+  // HTTP-date form. Require a letter (month name / "GMT") so Date.parse's
+  // leniency doesn't turn junk like "-5" into a spurious date.
+  if (!/[a-zA-Z]/.test(trimmed)) return null;
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) return null;
+  return Math.max(0, dateMs - now);
+}
+
+export interface RetryDelayOptions {
+  /** Parsed `Retry-After` in ms, or null to use backoff. */
+  retryAfterMs: number | null;
+  /** Zero-based attempt index (0 = first retry). */
+  attempt: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  /** Jitter source in [0, 1); defaults to `Math.random`. */
+  random?: () => number;
+}
+
+/**
+ * Compute how long to wait before the next attempt, in milliseconds.
+ *
+ * Honors `retryAfterMs` (capped at `maxDelayMs`); otherwise exponential backoff
+ * `baseDelayMs * 2**attempt` with full jitter, capped at `maxDelayMs`.
+ */
+export function computeRetryDelayMs(options: RetryDelayOptions): number {
+  const { retryAfterMs, attempt, baseDelayMs, maxDelayMs } = options;
+  if (retryAfterMs != null) {
+    return Math.min(retryAfterMs, maxDelayMs);
+  }
+  const random = options.random ?? Math.random;
+  const capped = Math.min(baseDelayMs * 2 ** Math.min(attempt, MAX_BACKOFF_EXPONENT), maxDelayMs);
+  return capped * (0.5 + 0.5 * random());
+}
+
+/** Resolve a caller-supplied `maxRetries` to a safe non-negative integer. */
+export function resolveMaxRetries(maxRetries: number | undefined): number {
+  if (maxRetries == null || !Number.isFinite(maxRetries)) return DEFAULT_MAX_RETRIES;
+  return Math.max(0, Math.floor(maxRetries));
+}

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -533,6 +533,13 @@ export interface QverisClientConfig {
 
   /** Default request timeout in milliseconds */
   timeoutMs?: number;
+
+  /**
+   * Max automatic retries for rate-limited (429) / transient (503) responses.
+   * Honors `Retry-After`, otherwise backs off exponentially with jitter.
+   * Defaults to 3; set to 0 to disable.
+   */
+  maxRetries?: number;
 }
 
 /**

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -533,6 +533,13 @@ export interface QverisClientConfig {
 
   /** Default request timeout in milliseconds */
   timeoutMs?: number;
+
+  /**
+   * Max automatic retries for rate-limited (429) / transient (503) responses.
+   * Honors `Retry-After`, otherwise backs off exponentially with jitter.
+   * Defaults to 3; set to 0 to disable.
+   */
+  maxRetries?: number;
 }
 
 /**


### PR DESCRIPTION
The 429-backoff slice of #120 for **`@qverisai/sdk`** (js-sdk), mirroring the Python SDK (#142).

## Behavior

- `request()` — the single chokepoint all of `discover`/`inspect`/`call`/`usage`/`ledger` route through — now retries rate-limited (`429`) and transient (`503`) responses: honors `Retry-After` (delta-seconds or HTTP-date), otherwise exponential backoff with **full jitter**, capped per-wait and bounded by `maxRetries` (default 3, config option; `0` disables) so a call never hangs.
- Each attempt is a fresh `fetch` with its own timeout/`AbortController`; the prior response body is cancelled before retrying.
- `qveris.rateLimitRetryCount` surfaces backoff as pressure, not failure.

## Structure

- `src/retry.ts` — pure, unit-tested helpers: `parseRetryAfterMs` (seconds + HTTP-date, ASCII-digit guard so junk like `²`/`-5` returns `null`), `computeRetryDelayMs` (jitter + overflow-safe exponent cap), `resolveMaxRetries`.
- `src/client.ts` — retry loop around the existing fetch/error handling (402 message, timeout→408, network→0, envelope unwrap all preserved).
- `maxRetries` added to the shared `QverisClientConfig`; **mirrored in `packages/mcp/src/types.ts`** so the types-drift guard stays green (the MCP client's own retry wiring is a follow-up).

## Testing

`src/retry.test.ts` (pure math) + `src/client.test.ts` retry cases (429→200 counts backoff, give-up throws the final 429, `maxRetries:0` disables). **js-sdk 33 pass, mcp 99 pass**, both typecheck/build clean.

## Rest of #120

**CLI** and **MCP** get the same treatment in follow-up PRs. (Python = #142.)