### PR TITLE
docs: per-package CHANGELOGs + release process with CHANGELOG gate (#116)

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -68,6 +68,13 @@ jobs:
           fi
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
+      - name: Verify CHANGELOG has an entry for this version
+        run: |
+          if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$VERSION]' section — move the Unreleased notes into a release section before tagging"
+            exit 1
+          fi
+
       - name: Syntax check
         run: |
           for f in $(find bin src -name '*.mjs'); do

--- a/.github/workflows/js-sdk-publish.yml
+++ b/.github/workflows/js-sdk-publish.yml
@@ -79,6 +79,13 @@ jobs:
           fi
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
+      - name: Verify CHANGELOG has an entry for this version
+        run: |
+          if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$VERSION]' section — move the Unreleased notes into a release section before tagging"
+            exit 1
+          fi
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -79,6 +79,13 @@ jobs:
           fi
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
+      - name: Verify CHANGELOG has an entry for this version
+        run: |
+          if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$VERSION]' section — move the Unreleased notes into a release section before tagging"
+            exit 1
+          fi
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -85,6 +85,13 @@ jobs:
           fi
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
+      - name: Verify CHANGELOG has an entry for this version
+        run: |
+          if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$VERSION]' section — move the Unreleased notes into a release section before tagging"
+            exit 1
+          fi
+
       - name: Build package
         run: uv build
 

