### PR TITLE
feat(mcp): honor Retry-After with backoff on 429/503 (#120)

### DIFF
--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -533,6 +533,13 @@ export interface QverisClientConfig {
 
   /** Default request timeout in milliseconds */
   timeoutMs?: number;
+
+  /**
+   * Max automatic retries for rate-limited (429) / transient (503) responses.
+   * Honors `Retry-After`, otherwise backs off exponentially with jitter.
+   * Defaults to 3; set to 0 to disable.
+   */
+  maxRetries?: number;
 }
 
 /**

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -309,6 +309,7 @@ npx -y @qverisai/mcp
 | `QVERIS_API_KEY` | ✓ | Your QVeris API key |
 | `QVERIS_REGION` | | Force region: `global` or `cn` (auto-detected from key prefix if not set) |
 | `QVERIS_BASE_URL` | | Override API base URL (highest priority, for custom endpoints) |
+| `QVERIS_MAX_RETRIES` | | Retries for rate-limited (429) / transient (503) responses (default 3; `0` disables). Honors `Retry-After`, else backs off with jitter. |
 | `QVERIS_MCP_TRANSPORT` | | `stdio` (default) or `http` |
 | `QVERIS_MCP_HTTP_PORT` | | HTTP port (default `3000`; setting it implies HTTP mode) |
 | `QVERIS_MCP_HTTP_HOST` | | HTTP bind host (default `127.0.0.1`) |

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -511,3 +511,70 @@ describe('createClientFromEnv', () => {
   });
 });
 
+describe('QverisClient rate-limit retries', () => {
+  const originalEnv = process.env;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.QVERIS_MAX_RETRIES;
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  // Retry-After: 0 -> the retry sleep is 0ms, so the test doesn't actually wait.
+  function rateLimited() {
+    return {
+      ok: false,
+      status: 429,
+      body: null,
+      headers: { get: (name: string) => (name.toLowerCase() === 'retry-after' ? '0' : null) },
+      json: async () => ({ error_message: 'rate limited' }),
+    };
+  }
+
+  function ok(payload: unknown) {
+    return { ok: true, json: async () => payload };
+  }
+
+  it('retries a 429 then succeeds, counting the backoff', async () => {
+    fetchMock.mockResolvedValueOnce(rateLimited()).mockResolvedValueOnce(ok({ search_id: 's1', results: [], total: 0 }));
+
+    const client = new QverisClient({ apiKey: 'test-api-key' });
+    const result = await client.searchTools({ query: 'weather' });
+
+    expect(result.search_id).toBe('s1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(client.rateLimitRetryCount).toBe(1);
+  });
+
+  it('gives up after QVERIS_MAX_RETRIES and throws the final 429', async () => {
+    process.env.QVERIS_MAX_RETRIES = '2';
+    fetchMock.mockResolvedValue(rateLimited());
+
+    const client = new QverisClient({ apiKey: 'test-api-key' });
+    const err = await client.searchTools({ query: 'weather' }).catch((e: unknown) => e);
+
+    expect((err as { status: number }).status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // maxRetries + 1
+    expect(client.rateLimitRetryCount).toBe(2);
+  });
+
+  it('QVERIS_MAX_RETRIES=0 disables retrying', async () => {
+    process.env.QVERIS_MAX_RETRIES = '0';
+    fetchMock.mockResolvedValue(rateLimited());
+
+    const client = new QverisClient({ apiKey: 'test-api-key' });
+    const err = await client.searchTools({ query: 'weather' }).catch((e: unknown) => e);
+
+    expect((err as { status: number }).status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(client.rateLimitRetryCount).toBe(0);
+  });
+});
+

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -576,5 +576,17 @@ describe('QverisClient rate-limit retries', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(client.rateLimitRetryCount).toBe(0);
   });
+
+  it('config.maxRetries takes precedence over QVERIS_MAX_RETRIES', async () => {
+    process.env.QVERIS_MAX_RETRIES = '5';
+    fetchMock.mockResolvedValue(rateLimited());
+
+    const client = new QverisClient({ apiKey: 'test-api-key', maxRetries: 1 });
+    const err = await client.searchTools({ query: 'weather' }).catch((e: unknown) => e);
+
+    expect((err as { status: number }).status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // config's 1 retry, not env's 5
+    expect(client.rateLimitRetryCount).toBe(1);
+  });
 });
 

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -24,6 +24,14 @@ import type {
   ApiObservability,
   ApiOperation,
 } from '../types.js';
+import {
+  computeRetryDelayMs,
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_MAX_DELAY_MS,
+  parseRetryAfterMs,
+  resolveMaxRetries,
+  RETRYABLE_STATUS,
+} from '../retry.js';
 
 /** Region-specific API base URLs */
 const REGION_URLS: Record<string, string> = {
@@ -82,6 +90,8 @@ export class QverisClient {
   private readonly apiKey: string;
   private readonly baseUrl: string;
   private readonly defaultTimeoutMs: number;
+  private readonly maxRetries: number;
+  private rateLimitRetries = 0;
 
   constructor(config: QverisClientConfig) {
     if (!config.apiKey) {
@@ -91,6 +101,22 @@ export class QverisClient {
     // Resolve base URL: explicit > env > key prefix auto-detect
     this.baseUrl = resolveBaseUrl(config.apiKey, config.baseUrl);
     this.defaultTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    // Retries for 429/503, configurable via env (the server is env-configured).
+    this.maxRetries = resolveMaxRetries(process.env.QVERIS_MAX_RETRIES);
+  }
+
+  /**
+   * How many times the client has backed off on a rate-limited (429) /
+   * transient (503) response so far — retried pressure, not failure.
+   */
+  get rateLimitRetryCount(): number {
+    return this.rateLimitRetries;
+  }
+
+  /** Sleep for `ms` (a seam so tests can stub out the wait). */
+  private async sleep(ms: number): Promise<void> {
+    if (ms <= 0) return;
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /**
@@ -112,7 +138,6 @@ export class QverisClient {
         }
       }
     }
-    const controller = new AbortController();
     const resolvedTimeoutMs = timeoutMs ?? this.defaultTimeoutMs;
     const queryParams = Object.fromEntries(url.searchParams.entries());
     const requestContext: ApiObservability = {
@@ -124,96 +149,117 @@ export class QverisClient {
       ...(Object.keys(queryParams).length > 0 && { query_params: queryParams }),
       timeout_ms: resolvedTimeoutMs,
     };
-    const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
 
-    try {
-      const response = await fetch(url.toString(), {
-        method,
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: body ? JSON.stringify(body) : undefined,
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        const status = response.status;
-        let errorMessage: string;
-        let errorDetails: unknown;
-
-        try {
-          const errorBody = (await response.json()) as Record<string, unknown>;
-          errorMessage =
-            (errorBody.error_message as string) ||
-            (errorBody.message as string) ||
-            (errorBody.error as string) ||
-            response.statusText;
-          errorDetails = errorBody;
-        } catch {
-          errorMessage = response.statusText || `HTTP ${status}`;
-        }
-
-        // Provide actionable hints for specific status codes
-        if (status === 402) {
-          const pricingHost = this.baseUrl.includes('qveris.cn') ? 'https://qveris.cn' : 'https://qveris.ai';
-          errorMessage = `Insufficient credits. ${errorMessage}. Purchase credits at ${pricingHost}/pricing`;
-        }
-
-        const error: ApiError = {
-          status,
-          message: errorMessage,
-          ...(errorDetails !== undefined && { details: errorDetails }),
-          observability: withErrorContext(
-            requestContext,
-            'http_error',
-            status,
-            extractRequestId(response),
-          ),
-        };
-
-        throw error;
-      }
+    // Retry rate-limited (429) / transient (503) responses: honor Retry-After,
+    // otherwise exponential backoff with jitter, bounded by maxRetries. Each
+    // attempt is a fresh fetch with its own timeout.
+    for (let attempt = 0; ; attempt++) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
+      let retryDelayMs: number | null = null;
 
       try {
-        return await response.json() as T;
-      } catch {
-        const error: ApiError = {
-          status: response.status,
-          message: 'Invalid or empty JSON response from API',
-          observability: withErrorContext(
-            requestContext,
-            'invalid_json',
-            response.status,
-            extractRequestId(response),
-          ),
-        };
-        throw error;
-      }
-    } catch (err: unknown) {
-      if (isApiError(err)) {
-        throw err;
-      }
-      if (err instanceof Error && err.name === 'AbortError') {
+        const response = await fetch(url.toString(), {
+          method,
+          headers: {
+            'Authorization': `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+
+        if (RETRYABLE_STATUS.has(response.status) && attempt < this.maxRetries) {
+          retryDelayMs = computeRetryDelayMs({
+            retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
+            attempt,
+            baseDelayMs: DEFAULT_BASE_DELAY_MS,
+            maxDelayMs: DEFAULT_MAX_DELAY_MS,
+          });
+          // Discard the body so the connection is released before we retry.
+          await response.body?.cancel().catch(() => undefined);
+          this.rateLimitRetries++;
+        } else if (!response.ok) {
+          const status = response.status;
+          let errorMessage: string;
+          let errorDetails: unknown;
+
+          try {
+            const errorBody = (await response.json()) as Record<string, unknown>;
+            errorMessage =
+              (errorBody.error_message as string) ||
+              (errorBody.message as string) ||
+              (errorBody.error as string) ||
+              response.statusText;
+            errorDetails = errorBody;
+          } catch {
+            errorMessage = response.statusText || `HTTP ${status}`;
+          }
+
+          // Provide actionable hints for specific status codes
+          if (status === 402) {
+            const pricingHost = this.baseUrl.includes('qveris.cn') ? 'https://qveris.cn' : 'https://qveris.ai';
+            errorMessage = `Insufficient credits. ${errorMessage}. Purchase credits at ${pricingHost}/pricing`;
+          }
+
+          const error: ApiError = {
+            status,
+            message: errorMessage,
+            ...(errorDetails !== undefined && { details: errorDetails }),
+            observability: withErrorContext(
+              requestContext,
+              'http_error',
+              status,
+              extractRequestId(response),
+            ),
+          };
+
+          throw error;
+        } else {
+          try {
+            return await response.json() as T;
+          } catch {
+            const error: ApiError = {
+              status: response.status,
+              message: 'Invalid or empty JSON response from API',
+              observability: withErrorContext(
+                requestContext,
+                'invalid_json',
+                response.status,
+                extractRequestId(response),
+              ),
+            };
+            throw error;
+          }
+        }
+      } catch (err: unknown) {
+        if (isApiError(err)) {
+          throw err;
+        }
+        if (err instanceof Error && err.name === 'AbortError') {
+          const cause = getErrorCause(err);
+          const error: ApiError = {
+            status: 408,
+            message: 'Request timed out. Check connectivity or increase timeout.',
+            observability: withErrorContext(requestContext, 'timeout', 0),
+            ...(cause && { cause }),
+          };
+          throw error;
+        }
         const cause = getErrorCause(err);
         const error: ApiError = {
-          status: 408,
-          message: 'Request timed out. Check connectivity or increase timeout.',
-          observability: withErrorContext(requestContext, 'timeout', 0),
+          status: 0,
+          message: getErrorMessage(err, 'Network request failed'),
+          observability: withErrorContext(requestContext, 'network_error', 0),
           ...(cause && { cause }),
         };
         throw error;
+      } finally {
+        clearTimeout(timeout);
       }
-      const cause = getErrorCause(err);
-      const error: ApiError = {
-        status: 0,
-        message: getErrorMessage(err, 'Network request failed'),
-        observability: withErrorContext(requestContext, 'network_error', 0),
-        ...(cause && { cause }),
-      };
-      throw error;
-    } finally {
-      clearTimeout(timeout);
+
+      // Only reached on the retry path (success returns, errors throw above).
+      await this.sleep(retryDelayMs ?? 0);
     }
   }
 

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -101,8 +101,9 @@ export class QverisClient {
     // Resolve base URL: explicit > env > key prefix auto-detect
     this.baseUrl = resolveBaseUrl(config.apiKey, config.baseUrl);
     this.defaultTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    // Retries for 429/503, configurable via env (the server is env-configured).
-    this.maxRetries = resolveMaxRetries(process.env.QVERIS_MAX_RETRIES);
+    // Retries for 429/503: explicit config wins, then the env var (the MCP
+    // server itself is env-configured), then the default.
+    this.maxRetries = resolveMaxRetries(config.maxRetries ?? process.env.QVERIS_MAX_RETRIES);
   }
 
   /**
@@ -177,7 +178,9 @@ export class QverisClient {
             maxDelayMs: DEFAULT_MAX_DELAY_MS,
           });
           // Discard the body so the connection is released before we retry.
-          await response.body?.cancel().catch(() => undefined);
+          // (`.cancel?.()` so a body without cancel — e.g. a test double —
+          // can't throw here and mask the rate-limit as a network error.)
+          await response.body?.cancel?.().catch(() => undefined);
           this.rateLimitRetries++;
         } else if (!response.ok) {
           const status = response.status;

--- a/packages/mcp/src/retry.test.ts
+++ b/packages/mcp/src/retry.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeRetryDelayMs,
+  DEFAULT_MAX_RETRIES,
+  parseRetryAfterMs,
+  resolveMaxRetries,
+} from './retry.js';
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds into milliseconds', () => {
+    expect(parseRetryAfterMs('12')).toBe(12_000);
+    expect(parseRetryAfterMs('0')).toBe(0);
+  });
+
+  it('parses an HTTP-date relative to now, clamped at 0', () => {
+    const now = Date.parse('2026-01-01T00:00:00Z');
+    expect(parseRetryAfterMs('Thu, 01 Jan 2026 00:00:30 GMT', now)).toBe(30_000);
+    expect(parseRetryAfterMs('Thu, 01 Jan 2020 00:00:00 GMT', now)).toBe(0);
+  });
+
+  it('returns null for absent/invalid values (never throws)', () => {
+    for (const junk of [null, undefined, '', 'not-a-date', '-5', '12.5', '²']) {
+      expect(parseRetryAfterMs(junk)).toBeNull();
+    }
+  });
+});
+
+describe('computeRetryDelayMs', () => {
+  const base = { baseDelayMs: 500, maxDelayMs: 60_000 };
+
+  it('honors Retry-After, capped at maxDelayMs', () => {
+    expect(computeRetryDelayMs({ ...base, retryAfterMs: 2_000, attempt: 0 })).toBe(2_000);
+    expect(computeRetryDelayMs({ ...base, retryAfterMs: 999_999, attempt: 0 })).toBe(60_000);
+  });
+
+  it('backs off exponentially with full jitter when no Retry-After', () => {
+    const full = (attempt: number) =>
+      computeRetryDelayMs({ ...base, retryAfterMs: null, attempt, random: () => 1 });
+    expect(full(0)).toBe(500);
+    expect(full(1)).toBe(1_000);
+    expect(full(2)).toBe(2_000);
+    expect(computeRetryDelayMs({ ...base, retryAfterMs: null, attempt: 0, random: () => 0 })).toBe(250);
+  });
+
+  it('never overflows at a huge attempt', () => {
+    expect(computeRetryDelayMs({ ...base, retryAfterMs: null, attempt: 5000, random: () => 1 })).toBe(60_000);
+  });
+});
+
+describe('resolveMaxRetries', () => {
+  it('defaults, clamps, and floors (string env values)', () => {
+    expect(resolveMaxRetries(undefined)).toBe(DEFAULT_MAX_RETRIES);
+    expect(resolveMaxRetries('5')).toBe(5);
+    expect(resolveMaxRetries('0')).toBe(0);
+    expect(resolveMaxRetries('-3')).toBe(0);
+    expect(resolveMaxRetries('2.9')).toBe(2);
+    expect(resolveMaxRetries('nope')).toBe(DEFAULT_MAX_RETRIES);
+  });
+});

--- a/packages/mcp/src/retry.test.ts
+++ b/packages/mcp/src/retry.test.ts
@@ -56,5 +56,8 @@ describe('resolveMaxRetries', () => {
     expect(resolveMaxRetries('-3')).toBe(0);
     expect(resolveMaxRetries('2.9')).toBe(2);
     expect(resolveMaxRetries('nope')).toBe(DEFAULT_MAX_RETRIES);
+    // An env var set to '' must fall back to the default, not disable retries.
+    expect(resolveMaxRetries('')).toBe(DEFAULT_MAX_RETRIES);
+    expect(resolveMaxRetries('  ')).toBe(DEFAULT_MAX_RETRIES);
   });
 });

--- a/packages/mcp/src/retry.ts
+++ b/packages/mcp/src/retry.ts
@@ -1,0 +1,76 @@
+/**
+ * Rate-limit aware retry helpers for the QVeris client.
+ *
+ * Pure functions the client uses to decide whether and how long to wait before
+ * retrying a rate-limited (`429`) or transient (`503`) response — honoring the
+ * `Retry-After` header when present, otherwise exponential backoff with full
+ * jitter. Kept separate from the client so the delay math is unit-testable.
+ *
+ * @module @qverisai/mcp/retry
+ */
+
+export const DEFAULT_MAX_RETRIES = 3;
+export const DEFAULT_BASE_DELAY_MS = 500;
+export const DEFAULT_MAX_DELAY_MS = 60_000;
+const MAX_BACKOFF_EXPONENT = 30; // guards 2**attempt against overflow
+
+/** HTTP statuses worth retrying: rate limiting + transient unavailability. */
+export const RETRYABLE_STATUS = new Set([429, 503]);
+
+/**
+ * Parse a `Retry-After` header into milliseconds.
+ *
+ * Accepts both RFC 9110 forms — a delta in seconds (`"12"`) or an HTTP-date.
+ * Returns `null` when absent/unparseable, and never a negative value.
+ */
+export function parseRetryAfterMs(value: string | null | undefined, now: number = Date.now()): number | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+
+  // Delta-seconds form: a non-negative integer.
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+
+  // HTTP-date form. Require a letter (month name / "GMT") so Date.parse's
+  // leniency doesn't turn junk like "-5" into a spurious date.
+  if (!/[a-zA-Z]/.test(trimmed)) return null;
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) return null;
+  return Math.max(0, dateMs - now);
+}
+
+export interface RetryDelayOptions {
+  /** Parsed `Retry-After` in ms, or null to use backoff. */
+  retryAfterMs: number | null;
+  /** Zero-based attempt index (0 = first retry). */
+  attempt: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  /** Jitter source in [0, 1); defaults to `Math.random`. */
+  random?: () => number;
+}
+
+/**
+ * Compute how long to wait before the next attempt, in milliseconds.
+ *
+ * Honors `retryAfterMs` (capped at `maxDelayMs`); otherwise exponential backoff
+ * `baseDelayMs * 2**attempt` with full jitter, capped at `maxDelayMs`.
+ */
+export function computeRetryDelayMs(options: RetryDelayOptions): number {
+  const { retryAfterMs, attempt, baseDelayMs, maxDelayMs } = options;
+  if (retryAfterMs != null) {
+    return Math.min(retryAfterMs, maxDelayMs);
+  }
+  const random = options.random ?? Math.random;
+  const capped = Math.min(baseDelayMs * 2 ** Math.min(attempt, MAX_BACKOFF_EXPONENT), maxDelayMs);
+  return capped * (0.5 + 0.5 * random());
+}
+
+/** Resolve a caller/env-supplied `maxRetries` to a safe non-negative integer. */
+export function resolveMaxRetries(value: number | string | undefined): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return DEFAULT_MAX_RETRIES;
+  return Math.max(0, Math.floor(n));
+}

--- a/packages/mcp/src/retry.ts
+++ b/packages/mcp/src/retry.ts
@@ -70,6 +70,11 @@ export function computeRetryDelayMs(options: RetryDelayOptions): number {
 
 /** Resolve a caller/env-supplied `maxRetries` to a safe non-negative integer. */
 export function resolveMaxRetries(value: number | string | undefined): number {
+  // Number('') === 0, so an env var set to an empty string would silently
+  // disable retries; treat blank as unset (default) instead.
+  if (value === undefined || (typeof value === 'string' && value.trim() === '')) {
+    return DEFAULT_MAX_RETRIES;
+  }
   const n = Number(value);
   if (!Number.isFinite(n)) return DEFAULT_MAX_RETRIES;
   return Math.max(0, Math.floor(n));

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -533,6 +533,13 @@ export interface QverisClientConfig {
 
   /** Default request timeout in milliseconds */
   timeoutMs?: number;
+
+  /**
+   * Max automatic retries for rate-limited (429) / transient (503) responses.
+   * Honors `Retry-After`, otherwise backs off exponentially with jitter.
+   * Defaults to 3; set to 0 to disable.
+   */
+  maxRetries?: number;
 }
 
 /**


### PR DESCRIPTION
The final 429-backoff slice of #120 — the **`@qverisai/mcp`** server's API client — matching Python (#142), js-sdk (#143), and CLI (#144).

## Behavior

- `request<T>` — the single chokepoint all of `searchTools`/`getToolsByIds`/`executeTool`/usage/ledger route through — now retries rate-limited (`429`) and transient (`503`) responses: honors `Retry-After`, otherwise exponential backoff with **full jitter**, capped per-wait and bounded by `QVERIS_MAX_RETRIES` (default 3; `0` disables) so a tool call never hangs.
- A 429 that outlasts the budget still surfaces the `ApiError` as before; 402/timeout/network/invalid-JSON paths unchanged. Each attempt is a fresh `fetch` with its own timeout; the prior body is cancelled before retrying.
- `client.rateLimitRetryCount` surfaces backoff as pressure, not failure.

## Structure & scope

- `src/retry.ts` — pure, unit-tested helpers (`parseRetryAfterMs` with ASCII-digit guard, `computeRetryDelayMs` with jitter + overflow cap, `resolveMaxRetries`).
- `src/api/client.ts` — retry loop around the existing fetch/error handling.
- `maxRetries` is read from **env** (`QVERIS_MAX_RETRIES`) since the MCP server is env-configured — so this PR **does not touch the shared `types.ts`** and won't conflict with the js-sdk PR (#143), which adds the `maxRetries` config field to the mirrored types.

## Testing

`src/retry.test.ts` + client retry cases in `src/api/client.test.ts` (429→200 counts backoff, give-up surfaces the 429, `QVERIS_MAX_RETRIES=0` disables). **109 MCP tests pass**, typecheck/build clean.

## #120 — 429 slice complete

Python #142 · js-sdk #143 · CLI #144 · **MCP (this)**. All four callers now honor `Retry-After` with bounded, jittered backoff.