### PR TITLE
feat(cli): honor Retry-After with backoff on 429/503 (#120)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -416,6 +416,15 @@ set QVERIS_BASE_URL=https://custom.endpoint/api/v1
 qveris discover "weather" --base-url https://qveris.cn/api/v1
 ```
 
+### Rate limiting & retries
+
+Rate-limited (`429`) and transient (`503`) responses are retried automatically: the CLI honors the `Retry-After` header when present, otherwise backs off exponentially with jitter. Retries default to 3 and are bounded so a command never hangs.
+
+```bash
+# Tune or disable via env
+export QVERIS_MAX_RETRIES=5   # default 3; 0 disables
+```
+
 ### Config File
 
 Located at:

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -1,64 +1,101 @@
 import { resolveBaseUrl } from "../config/region.mjs";
 import { CliError } from "../errors/handler.mjs";
+import {
+  computeRetryDelayMs,
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_MAX_DELAY_MS,
+  parseRetryAfterMs,
+  resolveMaxRetries,
+  RETRYABLE_STATUS,
+  sleep,
+} from "./retry.mjs";
 
 function getBaseUrl(baseUrlFlag, apiKey) {
   return resolveBaseUrl({ baseUrlFlag, apiKey }).baseUrl;
 }
 
-async function requestJson(path, { method = "POST", query = {}, body, timeoutMs = 30000, apiKey, baseUrl }) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const url = new URL(baseUrl.replace(/\/+$/, "") + path);
-    for (const [key, value] of Object.entries(query)) {
-      if (value !== undefined && value !== null) {
-        url.searchParams.set(key, String(value));
-      }
+async function requestJson(
+  path,
+  {
+    method = "POST",
+    query = {},
+    body,
+    timeoutMs = 30000,
+    apiKey,
+    baseUrl,
+    // Retry rate-limited (429) / transient (503) responses: honor Retry-After,
+    // otherwise exponential backoff with jitter, bounded by maxRetries.
+    maxRetries = resolveMaxRetries(process.env.QVERIS_MAX_RETRIES),
+  },
+) {
+  const url = new URL(baseUrl.replace(/\/+$/, "") + path);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
     }
+  }
 
-    const response = await fetch(url.toString(), {
-      method,
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const status = response.status;
-      const rawText = (await response.text()).slice(0, 8192);
-      let errorDetail, jsonBody;
-      try {
-        jsonBody = JSON.parse(rawText);
-        errorDetail = jsonBody.error_message || jsonBody.message || null;
-      } catch { /* not JSON */ }
-      if (status === 401 || status === 403) throw new CliError("AUTH_INVALID_KEY", errorDetail);
-      if (status === 402) {
-        const pricingHost = baseUrl.includes("qveris.cn") ? "https://qveris.cn" : "https://qveris.ai";
-        const err = new CliError("CREDITS_INSUFFICIENT", errorDetail);
-        err.hint = `Purchase credits at ${pricingHost}/pricing`;
-        throw err;
-      }
-      if (status === 429) throw new CliError("RATE_LIMITED", errorDetail);
-      const err = new CliError("API_ERROR", `HTTP ${status}: ${errorDetail || rawText}`);
-      if (jsonBody) err.responseData = jsonBody;
-      throw err;
-    }
+  for (let attempt = 0; ; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let retryDelayMs = null;
 
     try {
-      return await response.json();
-    } catch {
-      throw new CliError("API_ERROR", "Invalid JSON response from API");
+      const response = await fetch(url.toString(), {
+        method,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: controller.signal,
+      });
+
+      if (RETRYABLE_STATUS.has(response.status) && attempt < maxRetries) {
+        retryDelayMs = computeRetryDelayMs({
+          retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
+          attempt,
+          baseDelayMs: DEFAULT_BASE_DELAY_MS,
+          maxDelayMs: DEFAULT_MAX_DELAY_MS,
+        });
+        // Discard the body so the connection is released before we retry.
+        await response.body?.cancel?.().catch(() => {});
+      } else if (!response.ok) {
+        const status = response.status;
+        const rawText = (await response.text()).slice(0, 8192);
+        let errorDetail, jsonBody;
+        try {
+          jsonBody = JSON.parse(rawText);
+          errorDetail = jsonBody.error_message || jsonBody.message || null;
+        } catch { /* not JSON */ }
+        if (status === 401 || status === 403) throw new CliError("AUTH_INVALID_KEY", errorDetail);
+        if (status === 402) {
+          const pricingHost = baseUrl.includes("qveris.cn") ? "https://qveris.cn" : "https://qveris.ai";
+          const err = new CliError("CREDITS_INSUFFICIENT", errorDetail);
+          err.hint = `Purchase credits at ${pricingHost}/pricing`;
+          throw err;
+        }
+        if (status === 429) throw new CliError("RATE_LIMITED", errorDetail);
+        const err = new CliError("API_ERROR", `HTTP ${status}: ${errorDetail || rawText}`);
+        if (jsonBody) err.responseData = jsonBody;
+        throw err;
+      } else {
+        try {
+          return await response.json();
+        } catch {
+          throw new CliError("API_ERROR", "Invalid JSON response from API");
+        }
+      }
+    } catch (err) {
+      if (err instanceof CliError) throw err;
+      if (err.name === "AbortError") throw new CliError("NET_TIMEOUT");
+      throw err;
+    } finally {
+      clearTimeout(timeout);
     }
-  } catch (err) {
-    if (err instanceof CliError) throw err;
-    if (err.name === "AbortError") throw new CliError("NET_TIMEOUT");
-    throw err;
-  } finally {
-    clearTimeout(timeout);
+
+    // Only reached on the retry path (success returns, errors throw above).
+    await sleep(retryDelayMs ?? 0);
   }
 }
 

--- a/packages/cli/src/client/retry.mjs
+++ b/packages/cli/src/client/retry.mjs
@@ -52,6 +52,11 @@ export function computeRetryDelayMs({
 
 /** Resolve a caller/env-supplied max-retries value to a safe non-negative int. */
 export function resolveMaxRetries(value) {
+  // Number('') === 0, so an env var set to an empty string would silently
+  // disable retries; treat blank as unset (default) instead.
+  if (value === undefined || (typeof value === "string" && value.trim() === "")) {
+    return DEFAULT_MAX_RETRIES;
+  }
   const n = Number(value);
   if (!Number.isFinite(n)) return DEFAULT_MAX_RETRIES;
   return Math.max(0, Math.floor(n));

--- a/packages/cli/src/client/retry.mjs
+++ b/packages/cli/src/client/retry.mjs
@@ -1,0 +1,63 @@
+/**
+ * Rate-limit aware retry helpers for the QVeris CLI client.
+ *
+ * Pure functions that decide whether and how long to wait before retrying a
+ * rate-limited (429) or transient (503) response — honoring the `Retry-After`
+ * header when present, otherwise exponential backoff with full jitter. Kept
+ * separate from api.mjs so the delay math is unit-testable.
+ */
+
+export const DEFAULT_MAX_RETRIES = 3;
+export const DEFAULT_BASE_DELAY_MS = 500;
+export const DEFAULT_MAX_DELAY_MS = 60_000;
+const MAX_BACKOFF_EXPONENT = 30; // guards 2**attempt against overflow
+
+/** HTTP statuses worth retrying: rate limiting + transient unavailability. */
+export const RETRYABLE_STATUS = new Set([429, 503]);
+
+/**
+ * Parse a `Retry-After` header into milliseconds. Accepts delta-seconds
+ * (`"12"`) or an HTTP-date; returns null when absent/unparseable, never
+ * negative. Server-controlled input, so it must never throw.
+ */
+export function parseRetryAfterMs(value, now = Date.now()) {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  if (trimmed === "") return null;
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000;
+  // A valid HTTP-date always contains a letter (month name / "GMT"); require one
+  // so Date.parse's leniency doesn't turn junk like "-5" into a spurious date.
+  if (!/[a-zA-Z]/.test(trimmed)) return null;
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) return null;
+  return Math.max(0, dateMs - now);
+}
+
+/**
+ * How long to wait before the next attempt, in milliseconds. Honors
+ * `retryAfterMs` (capped at `maxDelayMs`), otherwise exponential backoff
+ * `baseDelayMs * 2**attempt` with full jitter, capped at `maxDelayMs`.
+ */
+export function computeRetryDelayMs({
+  retryAfterMs,
+  attempt,
+  baseDelayMs,
+  maxDelayMs,
+  random = Math.random,
+}) {
+  if (retryAfterMs != null) return Math.min(retryAfterMs, maxDelayMs);
+  const capped = Math.min(baseDelayMs * 2 ** Math.min(attempt, MAX_BACKOFF_EXPONENT), maxDelayMs);
+  return capped * (0.5 + 0.5 * random());
+}
+
+/** Resolve a caller/env-supplied max-retries value to a safe non-negative int. */
+export function resolveMaxRetries(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return DEFAULT_MAX_RETRIES;
+  return Math.max(0, Math.floor(n));
+}
+
+/** Sleep for `ms` (no-op for non-positive values). */
+export function sleep(ms) {
+  return ms <= 0 ? Promise.resolve() : new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/test/retry.test.mjs
+++ b/packages/cli/test/retry.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { discoverTools } from "../src/client/api.mjs";
+import { CliError } from "../src/errors/handler.mjs";
+import {
+  computeRetryDelayMs,
+  DEFAULT_MAX_RETRIES,
+  parseRetryAfterMs,
+  resolveMaxRetries,
+} from "../src/client/retry.mjs";
+
+// --- pure helpers ------------------------------------------------------------
+
+test("parseRetryAfterMs handles seconds, HTTP-date, and junk", () => {
+  assert.equal(parseRetryAfterMs("12"), 12_000);
+  assert.equal(parseRetryAfterMs("0"), 0);
+
+  const now = Date.parse("2026-01-01T00:00:00Z");
+  assert.equal(parseRetryAfterMs("Thu, 01 Jan 2026 00:00:30 GMT", now), 30_000);
+  assert.equal(parseRetryAfterMs("Thu, 01 Jan 2020 00:00:00 GMT", now), 0);
+
+  for (const junk of [null, undefined, "", "not-a-date", "-5", "12.5", "²"]) {
+    assert.equal(parseRetryAfterMs(junk), null, `${junk} -> null`);
+  }
+});
+
+test("computeRetryDelayMs honors Retry-After, backs off with jitter, caps, no overflow", () => {
+  const base = { baseDelayMs: 500, maxDelayMs: 60_000 };
+  assert.equal(computeRetryDelayMs({ ...base, retryAfterMs: 2_000, attempt: 0 }), 2_000);
+  assert.equal(computeRetryDelayMs({ ...base, retryAfterMs: 999_999, attempt: 0 }), 60_000);
+
+  const full = (attempt) => computeRetryDelayMs({ ...base, retryAfterMs: null, attempt, random: () => 1 });
+  assert.equal(full(0), 500);
+  assert.equal(full(1), 1_000);
+  assert.equal(full(2), 2_000);
+  assert.equal(computeRetryDelayMs({ ...base, retryAfterMs: null, attempt: 0, random: () => 0 }), 250);
+  assert.equal(full(5000), 60_000); // no overflow at a huge attempt
+});
+
+test("resolveMaxRetries defaults, clamps, and floors", () => {
+  assert.equal(resolveMaxRetries(undefined), DEFAULT_MAX_RETRIES);
+  assert.equal(resolveMaxRetries("5"), 5);
+  assert.equal(resolveMaxRetries("0"), 0);
+  assert.equal(resolveMaxRetries("-3"), 0);
+  assert.equal(resolveMaxRetries("2.9"), 2);
+  assert.equal(resolveMaxRetries("nope"), DEFAULT_MAX_RETRIES);
+});
+
+// --- integration through discoverTools --------------------------------------
+
+function rateLimited() {
+  return new Response(JSON.stringify({ error_message: "rate limited" }), {
+    status: 429,
+    headers: { "Content-Type": "application/json", "Retry-After": "0" }, // 0 -> instant retry
+  });
+}
+
+function jsonResponse(payload) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function withMockFetch(handler, fn) {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, options) => handler(new URL(url), options);
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+async function withEnv(key, value, fn) {
+  const had = Object.prototype.hasOwnProperty.call(process.env, key);
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    return await fn();
+  } finally {
+    if (had) process.env[key] = prev;
+    else delete process.env[key];
+  }
+}
+
+const DISCOVER_ARGS = { apiKey: "sk-test", baseUrl: "https://unit.test/api/v1", query: "weather", timeoutMs: 1000 };
+
+test("retries a 429 then succeeds", async () => {
+  let calls = 0;
+  await withMockFetch(
+    () => {
+      calls += 1;
+      return calls === 1 ? rateLimited() : jsonResponse({ search_id: "s1", results: [] });
+    },
+    async () => {
+      const result = await discoverTools(DISCOVER_ARGS);
+      assert.equal(result.search_id, "s1");
+      assert.equal(calls, 2);
+    },
+  );
+});
+
+test("gives up after maxRetries and throws RATE_LIMITED", async () => {
+  let calls = 0;
+  await withEnv("QVERIS_MAX_RETRIES", "2", () =>
+    withMockFetch(
+      () => {
+        calls += 1;
+        return rateLimited();
+      },
+      async () => {
+        const err = await discoverTools(DISCOVER_ARGS).catch((e) => e);
+        assert.ok(err instanceof CliError);
+        assert.equal(err.code, "RATE_LIMITED");
+        assert.equal(calls, 3); // maxRetries + 1
+      },
+    ),
+  );
+});
+
+test("QVERIS_MAX_RETRIES=0 disables retrying", async () => {
+  let calls = 0;
+  await withEnv("QVERIS_MAX_RETRIES", "0", () =>
+    withMockFetch(
+      () => {
+        calls += 1;
+        return rateLimited();
+      },
+      async () => {
+        const err = await discoverTools(DISCOVER_ARGS).catch((e) => e);
+        assert.equal(err.code, "RATE_LIMITED");
+        assert.equal(calls, 1);
+      },
+    ),
+  );
+});

--- a/packages/cli/test/retry.test.mjs
+++ b/packages/cli/test/retry.test.mjs
@@ -45,6 +45,9 @@ test("resolveMaxRetries defaults, clamps, and floors", () => {
   assert.equal(resolveMaxRetries("-3"), 0);
   assert.equal(resolveMaxRetries("2.9"), 2);
   assert.equal(resolveMaxRetries("nope"), DEFAULT_MAX_RETRIES);
+  // An env var set to "" must fall back to the default, not disable retries.
+  assert.equal(resolveMaxRetries(""), DEFAULT_MAX_RETRIES);
+  assert.equal(resolveMaxRetries("  "), DEFAULT_MAX_RETRIES);
 });
 
 // --- integration through discoverTools --------------------------------------


### PR DESCRIPTION
The 429-backoff slice of #120 for **`@qverisai/cli`**, matching the Python (#142) and js-sdk (#143) SDKs.

## Behavior

- `requestJson` — the single chokepoint every command routes through — now retries rate-limited (`429`) and transient (`503`) responses: honors `Retry-After` (delta-seconds or HTTP-date), otherwise exponential backoff with **full jitter**, capped per-wait and bounded by `QVERIS_MAX_RETRIES` (default 3; `0` disables) so a command never hangs.
- A 429 that outlasts the retry budget still throws `RATE_LIMITED` (behavior-preserving); the 401/402/403/generic error paths and JSON parsing are unchanged. Each attempt is a fresh `fetch` with its own timeout; the prior response body is cancelled before retrying.

## Structure

- `src/client/retry.mjs` — pure, unit-tested helpers: `parseRetryAfterMs` (seconds + HTTP-date, ASCII-digit guard so junk like `²`/`-5` returns `null`), `computeRetryDelayMs` (jitter + overflow-safe exponent cap), `resolveMaxRetries`.
- `src/client/api.mjs` — retry loop around the existing fetch/error handling.

## Testing

`test/retry.test.mjs` — pure math + integration through `discoverTools` (429→200, give-up throws `RATE_LIMITED`, `QVERIS_MAX_RETRIES=0` disables). **Full CLI suite (79) passes.**

## #120 — 429 slice status

Python #142 · js-sdk #143 · **CLI (this)** · **MCP** = last follow-up.