### PR TITLE
docs(skills): add a quick-first-run section to the CLI Skill (#123)

### DIFF
--- a/skills/qveris-cli/SKILL.md
+++ b/skills/qveris-cli/SKILL.md
@@ -3,6 +3,16 @@ name: qveris-cli
 description: "Use QVeris CLI to discover and call third-party API tools. Use when you need to find an external API, integrate a web service, or retrieve live data (prices, weather, news, etc)."
 ---
 
+## Quick first run
+
+New to QVeris? One command walks the whole loop end to end — auth, discover, inspect, a real call, and the exact usage/ledger commands to reconcile billing — no install needed:
+
+```bash
+npx @qverisai/cli init
+```
+
+Re-run anytime with `--query "..."` to target a different capability, or `--dry-run` to validate without consuming credits. Once you've seen the loop, the commands below are the day-to-day surface.
+
 ## Commands
 
 ```bash

--- a/skills/qveris-cli/SKILL.md
+++ b/skills/qveris-cli/SKILL.md
@@ -5,9 +5,10 @@ description: "Use QVeris CLI to discover and call third-party API tools. Use whe
 
 ## Quick first run
 
-New to QVeris? One command walks the whole loop end to end — auth, discover, inspect, a real call, and the exact usage/ledger commands to reconcile billing — no install needed:
+New to QVeris? With your `QVERIS_API_KEY` set (create one at [qveris.ai](https://qveris.ai/account?page=api-keys) or [qveris.cn](https://qveris.cn/account?page=api-keys)), one command walks the whole loop end to end — auth, discover, inspect, a real call, and the exact usage/ledger commands to reconcile billing — no install needed:
 
 ```bash
+export QVERIS_API_KEY="sk-..."
 npx @qverisai/cli init
 ```
 


### PR DESCRIPTION
Addresses the legitimate kernel of #123: the CLI Skill jumped straight into the command list with no low-friction first-run path.

Adds a **Quick first run** section at the top of `skills/qveris-cli/SKILL.md` pointing at the official guided wizard — `npx @qverisai/cli init` (auth → discover → inspect → call → usage/ledger reconciliation, zero install), with `--query` / `--dry-run` pointers.

Deliberately does **not** add the third-party hosted link proposed in the issue: that deployment is outside QVerisAI's control (users would run capabilities/credentials through it), and the link carries outreach-campaign tracking parameters. Rationale posted on the issue.

`skills/qveris/SKILL.md` (MCP-oriented, no CLI install involved) is unchanged.