### PR TITLE
docs: governance pack — SECURITY, CONTRIBUTING, templates, dependabot, CODEOWNERS (#155)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Something in a toolkit package doesn't work as documented
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      options:
+        - "@qverisai/cli"
+        - "@qverisai/mcp"
+        - "@qverisai/sdk (JS)"
+        - "qveris (Python SDK)"
+        - "OpenClaw plugin"
+        - "docs / skills / recipes"
+        - "other"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Package version (e.g. 0.8.0) — `qveris --version`, `pip show qveris`, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal commands/code. Redact your API key.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Node/Python version, region (global/cn). `qveris doctor` output is ideal (it redacts the key).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/QVerisAI/qveris-agent-toolkit/security/advisories/new
+    about: Please report vulnerabilities privately — never as a public issue.
+  - name: QVeris platform questions
+    url: https://qveris.ai
+    about: Questions about the QVeris platform/API (keys, billing, capabilities) rather than this toolkit.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Propose an improvement to the toolkit
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package / area
+      options:
+        - "@qverisai/cli"
+        - "@qverisai/mcp"
+        - "@qverisai/sdk (JS)"
+        - "qveris (Python SDK)"
+        - "OpenClaw plugin"
+        - "framework adapters"
+        - "docs / skills / recipes"
+        - "cross-cutting"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that's hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What
+
+<!-- What does this PR change, and why? Link the issue: Closes #NNN -->
+
+## Validation
+
+<!-- How was this verified? Test output, commands run. All suites run on ubuntu + windows in CI. -->
+
+## Checklist
+
+- [ ] Tests added/updated for behavior changes
+- [ ] Affected package's `CHANGELOG.md` `[Unreleased]` updated (releases gate on this)
+- [ ] Generated files (`generated/`) untouched by hand (regenerate via script if needed)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: { interval: weekly }
+  - package-ecosystem: npm
+    directory: /packages/mcp
+    schedule: { interval: weekly }
+  - package-ecosystem: npm
+    directory: /packages/js-sdk
+    schedule: { interval: weekly }
+  - package-ecosystem: npm
+    directory: /packages/cli
+    schedule: { interval: weekly }
+  - package-ecosystem: npm
+    directory: /packages/openclaw-qveris-plugin
+    schedule: { interval: weekly }
+  - package-ecosystem: pip
+    directory: /packages/python-sdk
+    schedule: { interval: weekly }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo.
+* @linfangw

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+In short: be respectful, assume good faith, no harassment or personal attacks. Report unacceptable behavior to **contact@qveris.ai**; reports are handled confidentially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thanks for your interest in the QVeris Agent Toolkit! This monorepo hosts five independently released packages plus agent-facing assets.
+
+## Layout
+
+| Path | What | Stack / tests |
+|------|------|---------------|
+| `packages/cli` | `@qverisai/cli` | Node ≥18, `node --test` |
+| `packages/mcp` | `@qverisai/mcp` MCP server (stdio + streamable HTTP) | TS strict, vitest |
+| `packages/js-sdk` | `@qverisai/sdk` typed REST client + Vercel AI adapter | TS strict, vitest |
+| `packages/python-sdk` | `qveris` on PyPI (client, Agent runtime, framework adapters) | Python ≥3.8, uv + pytest |
+| `packages/openclaw-qveris-plugin` | OpenClaw plugin | TS, vitest |
+| `skills/`, `recipes/`, `agent/`, `ecosystem/` | Agent-facing docs, recipes, manifests | see `ecosystem/CONTRIBUTING.md` for manifest contributions |
+
+## Dev setup & running tests
+
+Each package is self-contained:
+
+```bash
+# TS/JS packages (mcp, js-sdk, openclaw-qveris-plugin)
+cd packages/mcp && npm ci && npm run typecheck && npm test
+
+# CLI (no install needed)
+cd packages/cli && node --test
+
+# Python SDK (uses uv)
+cd packages/python-sdk && uv run --extra dev pytest
+```
+
+Contract alignment: the public OpenAPI spec lives at `docs/openapi/`; generated types and drift guards are enforced in CI (`contract-tests.yml`). If you change API-shaped types, regenerate via `scripts/regenerate-openapi-artifacts.sh` — never hand-edit `generated/` files.
+
+## Pull requests
+
+- Keep PRs scoped to one package/concern where possible; reference the issue (`#123`).
+- Add or update tests for behavior changes; all suites run on ubuntu **and** windows in CI.
+- Update the affected package's `CHANGELOG.md` `[Unreleased]` section (Keep a Changelog format) — releases fail without it.
+- New API-visible fields should follow additive compatibility (see each package's README compatibility notes).
+
+## Releases
+
+Maintainers only — see [RELEASING.md](RELEASING.md). Versions are tag-driven per package; publish workflows enforce version↔tag and CHANGELOG gates.
+
+## Security
+
+Never open a public issue for a vulnerability — see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+- Preferred: use GitHub's private vulnerability reporting — [Security → Report a vulnerability](https://github.com/QVerisAI/qveris-agent-toolkit/security/advisories/new).
+- Alternatively, email **contact@qveris.ai** with the details.
+
+We aim to acknowledge reports within 3 business days. Please include reproduction steps, the affected package/version, and impact assessment if you have one.
+
+## Scope
+
+This repository covers the QVeris client toolkit: `@qverisai/cli`, `@qverisai/mcp`, `@qverisai/sdk`, the `qveris` Python SDK, and the OpenClaw plugin. Vulnerabilities in the QVeris platform/API itself can be reported through the same channels.
+
+## Supported versions
+
+Only the latest released version of each package receives security fixes.
+
+## Handling of credentials
+
+- API keys are only ever sent as `Authorization: Bearer` headers to the configured QVeris endpoint; debug output redacts them.
+- The MCP server's remote (HTTP) mode refuses to bind non-loopback interfaces without inbound auth (fail-closed); see `packages/mcp/README.md`.


### PR DESCRIPTION
Closes #155 — the governance-file gaps from the repo audit, benchmarked against top-tier OSS toolkits.

- **SECURITY.md** — private disclosure path (GitHub advisories + `contact@qveris.ai`), scope, supported-versions policy, credential-handling notes (key redaction, MCP fail-closed bind).
- **Root CONTRIBUTING.md** — monorepo map, per-package dev/test commands (matching what CI runs), the never-hand-edit-`generated/` rule, PR conventions including the CHANGELOG gate, release pointer.
- **Issue templates** — bug (package dropdown, version, `qveris doctor` hint), feature request, and `config.yml` routing security reports to private advisories and platform questions to qveris.ai.
- **PR template** — mirrors the CI gates (tests, CHANGELOG, generated files).
- **dependabot.yml** — weekly: github-actions, 4 npm dirs, pip.
- **CODEOWNERS** + short Contributor Covenant **CODE_OF_CONDUCT.md**.

All YAML validated. Docs-only — no workflow/code changes (those are in #165).