### PR TITLE
test: shared conformance suite for the four framework adapters (#157)

### DIFF
--- a/packages/js-sdk/src/integrations/adapter-conformance.ts
+++ b/packages/js-sdk/src/integrations/adapter-conformance.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared conformance suite for JS framework adapters.
+ *
+ * Every adapter that exposes the QVeris workflow as framework tools must hold
+ * the same invariants (mirroring the Python `adapter_conformance` suite):
+ * three named tools, session threading, optional-argument omission, and an
+ * upfront client check. New adapters call
+ * {@link describeQverisAdapterConformance} from their test file and inherit
+ * the suite, so semantic drift between adapters fails tests instead of
+ * shipping.
+ *
+ * @module integrations/adapter-conformance (test-only)
+ */
+
+import { describe, expect, it } from 'vitest';
+
+/** Records client calls and returns canned payloads. */
+export class FakeQveris {
+  calls: Array<Record<string, unknown>> = [];
+
+  async discover(query: string, options: Record<string, unknown> = {}) {
+    this.calls.push({ method: 'discover', query, options });
+    return { search_id: 's1', total: 1, results: [{ tool_id: 't1' }] };
+  }
+
+  async inspect(toolIds: string | string[], options: Record<string, unknown> = {}) {
+    this.calls.push({ method: 'inspect', toolIds, options });
+    return { search_id: 's1', total: 1, results: [{ tool_id: 't1' }] };
+  }
+
+  async call(toolId: string, options: Record<string, unknown>) {
+    this.calls.push({ method: 'call', toolId, options });
+    return { execution_id: 'e1', success: true };
+  }
+}
+
+export interface AdapterConformanceOptions {
+  /** Display name for the describe block. */
+  adapterName: string;
+  /** The adapter's getQverisTools(client, options?). */
+  getTools: (
+    client: FakeQveris,
+    options?: { sessionId?: string },
+  ) => Record<string, { description?: string }>;
+  /** Invoke a tool produced by the adapter with raw tool arguments. */
+  invoke: (tool: unknown, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function describeQverisAdapterConformance(opts: AdapterConformanceOptions): void {
+  const { adapterName, getTools, invoke } = opts;
+
+  describe(`${adapterName} adapter conformance`, () => {
+    it('exposes exactly the three named tools with descriptions', () => {
+      const tools = getTools(new FakeQveris());
+      expect(Object.keys(tools)).toEqual(['qveris_discover', 'qveris_inspect', 'qveris_call']);
+      for (const tool of Object.values(tools)) {
+        expect(tool.description).toBeTruthy();
+      }
+    });
+
+    it('requires a valid client', () => {
+      expect(() => getTools(undefined as never)).toThrow();
+      expect(() => getTools({} as never)).toThrow();
+    });
+
+    it('discover routes with limit and threads sessionId', async () => {
+      const client = new FakeQveris();
+      const tools = getTools(client, { sessionId: 'sess-1' });
+
+      await invoke(tools.qveris_discover, { query: 'weather forecast API', limit: 3 });
+
+      expect(client.calls[0]).toEqual({
+        method: 'discover',
+        query: 'weather forecast API',
+        options: { limit: 3, sessionId: 'sess-1' },
+      });
+    });
+
+    it('inspect passes tool ids and search id', async () => {
+      const client = new FakeQveris();
+      const tools = getTools(client);
+
+      await invoke(tools.qveris_inspect, { tool_ids: ['t1', 't2'], search_id: 's1' });
+
+      expect(client.calls[0]).toEqual({
+        method: 'inspect',
+        toolIds: ['t1', 't2'],
+        options: { searchId: 's1' },
+      });
+    });
+
+    it('call threads ids and omits absent maxResponseSize', async () => {
+      const client = new FakeQveris();
+      const tools = getTools(client);
+
+      await invoke(tools.qveris_call, {
+        tool_id: 't1',
+        search_id: 's1',
+        params_to_tool: { city: 'London' },
+      });
+
+      expect(client.calls[0]).toEqual({
+        method: 'call',
+        toolId: 't1',
+        options: { parameters: { city: 'London' }, searchId: 's1' },
+      });
+    });
+
+    it('call omits absent search_id and defaults params to {}', async () => {
+      const client = new FakeQveris();
+      const tools = getTools(client);
+
+      await invoke(tools.qveris_call, { tool_id: 't1' });
+
+      expect(client.calls[0]).toEqual({
+        method: 'call',
+        toolId: 't1',
+        options: { parameters: {} },
+      });
+    });
+
+    it('call forwards maxResponseSize when given', async () => {
+      const client = new FakeQveris();
+      const tools = getTools(client);
+
+      await invoke(tools.qveris_call, {
+        tool_id: 't1',
+        search_id: 's1',
+        params_to_tool: {},
+        max_response_size: 2048,
+      });
+
+      expect((client.calls[0].options as Record<string, unknown>).maxResponseSize).toBe(2048);
+    });
+  });
+}

--- a/packages/js-sdk/src/integrations/ai.test.ts
+++ b/packages/js-sdk/src/integrations/ai.test.ts
@@ -1,101 +1,41 @@
 import { describe, expect, it } from 'vitest';
 
 import { getQverisTools } from './ai.js';
-
-class FakeQveris {
-  calls: Array<Record<string, unknown>> = [];
-
-  async discover(query: string, options: Record<string, unknown> = {}) {
-    this.calls.push({ method: 'discover', query, options });
-    return { search_id: 's1', total: 1, results: [{ tool_id: 't1' }] };
-  }
-
-  async inspect(toolIds: string | string[], options: Record<string, unknown> = {}) {
-    this.calls.push({ method: 'inspect', toolIds, options });
-    return { search_id: 's1', total: 1, results: [{ tool_id: 't1' }] };
-  }
-
-  async call(toolId: string, options: Record<string, unknown>) {
-    this.calls.push({ method: 'call', toolId, options });
-    return { execution_id: 'e1', success: true };
-  }
-}
+import { describeQverisAdapterConformance, FakeQveris } from './adapter-conformance.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const invoke = (t: any, args: Record<string, unknown>) =>
   t.execute(args, { toolCallId: 'c1', messages: [] });
 
-describe('getQverisTools (Vercel AI SDK)', () => {
-  it('exposes three named tools', () => {
+// Shared invariants — mirrors the Python adapter_conformance suite.
+describeQverisAdapterConformance({
+  adapterName: 'Vercel AI SDK',
+  getTools: (client, options) => getQverisTools(client as never, options),
+  invoke,
+});
+
+// --- Vercel-AI-specific behavior ----------------------------------------------
+
+describe('getQverisTools (Vercel AI SDK specifics)', () => {
+  it('tools declare v7 inputSchema (not the legacy parameters field)', () => {
     const tools = getQverisTools(new FakeQveris() as never);
-    expect(Object.keys(tools)).toEqual(['qveris_discover', 'qveris_inspect', 'qveris_call']);
-    for (const key of Object.keys(tools) as Array<keyof typeof tools>) {
-      expect(tools[key].description).toBeTruthy();
+    for (const tool of Object.values(tools)) {
+      expect((tool as { inputSchema?: unknown }).inputSchema).toBeDefined();
     }
   });
 
-  it('discover routes to client.discover with limit and sessionId', async () => {
-    const client = new FakeQveris();
-    const tools = getQverisTools(client as never, { sessionId: 'sess-1' });
-
-    const out = await invoke(tools.qveris_discover, { query: 'weather forecast API', limit: 3 });
-
-    expect(client.calls[0]).toEqual({
-      method: 'discover',
-      query: 'weather forecast API',
-      options: { limit: 3, sessionId: 'sess-1' },
-    });
-    expect(out.search_id).toBe('s1');
-  });
-
-  it('call maps params_to_tool/search_id and omits max_response_size when absent', async () => {
+  it('results pass through the client payload', async () => {
     const client = new FakeQveris();
     const tools = getQverisTools(client as never);
 
-    const out = await invoke(tools.qveris_call, {
+    const out = await invoke(tools.qveris_discover, { query: 'weather forecast API' });
+    expect(out.search_id).toBe('s1');
+
+    const outcome = await invoke(tools.qveris_call, {
       tool_id: 't1',
       search_id: 's1',
-      params_to_tool: { city: 'London' },
+      params_to_tool: {},
     });
-
-    expect(client.calls[0]).toEqual({
-      method: 'call',
-      toolId: 't1',
-      options: { parameters: { city: 'London' }, searchId: 's1' },
-    });
-    expect('maxResponseSize' in (client.calls[0].options as object)).toBe(false);
-    expect(out.execution_id).toBe('e1');
-  });
-
-  it('throws when given no valid client', () => {
-    expect(() => getQverisTools(undefined as never)).toThrow(TypeError);
-    expect(() => getQverisTools({} as never)).toThrow(/valid Qveris client/);
-  });
-
-  it('call omits search_id when absent and defaults params to {}', async () => {
-    const client = new FakeQveris();
-    const tools = getQverisTools(client as never);
-
-    await invoke(tools.qveris_call, { tool_id: 't1' });
-
-    expect(client.calls[0]).toEqual({
-      method: 'call',
-      toolId: 't1',
-      options: { parameters: {} },
-    });
-    expect('searchId' in (client.calls[0].options as object)).toBe(false);
-  });
-
-  it('inspect passes tool_ids and searchId', async () => {
-    const client = new FakeQveris();
-    const tools = getQverisTools(client as never);
-
-    await invoke(tools.qveris_inspect, { tool_ids: ['t1', 't2'], search_id: 's1' });
-
-    expect(client.calls[0]).toEqual({
-      method: 'inspect',
-      toolIds: ['t1', 't2'],
-      options: { searchId: 's1' },
-    });
+    expect(outcome.execution_id).toBe('e1');
   });
 });

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/integrations/adapter-conformance.ts"]
 }

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- LangChain adapter: `search_id` is now optional in `qveris_call` and omitted from the request when absent — consistent with the OpenAI-Agents, CrewAI, and Vercel-AI adapters (the earlier consistency fix missed this adapter; caught by the new cross-adapter conformance suite). ([#157])
+
 ## [0.3.0] - 2026-07-09
 
 ### Added
@@ -42,6 +46,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.1...python-sdk-v0.3.0
 [0.2.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.0...python-sdk-v0.2.1
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/python-sdk-v0.2.0
+[#157]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/157
 [#142]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/142
 [#141]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/141
 [#138]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/138

--- a/packages/python-sdk/qveris/integrations/langchain.py
+++ b/packages/python-sdk/qveris/integrations/langchain.py
@@ -46,8 +46,8 @@ class _InspectArgs(BaseModel):
 
 class _CallArgs(BaseModel):
     tool_id: str = Field(description="The capability tool_id, from discover or inspect.")
-    search_id: str = Field(description="The search_id from the discover response.")
     params_to_tool: Dict[str, Any] = Field(description="Parameters to pass to the capability.")
+    search_id: Optional[str] = Field(default=None, description="The search_id from the discover response, if available.")
     max_response_size: Optional[int] = Field(
         default=None, description="Max response size in bytes; -1 means unlimited."
     )
@@ -92,15 +92,16 @@ def get_qveris_tools(
 
     async def _call(
         tool_id: str,
-        search_id: str,
         params_to_tool: Dict[str, Any],
+        search_id: Optional[str] = None,
         max_response_size: Optional[int] = None,
     ) -> str:
         args: Dict[str, Any] = {
             "tool_id": tool_id,
-            "search_id": search_id,
             "params_to_tool": params_to_tool,
         }
+        if search_id is not None:
+            args["search_id"] = search_id
         if max_response_size is not None:
             args["max_response_size"] = max_response_size
         return await _route("call", args)

--- a/packages/python-sdk/tests/adapter_conformance.py
+++ b/packages/python-sdk/tests/adapter_conformance.py
@@ -1,0 +1,139 @@
+"""Shared conformance suite for the framework adapters.
+
+Every adapter (LangChain, OpenAI Agents SDK, CrewAI, ...) must expose the same
+QVeris workflow with the same semantics. Each adapter's test module subclasses
+:class:`AdapterConformance`, implements the two hooks, and inherits the full
+invariant suite — so a semantic drift in one adapter (e.g. an argument that is
+optional in three adapters but required in the fourth) fails its tests instead
+of shipping. Modeled on the ``langchain-tests`` standard-tests pattern.
+
+Invariants covered:
+
+1. ``get_qveris_tools(client, session_id=...)`` returns exactly three tools
+   named ``qveris_discover`` / ``qveris_inspect`` / ``qveris_call``, in that
+   order, each with a non-empty description.
+2. The client is a required argument.
+3. ``discover`` routes to ``handle_tool_call("discover", {query, limit})`` and
+   threads ``session_id``.
+4. ``inspect`` passes ``tool_ids`` (+ ``search_id``).
+5. ``call`` threads ``tool_id``/``search_id``/``params_to_tool``, and OMITS
+   ``search_id`` and ``max_response_size`` from the request when not provided.
+6. Tool results are JSON strings of the client payload.
+"""
+
+import asyncio
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+
+class FakeClient:
+    """Records handle_tool_call invocations and returns canned payloads."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def handle_tool_call(
+        self, func_name: str, func_args: Dict[str, Any], session_id: Optional[str] = None
+    ) -> Tuple[Any, bool, bool]:
+        self.calls.append({"name": func_name, "args": func_args, "session_id": session_id})
+        if func_name == "discover":
+            return {"search_id": "s1", "results": [{"tool_id": "t1"}]}, False, True
+        if func_name == "inspect":
+            return {"results": [{"tool_id": "t1", "name": "T"}]}, False, True
+        return {"execution_id": "e1", "success": True}, False, True
+
+
+def run(coro: Any) -> Any:
+    """Run a coroutine from a sync test (adapters may also be natively sync)."""
+    return asyncio.run(coro)
+
+
+class AdapterConformance:
+    """Inherit and implement :meth:`make_tools` and :meth:`invoke`."""
+
+    def make_tools(self, client: Any, session_id: Optional[str] = None) -> List[Any]:
+        """Return the adapter's tools for ``client`` (its get_qveris_tools)."""
+        raise NotImplementedError
+
+    def invoke(self, tool: Any, args: Dict[str, Any]) -> str:
+        """Invoke ``tool`` with ``args`` and return its raw (string) result."""
+        raise NotImplementedError
+
+    def make_tools_no_client(self) -> Any:
+        """Call the adapter's get_qveris_tools with no arguments."""
+        raise NotImplementedError
+
+    # -- helpers ---------------------------------------------------------
+
+    def tool(self, tools: List[Any], name: str) -> Any:
+        return next(t for t in tools if t.name == name)
+
+    # -- invariants ------------------------------------------------------
+
+    def test_exposes_three_named_tools_in_order(self) -> None:
+        tools = self.make_tools(FakeClient())
+        assert [t.name for t in tools] == ["qveris_discover", "qveris_inspect", "qveris_call"]
+        for t in tools:
+            assert t.description, f"{t.name} must have a description"
+
+    def test_client_is_required(self) -> None:
+        with pytest.raises(TypeError):
+            self.make_tools_no_client()
+
+    def test_discover_routes_and_threads_session_id(self) -> None:
+        client = FakeClient()
+        discover = self.tool(self.make_tools(client, session_id="sess-1"), "qveris_discover")
+
+        out = self.invoke(discover, {"query": "weather forecast API", "limit": 3})
+
+        assert client.calls == [
+            {"name": "discover", "args": {"query": "weather forecast API", "limit": 3}, "session_id": "sess-1"}
+        ]
+        assert isinstance(out, str), "adapters must return JSON strings"
+        assert json.loads(out)["search_id"] == "s1"
+
+    def test_inspect_passes_tool_ids_and_search_id(self) -> None:
+        client = FakeClient()
+        inspect = self.tool(self.make_tools(client), "qveris_inspect")
+
+        self.invoke(inspect, {"tool_ids": ["t1", "t2"], "search_id": "s1"})
+
+        assert client.calls[0]["name"] == "inspect"
+        assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}
+
+    def test_call_threads_ids_and_omits_absent_max_response_size(self) -> None:
+        client = FakeClient()
+        call = self.tool(self.make_tools(client), "qveris_call")
+
+        out = self.invoke(call, {"tool_id": "t1", "search_id": "s1", "params_to_tool": {"city": "London"}})
+
+        assert client.calls[0]["name"] == "call"
+        assert client.calls[0]["args"] == {
+            "tool_id": "t1",
+            "search_id": "s1",
+            "params_to_tool": {"city": "London"},
+        }
+        assert "max_response_size" not in client.calls[0]["args"]
+        assert json.loads(out)["execution_id"] == "e1"
+
+    def test_call_omits_absent_search_id(self) -> None:
+        client = FakeClient()
+        call = self.tool(self.make_tools(client), "qveris_call")
+
+        self.invoke(call, {"tool_id": "t1", "params_to_tool": {}})
+
+        assert client.calls[0]["args"] == {"tool_id": "t1", "params_to_tool": {}}
+        assert "search_id" not in client.calls[0]["args"]
+
+    def test_call_forwards_max_response_size_when_given(self) -> None:
+        client = FakeClient()
+        call = self.tool(self.make_tools(client), "qveris_call")
+
+        self.invoke(
+            call,
+            {"tool_id": "t1", "search_id": "s1", "params_to_tool": {}, "max_response_size": 2048},
+        )
+
+        assert client.calls[0]["args"]["max_response_size"] == 2048

--- a/packages/python-sdk/tests/test_crewai_integration.py
+++ b/packages/python-sdk/tests/test_crewai_integration.py
@@ -1,6 +1,5 @@
 import asyncio
-import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -8,71 +7,28 @@ pytest.importorskip("crewai", reason="CrewAI integration requires crewai (Python
 
 from qveris.integrations.crewai import aclose, get_qveris_tools  # noqa: E402
 
+from adapter_conformance import AdapterConformance  # noqa: E402
 
-class FakeClient:
-    def __init__(self) -> None:
-        self.calls: List[Dict[str, Any]] = []
 
-    async def handle_tool_call(
-        self, func_name: str, func_args: Dict[str, Any], session_id: Optional[str] = None
-    ) -> Tuple[Any, bool, bool]:
-        self.calls.append({"name": func_name, "args": func_args, "session_id": session_id})
-        if func_name == "discover":
-            return {"search_id": "s1", "results": [{"tool_id": "t1"}]}, False, True
-        if func_name == "inspect":
-            return {"results": [{"tool_id": "t1"}]}, False, True
-        return {"execution_id": "e1", "success": True}, False, True
+class TestCrewAIAdapterConformance(AdapterConformance):
+    """Shared invariants (see adapter_conformance.py) for the CrewAI adapter."""
+
+    def make_tools(self, client: Any, session_id: Optional[str] = None) -> List[Any]:
+        return get_qveris_tools(client, session_id=session_id)
+
+    def make_tools_no_client(self) -> Any:
+        return get_qveris_tools()  # type: ignore[call-arg]
+
+    def invoke(self, tool: Any, args: Dict[str, Any]) -> str:
+        # CrewAI tools are synchronous; they bridge to the async client internally.
+        return tool._run(**args)
+
+
+# --- CrewAI-specific behavior: the sync/async bridge loop ---------------------
 
 
 def _tool(tools, name):
     return next(t for t in tools if t.name == name)
-
-
-def test_get_qveris_tools_exposes_three_named_tools() -> None:
-    tools = get_qveris_tools(FakeClient())
-    assert [t.name for t in tools] == ["qveris_discover", "qveris_inspect", "qveris_call"]
-    for tool in tools:
-        assert tool.description
-        assert tool.args_schema is not None
-
-
-def test_discover_tool_routes_to_handle_tool_call() -> None:
-    client = FakeClient()
-    discover = _tool(get_qveris_tools(client, session_id="sess-1"), "qveris_discover")
-
-    # _run bridges the async client synchronously (no running loop in this test).
-    out = discover._run(query="weather forecast API", limit=3)
-
-    assert client.calls == [
-        {"name": "discover", "args": {"query": "weather forecast API", "limit": 3}, "session_id": "sess-1"}
-    ]
-    assert json.loads(out)["search_id"] == "s1"
-
-
-def test_call_tool_threads_ids_and_omits_absent_max_response_size() -> None:
-    client = FakeClient()
-    call = _tool(get_qveris_tools(client), "qveris_call")
-
-    out = call._run(tool_id="t1", search_id="s1", params_to_tool={"city": "London"})
-
-    assert client.calls[0]["name"] == "call"
-    assert client.calls[0]["args"] == {
-        "tool_id": "t1",
-        "search_id": "s1",
-        "params_to_tool": {"city": "London"},
-    }
-    assert "max_response_size" not in client.calls[0]["args"]
-    assert json.loads(out)["execution_id"] == "e1"
-
-
-def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
-    client = FakeClient()
-    inspect = _tool(get_qveris_tools(client), "qveris_inspect")
-
-    inspect._run(tool_ids=["t1", "t2"], search_id="s1")
-
-    assert client.calls[0]["name"] == "inspect"
-    assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}
 
 
 def test_all_tool_calls_run_on_one_shared_event_loop() -> None:
@@ -94,16 +50,6 @@ def test_all_tool_calls_run_on_one_shared_event_loop() -> None:
 
     assert len(loop_ids) == 3
     assert len(set(loop_ids)) == 1  # all three on one stable bridge loop
-
-
-def test_call_tool_omits_absent_search_id() -> None:
-    client = FakeClient()
-    call = _tool(get_qveris_tools(client), "qveris_call")
-
-    call._run(tool_id="t1", params_to_tool={})
-
-    assert "search_id" not in client.calls[0]["args"]
-    assert client.calls[0]["args"] == {"tool_id": "t1", "params_to_tool": {}}
 
 
 def test_arun_dispatches_work_onto_the_bridge_loop() -> None:

--- a/packages/python-sdk/tests/test_langchain_integration.py
+++ b/packages/python-sdk/tests/test_langchain_integration.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -7,69 +6,30 @@ pytest.importorskip("langchain_core", reason="LangChain integration requires lan
 
 from qveris.integrations.langchain import get_qveris_tools  # noqa: E402
 
-
-class FakeClient:
-    def __init__(self) -> None:
-        self.calls: List[Dict[str, Any]] = []
-
-    async def handle_tool_call(
-        self, func_name: str, func_args: Dict[str, Any], session_id: Optional[str] = None
-    ) -> Tuple[Any, bool, bool]:
-        self.calls.append({"name": func_name, "args": func_args, "session_id": session_id})
-        if func_name == "discover":
-            return {"search_id": "s1", "results": [{"tool_id": "t1"}]}, False, True
-        if func_name == "inspect":
-            return {"results": [{"tool_id": "t1", "name": "T"}]}, False, True
-        return {"execution_id": "e1", "success": True}, False, True
+from adapter_conformance import AdapterConformance, FakeClient, run  # noqa: E402
 
 
-def test_get_qveris_tools_exposes_three_named_tools() -> None:
+class TestLangChainAdapterConformance(AdapterConformance):
+    """Shared invariants (see adapter_conformance.py) for the LangChain adapter."""
+
+    def make_tools(self, client: Any, session_id: Optional[str] = None) -> List[Any]:
+        return get_qveris_tools(client, session_id=session_id)
+
+    def make_tools_no_client(self) -> Any:
+        return get_qveris_tools()  # type: ignore[call-arg]
+
+    def invoke(self, tool: Any, args: Dict[str, Any]) -> str:
+        return run(tool.ainvoke(args))
+
+
+# --- LangChain-specific behavior ---------------------------------------------
+
+
+def test_tools_are_structured_tools_with_args_schemas() -> None:
+    from langchain_core.tools import StructuredTool
+
     tools = get_qveris_tools(FakeClient())
-    assert [t.name for t in tools] == ["qveris_discover", "qveris_inspect", "qveris_call"]
     for tool in tools:
-        assert tool.description
+        assert isinstance(tool, StructuredTool)
         assert tool.args_schema is not None
-
-
-@pytest.mark.asyncio
-async def test_discover_tool_routes_to_handle_tool_call_and_returns_json() -> None:
-    client = FakeClient()
-    discover = next(t for t in get_qveris_tools(client, session_id="sess-1") if t.name == "qveris_discover")
-
-    out = await discover.ainvoke({"query": "weather forecast API", "limit": 3})
-
-    assert client.calls == [
-        {"name": "discover", "args": {"query": "weather forecast API", "limit": 3}, "session_id": "sess-1"}
-    ]
-    parsed = json.loads(out)
-    assert parsed["search_id"] == "s1"
-
-
-@pytest.mark.asyncio
-async def test_call_tool_threads_ids_and_omits_absent_max_response_size() -> None:
-    client = FakeClient()
-    call = next(t for t in get_qveris_tools(client) if t.name == "qveris_call")
-
-    out = await call.ainvoke(
-        {"tool_id": "t1", "search_id": "s1", "params_to_tool": {"city": "London"}}
-    )
-
-    assert client.calls[0]["name"] == "call"
-    assert client.calls[0]["args"] == {
-        "tool_id": "t1",
-        "search_id": "s1",
-        "params_to_tool": {"city": "London"},
-    }
-    assert "max_response_size" not in client.calls[0]["args"]
-    assert json.loads(out)["execution_id"] == "e1"
-
-
-@pytest.mark.asyncio
-async def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
-    client = FakeClient()
-    inspect = next(t for t in get_qveris_tools(client) if t.name == "qveris_inspect")
-
-    await inspect.ainvoke({"tool_ids": ["t1", "t2"], "search_id": "s1"})
-
-    assert client.calls[0]["name"] == "inspect"
-    assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}
+        assert tool.coroutine is not None, "tools must be async-native"

--- a/packages/python-sdk/tests/test_openai_agents_integration.py
+++ b/packages/python-sdk/tests/test_openai_agents_integration.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -9,92 +9,43 @@ from agents.tool_context import ToolContext  # noqa: E402
 
 from qveris.integrations.openai_agents import get_qveris_tools  # noqa: E402
 
-
-class FakeClient:
-    def __init__(self) -> None:
-        self.calls: List[Dict[str, Any]] = []
-
-    async def handle_tool_call(
-        self, func_name: str, func_args: Dict[str, Any], session_id: Optional[str] = None
-    ) -> Tuple[Any, bool, bool]:
-        self.calls.append({"name": func_name, "args": func_args, "session_id": session_id})
-        if func_name == "discover":
-            return {"search_id": "s1", "results": [{"tool_id": "t1"}]}, False, True
-        if func_name == "inspect":
-            return {"results": [{"tool_id": "t1"}]}, False, True
-        return {"execution_id": "e1", "success": True}, False, True
+from adapter_conformance import AdapterConformance, FakeClient, run  # noqa: E402
 
 
-def _tool(tools, name):
-    return next(t for t in tools if t.name == name)
+class TestOpenAIAgentsAdapterConformance(AdapterConformance):
+    """Shared invariants (see adapter_conformance.py) for the OpenAI Agents adapter."""
+
+    def make_tools(self, client: Any, session_id: Optional[str] = None) -> List[Any]:
+        return get_qveris_tools(client, session_id=session_id)
+
+    def make_tools_no_client(self) -> Any:
+        return get_qveris_tools()  # type: ignore[call-arg]
+
+    def invoke(self, tool: Any, args: Dict[str, Any]) -> str:
+        ctx = ToolContext(
+            context=None,
+            tool_name=tool.name,
+            tool_call_id="call-1",
+            tool_arguments=json.dumps(args),
+        )
+        return run(tool.on_invoke_tool(ctx, json.dumps(args)))
 
 
-async def _invoke(tool, args: Dict[str, Any]) -> str:
-    ctx = ToolContext(
-        context=None,
-        tool_name=tool.name,
-        tool_call_id="call-1",
-        tool_arguments=json.dumps(args),
-    )
-    return await tool.on_invoke_tool(ctx, json.dumps(args))
+# --- OpenAI-Agents-specific behavior ------------------------------------------
 
 
-def test_get_qveris_tools_exposes_three_named_function_tools() -> None:
+def test_tool_schemas_expose_expected_properties() -> None:
     tools = get_qveris_tools(FakeClient())
-    assert [t.name for t in tools] == ["qveris_discover", "qveris_inspect", "qveris_call"]
     props = {t.name: set(t.params_json_schema.get("properties", {})) for t in tools}
     assert props["qveris_discover"] == {"query", "limit"}
     assert props["qveris_inspect"] == {"tool_ids", "search_id"}
     assert props["qveris_call"] == {"tool_id", "search_id", "params_to_tool", "max_response_size"}
 
 
-@pytest.mark.asyncio
-async def test_discover_tool_routes_to_handle_tool_call() -> None:
-    client = FakeClient()
-    discover = _tool(get_qveris_tools(client, session_id="sess-1"), "qveris_discover")
-
-    out = await _invoke(discover, {"query": "weather forecast API", "limit": 3})
-
-    assert client.calls == [
-        {"name": "discover", "args": {"query": "weather forecast API", "limit": 3}, "session_id": "sess-1"}
-    ]
-    assert json.loads(out)["search_id"] == "s1"
-
-
-@pytest.mark.asyncio
-async def test_call_tool_threads_ids_and_omits_absent_max_response_size() -> None:
-    client = FakeClient()
-    call = _tool(get_qveris_tools(client), "qveris_call")
-
-    out = await _invoke(call, {"tool_id": "t1", "search_id": "s1", "params_to_tool": {"city": "London"}})
-
-    assert client.calls[0]["name"] == "call"
-    assert client.calls[0]["args"] == {
-        "tool_id": "t1",
-        "search_id": "s1",
-        "params_to_tool": {"city": "London"},
-    }
-    assert "max_response_size" not in client.calls[0]["args"]
-    assert json.loads(out)["execution_id"] == "e1"
-
-
-@pytest.mark.asyncio
-async def test_call_tool_omits_absent_search_id() -> None:
-    client = FakeClient()
-    call = _tool(get_qveris_tools(client), "qveris_call")
-
-    await _invoke(call, {"tool_id": "t1", "params_to_tool": {}})
-
-    assert "search_id" not in client.calls[0]["args"]
-    assert client.calls[0]["args"] == {"tool_id": "t1", "params_to_tool": {}}
-
-
-@pytest.mark.asyncio
-async def test_inspect_tool_passes_tool_ids_and_search_id() -> None:
-    client = FakeClient()
-    inspect = _tool(get_qveris_tools(client), "qveris_inspect")
-
-    await _invoke(inspect, {"tool_ids": ["t1", "t2"], "search_id": "s1"})
-
-    assert client.calls[0]["name"] == "inspect"
-    assert client.calls[0]["args"] == {"tool_ids": ["t1", "t2"], "search_id": "s1"}
+def test_discover_is_strict_but_dict_taking_tools_are_not() -> None:
+    # strict JSON schema can't represent free-form dicts / optionals, so
+    # inspect/call must be non-strict while discover stays strict.
+    tools = {t.name: t for t in get_qveris_tools(FakeClient())}
+    assert tools["qveris_discover"].strict_json_schema is True
+    assert tools["qveris_inspect"].strict_json_schema is False
+    assert tools["qveris_call"].strict_json_schema is False


### PR DESCRIPTION
Closes #157. Adopts the `langchain-tests` standard-tests pattern for our four framework adapters, so semantic drift between them fails tests instead of shipping.

## Structure

- **Python** — `tests/adapter_conformance.py`: an `AdapterConformance` base class encoding the cross-adapter invariants (three named tools in order · client required · `session_id` threading · `search_id` threading · optional-arg omission from the request · JSON-string returns · `max_response_size` forwarding). Each adapter's test module subclasses it with two hooks (`make_tools`, `invoke` — bridging sync/async per framework) and keeps only adapter-specific tests (OpenAI strict-schema split, CrewAI bridge-loop semantics, LangChain StructuredTool shape).
- **JS** — `src/integrations/adapter-conformance.ts`: the same invariants as a reusable vitest `describe`; the Vercel adapter's tests consume it. Build-excluded (test-only, imports vitest) — verified `dist/` stays clean.

## It caught a real bug on its first run

The LangChain adapter still had `search_id` **required** in `qveris_call` — the optional-`search_id` consistency fix from the adapter reviews (#133 / #135 / #143) never reached it. Fixed here (optional + omitted when absent), with a python-sdk CHANGELOG entry. Exactly the drift class this suite exists to prevent.

## Validation

langchain 8 · openai-agents 9 · crewai 10 (run with crewai installed) · js-sdk 36 · python full suite 83 passed · js-sdk typecheck/build clean with no helper leakage into dist.