### PR TITLE
chore(release): cli 0.7.0 · mcp 0.8.0 · js-sdk 0.3.0 · python-sdk 0.3.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-09
+
 ### Added
 
 - Rate-limited (`429`) and transient (`503`) responses are retried automatically: the CLI honors `Retry-After`, otherwise backs off exponentially with jitter, bounded by `QVERIS_MAX_RETRIES` (default 3; `0` disables). ([#144])
@@ -61,7 +63,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Initial release: `discover` / `inspect` / `call` from the terminal against the QVeris API.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.6.1...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.7.0...HEAD
+[0.7.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.6.1...cli-v0.7.0
 [0.6.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.6.0...cli-v0.6.1
 [0.6.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.5.0...cli-v0.6.0
 [0.5.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.3.0...cli-v0.5.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "QVeris CLI for agent capability discovery, inspection, calling, and audit",
   "type": "module",
   "bin": {

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-09
+
 ### Added
 
 - Vercel AI SDK adapter: `getQverisTools(qveris)` from `@qverisai/sdk/ai` returns `qveris_discover` / `qveris_inspect` / `qveris_call` tools for `generateText`/`streamText` (`ai` and `zod` as optional peer dependencies). ([#134])
@@ -23,7 +25,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - `0.1.x` under this npm name was an early MCP-focused SDK, superseded by `@qverisai/mcp`.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.2.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.3.0...HEAD
+[0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.2.0...js-sdk-v0.3.0
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/js-sdk-v0.2.0
 [#143]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/143
 [#134]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/134

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "QVeris TypeScript SDK for agent capability discovery, inspection, calling, and audit",
   "keywords": [
     "qveris",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,11 +6,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-09
+
 ### Added
 
 - Streamable HTTP transport for remote MCP alongside the stdio default: per-session servers keyed by `Mcp-Session-Id`, optional inbound bearer auth (fail-closed on non-loopback binds), DNS-rebinding protection, request-body cap, and idle-session eviction. ([#139])
 - Server Card (`GET {path}/server-card`) and MCP Catalog (`GET /.well-known/mcp/catalog.json`) discovery documents, so registries and crawlers can learn about the server without connecting. ([#140])
 - Rate-limited (`429`) and transient (`503`) API responses are retried automatically: honors `Retry-After`, otherwise exponential backoff with jitter, bounded by `config.maxRetries` / `QVERIS_MAX_RETRIES` (default 3; `0` disables); `rateLimitRetryCount` exposes the backoff. ([#145])
+
+### Changed
+
+- Requires Node.js >= 18.2 (was >= 18.0): prompt HTTP-server shutdown uses `closeAllConnections`, added in 18.2. ([#139])
 
 ## [0.7.5] - 2026-07-07
 
@@ -88,7 +94,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Handle empty/non-JSON success responses gracefully; `params_to_tool` documented as an object.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.5...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.8.0...HEAD
+[0.8.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.5...mcp-v0.8.0
 [0.7.5]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.4...mcp-v0.7.5
 [0.7.4]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.3...mcp-v0.7.4
 [0.7.3]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.2...mcp-v0.7.3

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.QVerisAI/mcp",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-09
+
 ### Added
 
 - Framework adapters as optional extras: LangChain (`qveris[langchain]`), OpenAI Agents SDK (`qveris[openai-agents]`), and CrewAI (`qveris[crewai]`) — each exposes the discover/inspect/call workflow as native tools for that framework. ([#132], [#133], [#135])
@@ -36,7 +38,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Generated OpenAPI contract models with drift CI. ([#48])
 - `Agent` runtime: LLM tool loop over the QVeris workflow with streaming events.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.1...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.0...HEAD
+[0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.1...python-sdk-v0.3.0
 [0.2.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.0...python-sdk-v0.2.1
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/python-sdk-v0.2.0
 [#142]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/142

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qveris"
-version = "0.2.1"
+version = "0.3.0"
 description = "QVeris Python SDK for agent capability discovery, calling, and audit"
 requires-python = ">=3.8"
 license = "MIT"


### PR DESCRIPTION
First release wave through the new RELEASING.md process (#116). Versions bumped; each CHANGELOG's `Unreleased` rolled into a dated release section with compare links updated; the publish workflows' CHANGELOG gate verified locally against all four new versions.

## What ships

| Package | Version | Highlights |
|---------|---------|------------|
| `qveris` (PyPI) | 0.2.1 → **0.3.0** | LangChain/OpenAI-Agents/CrewAI adapters, budget guard, optional OTel tracing, 429/503 backoff, config precedence fix |
| `@qverisai/mcp` | 0.7.5 → **0.8.0** | Streamable HTTP remote transport, Server Card + Catalog discovery, 429/503 backoff (⚠ now requires Node ≥ 18.2) |
| `@qverisai/cli` | 0.6.1 → **0.7.0** | 429/503 backoff, doctor/init diagnostics, why_recommended surfaces |
| `@qverisai/sdk` | 0.2.0 → **0.3.0** | Vercel AI SDK adapter, 429/503 backoff |

## Pre-release validation (all against the live API)

- **CLI** (source): doctor → discover → inspect → dry-run → real call (1 credit) → usage reconciliation (charged, ledger IDs match) — and driven end-to-end **inside Codex CLI** (VERDICT PASS).
- **MCP** (built dist): raw stdio JSON-RPC (initialize / tools/list / real discover) — and end-to-end **inside Codex CLI** via `mcp_servers` config: discover → inspect → call (VERDICT PASS).
- **python-sdk**: the built **wheel** installed into a clean venv — live discover/inspect/call/usage + the new `rate_limit_retries` surface.
- **js-sdk**: the npm-packed **tarball** installed into a fresh project — same live E2E + `rateLimitRetryCount`.
- All four suites green post-bump (cli 79, mcp 110, js-sdk 33, python 75).

## After merge

Tag each release commit per RELEASING.md (annotated tag message = CHANGELOG section via the awk one-liner) and push; the publish workflows enforce version-match + CHANGELOG gates and run the full ubuntu+windows matrices before publishing.