### PR TITLE
ci: add windows-latest to the js-sdk publish test matrix (#113)

### DIFF
--- a/.github/workflows/js-sdk-publish.yml
+++ b/.github/workflows/js-sdk-publish.yml
@@ -1,6 +1,7 @@
 name: Publish JS SDK to npm
 
 on:
+  workflow_dispatch: # run the test matrix on demand (publish still requires a tag)
   push:
     tags:
       - "js-sdk-v*" # Trigger on tags like js-sdk-v0.1.0, js-sdk-v1.0.0
@@ -10,14 +11,20 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: packages/js-sdk
 
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         node-version: [18, 20, 22]
+        include:
+          # Windows coverage on the LTS line only (issue #113).
+          - os: windows-latest
+            node-version: 20
 
     steps:
       - name: Checkout
@@ -44,6 +51,9 @@ jobs:
 
   publish:
     needs: test
+    # Event-scoped: a workflow_dispatch (even one targeting a tag ref) runs
+    # tests only; publishing requires an actual tag push.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Follow-up to #146, which covered the cli/mcp/python-sdk publish workflows but missed **`js-sdk-publish.yml`** — issue #113 predates the js-sdk package (#106), so it wasn't on the issue's list.

Same treatment as the other three:
- `test` matrix: node 18/20/22 stay ubuntu-only; **windows-latest added on node 20** (verified byte-identical matrix block to `mcp-publish.yml`).
- **`workflow_dispatch`** for on-demand matrix validation.
- **Event-scoped publish guard**: `github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')` — a dispatch (even targeting a tag ref) runs tests only.

PR-level Windows coverage for the js-sdk already exists (contract-tests `js-sdk-tests` runs the full suite on both OSes since #146); this closes the tag-time gap. The openclaw plugin publish workflow has no test matrix (single trivial leg) and is out of scope.