### PR TITLE
ci: add windows-latest to test matrices (#113)

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -40,7 +40,9 @@ jobs:
 
   publish:
     needs: test
-    if: startsWith(github.ref, 'refs/tags/') # dispatch runs tests only
+    # Event-scoped: a workflow_dispatch (even one targeting a tag ref) runs
+    # tests only; publishing requires an actual tag push.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,6 +1,7 @@
 name: Publish CLI to npm
 
 on:
+  workflow_dispatch: # run the test matrix on demand (publish still requires a tag)
   push:
     tags:
       - "cli-v*" # Trigger on tags like cli-v0.1.0, cli-v1.0.0
@@ -10,14 +11,20 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: packages/cli
 
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         node-version: [18, 20, 22]
+        include:
+          # Windows coverage on the LTS line only (issue #113).
+          - os: windows-latest
+            node-version: 20
 
     steps:
       - name: Checkout
@@ -33,6 +40,7 @@ jobs:
 
   publish:
     needs: test
+    if: startsWith(github.ref, 'refs/tags/') # dispatch runs tests only
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -40,7 +40,11 @@ permissions:
 
 jobs:
   cli-contract:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -51,7 +55,11 @@ jobs:
         run: node --test test/openapi-contract.test.mjs
 
   python-contract:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -59,12 +67,20 @@ jobs:
           python-version: "3.11"
       - name: Python SDK ↔ generated-contract test
         working-directory: packages/python-sdk
+        # PYTHONPATH is set via env (not inline) so the step works under both
+        # bash (ubuntu) and pwsh (windows) default shells.
+        env:
+          PYTHONPATH: .
         run: |
           python -m pip install --quiet pytest "pydantic>=2.0.0"
-          PYTHONPATH=. python -m pytest tests/test_openapi_contract.py -q
+          python -m pytest tests/test_openapi_contract.py -q
 
   js-sdk-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: packages/js-sdk
@@ -83,7 +99,11 @@ jobs:
         run: npm test
 
   mcp-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: packages/mcp

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -51,7 +51,9 @@ jobs:
 
   publish:
     needs: test
-    if: startsWith(github.ref, 'refs/tags/') # dispatch runs tests only
+    # Event-scoped: a workflow_dispatch (even one targeting a tag ref) runs
+    # tests only; publishing requires an actual tag push.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,6 +1,7 @@
 name: Publish MCP to npm
 
 on:
+  workflow_dispatch: # run the test matrix on demand (publish still requires a tag)
   push:
     tags:
       - "mcp-v*" # Trigger on tags like mcp-v0.1.3, mcp-v1.0.0
@@ -10,14 +11,20 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: packages/mcp
 
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         node-version: [18, 20, 22]
+        include:
+          # Windows coverage on the LTS line only (issue #113).
+          - os: windows-latest
+            node-version: 20
 
     steps:
       - name: Checkout
@@ -44,6 +51,7 @@ jobs:
 
   publish:
     needs: test
+    if: startsWith(github.ref, 'refs/tags/') # dispatch runs tests only
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -1,6 +1,7 @@
 name: Publish Python SDK to PyPI
 
 on:
+  workflow_dispatch: # run the test matrix on demand (publish still requires a tag)
   push:
     tags:
       - "python-sdk-v*" # Trigger on tags like python-sdk-v0.1.0, python-sdk-v1.0.0
@@ -10,14 +11,20 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: packages/python-sdk
 
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]
+        include:
+          # Windows coverage on one interpreter only (issue #113).
+          - os: windows-latest
+            python-version: "3.11"
 
     steps:
       - name: Checkout
@@ -42,6 +49,7 @@ jobs:
 
   publish:
     needs: test
+    if: startsWith(github.ref, 'refs/tags/') # dispatch runs tests only
     runs-on: ubuntu-latest
     permissions:
       contents: write # For creating GitHub Releases

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -49,7 +49,9 @@ jobs:
 
   publish:
     needs: test
-    if: startsWith(github.ref, 'refs/tags/') # dispatch runs tests only
+    # Event-scoped: a workflow_dispatch (even one targeting a tag ref) runs
+    # tests only; publishing requires an actual tag push.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write # For creating GitHub Releases


### PR DESCRIPTION
Closes #113.

## What

- **`contract-tests.yml`** (the every-PR gate): all four jobs — `cli-contract`, `python-contract`, `js-sdk-tests`, `mcp-tests` — now run on **ubuntu-latest and windows-latest** (`fail-fast: false` so one OS failing doesn't mask the other). This PR itself exercises all 8 legs.
- **Publish workflows** (full suites at tag time), per the issue's guidance to keep the Windows cost low:
  - `cli-publish` / `mcp-publish`: node 18/20/22 stay ubuntu-only; **windows-latest added on node 20** only.
  - `python-sdk-publish`: 3.10–3.12 stay ubuntu-only; **windows-latest added on 3.11** only.
- Publish workflows gain **`workflow_dispatch`** so the full test matrix can be validated on demand after merge (no release needed); the `publish` job is guarded with `startsWith(github.ref, 'refs/tags/')` so a manual dispatch never publishes.

## Windows-specific fixes / pre-checks

- `python-contract` used `PYTHONPATH=. python -m pytest` — bash-only inline-env syntax that fails under the Windows `pwsh` default shell. Now set via the step's `env:` block (works on both).
- Pre-scanned the gated suites for landmines: the MCP entrypoint test's `symlinkSync` already skips on `EPERM` (Windows privilege), the js-sdk types-drift test already normalizes CRLF, and the audit-export tests don't assert path separators.

## Validation

- All four workflow files parse as valid YAML.
- No `required_status_checks` rule exists on `main` (verified via the rulesets API), so the matrix-induced check renames (`cli-contract` → `cli-contract (ubuntu-latest)` etc.) don't strand any branch-protection requirement.
- The 8 contract legs run on this PR; the publish-side Windows legs can be validated post-merge with a manual dispatch.