--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -35,6 +35,13 @@ jobs:
           fi
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
+      - name: Verify CHANGELOG has an entry for this version
+        run: |
+          if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$VERSION]' section — move the Unreleased notes into a release section before tagging"
+            exit 1
+          fi
+
       - name: Verify npm package contents
         run: npm run check:pack
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,32 @@
+# Releasing
+
+Each package releases independently via an annotated git tag; the matching GitHub Actions workflow runs the test matrix and publishes to npm / PyPI.
+
+| Package | Tag format | Workflow |
+|---------|------------|----------|
+| `@qverisai/cli` | `cli-v<version>` | `cli-publish.yml` |
+| `@qverisai/mcp` | `mcp-v<version>` | `mcp-publish.yml` |
+| `@qverisai/sdk` | `js-sdk-v<version>` | `js-sdk-publish.yml` |
+| `qveris` (PyPI) | `python-sdk-v<version>` | `python-sdk-publish.yml` |
+| OpenClaw plugin | `qveris-plugin-v<version>` | `qveris-plugin-publish.yml` |
+
+## Process
+
+1. **Bump the version** in the package's `package.json` / `pyproject.toml`.
+2. **Update `CHANGELOG.md`** (Keep a Changelog format): move the `## [Unreleased]` notes into a new `## [<version>] - <YYYY-MM-DD>` section, and update the compare links at the bottom. The publish workflow **fails if `CHANGELOG.md` has no `## [<version>]` section** for the tagged version.
+3. Open a PR with the bump + changelog; merge it.
+4. **Tag the release commit with an annotated tag**, using the new CHANGELOG section as the tag message — this is what powers the release Highlights (#101), so the changelog and the tag stay one source of truth:
+
+   ```bash
+   # Example for the MCP server
+   git tag -a mcp-v0.8.0 -F <(sed -n '/^## \[0.8.0\]/,/^## \[/p' packages/mcp/CHANGELOG.md | sed '$d' | tail -n +2)
+   git push origin mcp-v0.8.0
+   ```
+
+5. The publish workflow verifies **version == tag** and **CHANGELOG has the section**, runs the full test matrix (ubuntu + windows), publishes, and creates the GitHub Release.
+
+## Notes
+
+- `CHANGELOG.md` ships inside each package (npm `files` whitelist / Python sdist), so registry users can read version diffs offline.
+- The cli/mcp/js-sdk/python-sdk publish workflows also support `workflow_dispatch` to run the test matrix on demand; a dispatch never publishes (publishing requires an actual tag push).
+- Keep the `[Unreleased]` section current as PRs land — release day should only be a rename, not an archaeology dig.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,8 +18,9 @@ Each package releases independently via an annotated git tag; the matching GitHu
 4. **Tag the release commit with an annotated tag**, using the new CHANGELOG section as the tag message — this is what powers the release Highlights (#101), so the changelog and the tag stay one source of truth:
 
    ```bash
-   # Example for the MCP server
-   git tag -a mcp-v0.8.0 -F <(sed -n '/^## \[0.8.0\]/,/^## \[/p' packages/mcp/CHANGELOG.md | sed '$d' | tail -n +2)
+   # Example for the MCP server (stops at the next heading or the link
+   # definitions, so it also works for the oldest section in the file)
+   git tag -a mcp-v0.8.0 -F <(awk '/^## \[0.8.0\]/{p=1; next} /^## \[/ || /^\[/{p=0} p' packages/mcp/CHANGELOG.md)
    git push origin mcp-v0.8.0
    ```
 
@@ -27,6 +28,6 @@ Each package releases independently via an annotated git tag; the matching GitHu
 
 ## Notes
 
-- `CHANGELOG.md` ships inside each package (npm `files` whitelist / Python sdist), so registry users can read version diffs offline.
+- `CHANGELOG.md` ships inside each package (npm `files` whitelist; Python sdist and wheel, plus a PyPI `Changelog` project link), so registry users can read version diffs offline.
 - The cli/mcp/js-sdk/python-sdk publish workflows also support `workflow_dispatch` to run the test matrix on demand; a dispatch never publishes (publishing requires an actual tag push).
 - Keep the `[Unreleased]` section current as PRs land — release day should only be a rename, not an archaeology dig.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to `@qverisai/cli` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Rate-limited (`429`) and transient (`503`) responses are retried automatically: the CLI honors `Retry-After`, otherwise backs off exponentially with jitter, bounded by `QVERIS_MAX_RETRIES` (default 3; `0` disables). ([#144])
+- `qveris doctor` / `qveris init` diagnostics: preflight checks (Node version, key, region, connectivity) with actionable hints and exact next commands. ([#131])
+- Discover/inspect render `why_recommended`, standardized capability descriptors, `expected_cost`, and provider fields from the API. ([#102])
+
+## [0.6.1] - 2026-07-06
+
+### Fixed
+
+- Accept object-shaped tool categories in discover/inspect results (legacy string tags still supported). ([#97])
+- Hardened the MCP probe and call params/observability paths. ([#85])
+
+## [0.6.0] - 2026-05-19
+
+### Added
+
+- `qveris init` — guided first-call wizard: auth → discover → inspect → call → usage/ledger reconciliation guidance. ([#32])
+- `qveris mcp configure` / `qveris mcp validate` — generate and validate MCP client configs for Cursor, Claude Desktop, and others. ([#33])
+- Generated OpenAPI contract types with drift CI, keeping the CLI aligned with the public API contract. ([#48])
+
+### Fixed
+
+- README examples aligned with actual CLI output. ([#35])
+
+## [0.5.0] - 2026-05-06
+
+### Added
+
+- Billing transparency audit surfaces: `qveris usage` and `qveris ledger` with context-safe summaries. ([#18])
+- Multi-region support (global/China) with key-prefix auto-detection and interactive region selection at login. ([#12], [#13])
+- Canonical `discover` / `inspect` / `call` naming aligned across CLI and MCP. ([#14])
+
+## [0.3.0] - 2026-04-08
+
+### Added
+
+- Gradient welcome/login banners. ([#10])
+
+### Changed
+
+- Batched ANSI spans in banner rendering; CLI install URL corrected across docs.
+
+## [0.2.0] - 2026-04-04
+
+### Added
+
+- China region (`qveris.cn`) support. ([#9])
+
+## [0.1.0] - 2026-04-04
+
+### Added
+
+- Initial release: `discover` / `inspect` / `call` from the terminal against the QVeris API.
+
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.6.1...HEAD
+[0.6.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.6.0...cli-v0.6.1
+[0.6.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.5.0...cli-v0.6.0
+[0.5.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.3.0...cli-v0.5.0
+[0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.2.0...cli-v0.3.0
+[0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.1.0...cli-v0.2.0
+[0.1.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/cli-v0.1.0
+[#144]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/144
+[#131]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/131
+[#102]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/102
+[#97]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/97
+[#85]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/85
+[#48]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/48
+[#35]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/35
+[#33]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/33
+[#32]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/32
+[#18]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/18
+[#14]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/14
+[#13]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/13
+[#12]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/12
+[#10]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/10
+[#9]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/9

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,8 @@
   "files": [
     "bin/",
     "src/",
-    "scripts/"
+    "scripts/",
+    "CHANGELOG.md"
   ],
   "keywords": [
     "qveris",

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to `@qverisai/sdk` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Vercel AI SDK adapter: `getQverisTools(qveris)` from `@qverisai/sdk/ai` returns `qveris_discover` / `qveris_inspect` / `qveris_call` tools for `generateText`/`streamText` (`ai` and `zod` as optional peer dependencies). ([#134])
+- Rate-limited (`429`) and transient (`503`) responses are retried automatically: honors `Retry-After`, otherwise exponential backoff with jitter, bounded by the `maxRetries` config option (default 3; `0` disables); `rateLimitRetryCount` exposes the backoff. ([#143])
+
+## [0.2.0] - 2026-07-06
+
+### Added
+
+- First release of the typed QVeris REST client: `discover` / `inspect` / `call` / `credits` / `usage` / `ledger`, zero dependencies (native fetch, Node 18+). ([#106])
+- Wire semantics aligned with the Python SDK and MCP server: success-envelope unwrapping, region auto-detection from the key prefix, structured `QverisApiError` with observability context.
+- Response types cover category objects, capability descriptors, `why_recommended`, and `expected_cost`.
+
+### Note
+
+- `0.1.x` under this npm name was an early MCP-focused SDK, superseded by `@qverisai/mcp`.
+
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.2.0...HEAD
+[0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/js-sdk-v0.2.0
+[#143]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/143
+[#134]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/134
+[#106]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/106

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -36,7 +36,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+All notable changes to `@qverisai/mcp` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Streamable HTTP transport for remote MCP alongside the stdio default: per-session servers keyed by `Mcp-Session-Id`, optional inbound bearer auth (fail-closed on non-loopback binds), DNS-rebinding protection, request-body cap, and idle-session eviction. ([#139])
+- Server Card (`GET {path}/server-card`) and MCP Catalog (`GET /.well-known/mcp/catalog.json`) discovery documents, so registries and crawlers can learn about the server without connecting. ([#140])
+- Rate-limited (`429`) and transient (`503`) API responses are retried automatically: honors `Retry-After`, otherwise exponential backoff with jitter, bounded by `config.maxRetries` / `QVERIS_MAX_RETRIES` (default 3; `0` disables); `rateLimitRetryCount` exposes the backoff. ([#145])
+
+## [0.7.5] - 2026-07-07
+
+### Fixed
+
+- The server starts without `QVERIS_API_KEY`: MCP clients and registry scanners can list tools before credentials are configured; tool calls return an actionable error until a key is set. ([#126])
+
+## [0.7.4] - 2026-07-07
+
+### Fixed
+
+- `mcpName` casing (`io.github.QVerisAI/mcp`) required by the official MCP Registry ownership validation. ([#122])
+
+## [0.7.3] - 2026-07-06
+
+### Added
+
+- `ToolInfo` declares `capabilities`, `expected_cost`, `why_recommended`, and `provider_id`, matching current Discover/Inspect responses. ([#102])
+- `mcpName` and MCP registry metadata (`server.json`, Smithery, Glama) for directory listings. ([#117])
+
+### Removed
+
+- `provider_logo_url` from type declarations (dropped from the public spec). ([#105])
+
+## [0.7.2] - 2026-07-06
+
+### Fixed
+
+- Accept object-shaped tool categories in discover/inspect results (legacy string tags still supported). ([#97])
+- Hardened MCP probe and call params/observability paths. ([#85])
+
+## [0.7.1] - 2026-06-13
+
+### Fixed
+
+- Hardened process-entrypoint detection, including npm bin symlinks.
+
+## [0.7.0] - 2026-05-21
+
+### Added
+
+- Generated OpenAPI contract types with drift CI. ([#48])
+- Canonical qveris tool names standardized across surfaces. ([#31])
+
+## [0.6.0] - 2026-05-06
+
+### Added
+
+- Context-safe `usage_history` and `credits_ledger` audit tools. ([#18])
+
+## [0.5.0] - 2026-04-09
+
+### Changed
+
+- Tools renamed to `discover` / `inspect` / `call`; the previous names remain as deprecated aliases. ([#14])
+- Multi-region (global/China) support improvements. ([#13])
+
+## [0.4.0] - 2026-04-04
+
+### Added
+
+- China region (`qveris.cn`) support. ([#9])
+
+### Changed
+
+- Monorepo restructure. ([#8])
+
+## [0.3.0] / [0.2.0] - 2026-04-04
+
+- Version bumps / republish; no functional changes.
+
+## [0.1.2] - 2026-04-04
+
+### Fixed
+
+- Handle empty/non-JSON success responses gracefully; `params_to_tool` documented as an object.
+
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.5...HEAD
+[0.7.5]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.4...mcp-v0.7.5
+[0.7.4]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.3...mcp-v0.7.4
+[0.7.3]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.2...mcp-v0.7.3
+[0.7.2]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.1...mcp-v0.7.2
+[0.7.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.0...mcp-v0.7.1
+[0.7.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.6.0...mcp-v0.7.0
+[0.6.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.5.0...mcp-v0.6.0
+[0.5.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.4.0...mcp-v0.5.0
+[0.4.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.3.0...mcp-v0.4.0
+[0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.2.0...mcp-v0.3.0
+[0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.1.2...mcp-v0.2.0
+[0.1.2]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/mcp-v0.1.2
+[#145]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/145
+[#140]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/140
+[#139]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/139
+[#126]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/126
+[#122]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/122
+[#117]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/117
+[#105]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/105
+[#102]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/102
+[#97]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/97
+[#85]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/85
+[#48]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/48
+[#31]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/31
+[#18]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/18
+[#14]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/14
+[#13]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/13
+[#9]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/9
+[#8]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/8

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -29,7 +29,8 @@
     "qveris-mcp": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the OpenClaw QVeris plugin are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions are date-based (`YYYY.M.D`).
+
+## [Unreleased]
+
+### Added
+
+- `why_recommended` and `expected_cost` from discover results are projected to the model, so capability selection can weigh relevance and cost. ([#104])
+
+## [2026.6.4] - 2026-06-04
+
+### Added
+
+- First published build with compiled `dist/` output. ([#90])
+
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.6.4...HEAD
+[2026.6.4]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/qveris-plugin-v2026.6.4
+[#104]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/104
+[#90]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/90

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -14,7 +14,8 @@
     "src/qveris-client.ts",
     "src/qveris-errors.ts",
     "src/qveris-materialization.ts",
-    "src/qveris-tools.ts"
+    "src/qveris-tools.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "node scripts/build.mjs",

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to the `qveris` Python SDK are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Framework adapters as optional extras: LangChain (`qveris[langchain]`), OpenAI Agents SDK (`qveris[openai-agents]`), and CrewAI (`qveris[crewai]`) — each exposes the discover/inspect/call workflow as native tools for that framework. ([#132], [#133], [#135])
+- Per-session credit budget guard for the agent: `Agent(budget_credits=...)`. ([#130])
+- Optional OpenTelemetry tracing (`qveris[otel]`): one span per discover/inspect/call with `qveris.*` attributes (tool_id, search_id, execution_id, elapsed_time_ms, credits); dependency-free no-op when opentelemetry is absent, and tracer faults never break a call. ([#141])
+- Rate-limited (`429`) and transient (`503`) responses are retried automatically: honors `Retry-After` (measured against the response `Date` per RFC 9110), otherwise exponential backoff with jitter, bounded by `QverisConfig.max_retries` / `QVERIS_MAX_RETRIES` (default 3; `0` disables); `client.rate_limit_retries` surfaces backoff as pressure. ([#142])
+- `ToolInfo` declares `capabilities`, `expected_cost`, `why_recommended`, and provider fields; explainable-routing example. ([#102], [#128])
+
+### Fixed
+
+- `QverisConfig(api_key=...)` explicit constructor values override environment variables again under pydantic 2.11+/2.12, without exposing the generic `API_KEY` / `BASE_URL` env names. ([#138])
+
+### Removed
+
+- `provider_logo_url` from type declarations (dropped from the public spec). ([#105])
+
+## [0.2.1] - 2026-07-06
+
+### Fixed
+
+- Accept object-shaped tool categories in discover/inspect results (legacy string tags still supported); type widening recorded per review. ([#97])
+
+## [0.2.0] - 2026-05-21
+
+### Added
+
+- First release of the typed client surface: `discover` / `inspect` / `call` / `usage` / `ledger` with pydantic v2 models for capabilities, billing, execution, and audit. ([#34])
+- Generated OpenAPI contract models with drift CI. ([#48])
+- `Agent` runtime: LLM tool loop over the QVeris workflow with streaming events.
+
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.1...HEAD
+[0.2.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.0...python-sdk-v0.2.1
+[0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/python-sdk-v0.2.0
+[#142]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/142
+[#141]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/141
+[#138]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/138
+[#135]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/135
+[#133]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/133
+[#132]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/132
+[#130]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/130
+[#128]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/128
+[#105]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/105
+[#102]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/102
+[#97]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/97
+[#48]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/48
+[#34]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/34

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -54,5 +54,13 @@ dev = [
     "datamodel-code-generator==0.26.3",
 ]
 
+[project.urls]
+Changelog = "https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/packages/python-sdk/CHANGELOG.md"
+
 [tool.hatch.build.targets.wheel]
 packages = ["qveris"]
+
+# Ship the changelog in the wheel too (most users install the wheel, not the
+# sdist); it lands as qveris/CHANGELOG.md in site-packages.
+[tool.hatch.build.targets.wheel.force-include]
+"CHANGELOG.md" = "qveris/CHANGELOG.md"


### PR DESCRIPTION
Closes #116.

## What

- **`CHANGELOG.md` for all five packages** (cli, mcp, python-sdk, js-sdk, openclaw plugin — js-sdk postdates the issue but is included), in [Keep a Changelog](https://keepachangelog.com) format:
  - Backfilled every released version from the annotated-tag messages (#101 Highlights) and per-package commit history, with GitHub compare links per version.
  - An `[Unreleased]` section captures everything landed since each package's last tag (adapters, budget guard, OTel, 429 backoff, HTTP transport, Server Card, …), so the next release only renames the section.
- **Ships with the packages**: added to the npm `files` whitelists — verified via `npm pack --dry-run` for all four npm packages — and included in the Python sdist by hatchling's defaults (verified via `uv build --sdist`).
- **Publish gate**: every publish workflow now fails before publishing if `CHANGELOG.md` lacks a `## [<version>]` section for the tagged version. Pattern verified against all five real files (released versions match; unreleased versions correctly fail).
- **`RELEASING.md`**: documents the process — bump → move `Unreleased` into a release section → PR → **annotated tag whose message is the CHANGELOG section** (this is the evaluated linkage with the #101 tag Highlights: one source of truth, no automation needed; the `sed` extraction one-liner is included and verified against a real section).

## Issue checklist

- [x] Per-package CHANGELOG.md, Keep a Changelog format, versions backfilled
- [x] Included in npm files whitelist / sdist
- [x] Release process doc + publish-workflow existence check
- [x] Annotated-tag Highlights linkage: tag message = CHANGELOG section (documented in RELEASING.md)