### PR TITLE
docs: sync API docs from website

### DIFF
--- a/docs/openapi/qveris-public-api.openapi.json
+++ b/docs/openapi/qveris-public-api.openapi.json
@@ -132,7 +132,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3182
+          "line": 3470
         },
         "x-qveris-response-model": "APIResponse[SettlementHistoryResponse]"
       }
@@ -170,7 +170,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 1162
+          "line": 1245
         },
         "x-qveris-response-model": "APIResponse[dict]"
       }
@@ -469,7 +469,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3280
+          "line": 3568
         },
         "x-qveris-response-model": "APIResponse[CreditsLedgerResponse]"
       }
@@ -555,7 +555,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3584
+          "line": 3872
         },
         "x-qveris-response-model": "APIResponse[CreditsLedgerReadinessResponse]"
       }
@@ -651,7 +651,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3456
+          "line": 3744
         }
       }
     },
@@ -709,7 +709,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3532
+          "line": 3820
         },
         "x-qveris-response-model": "APIResponse[CreditsLedgerItem]"
       }
@@ -831,7 +831,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 2951
+          "line": 3239
         },
         "x-qveris-response-model": "APIResponse[UsageCreditsSpentResponse]"
       }
@@ -1299,7 +1299,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 2637
+          "line": 2925
         },
         "x-qveris-response-model": "APIResponse[UsageEventsResponse]"
       }
@@ -1574,7 +1574,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3021
+          "line": 3309
         }
       }
     },
@@ -1889,7 +1889,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 2840
+          "line": 3128
         },
         "x-qveris-response-model": "APIResponse[UsageEventSummaryResponse]"
       }
@@ -1949,7 +1949,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3140
+          "line": 3428
         },
         "x-qveris-response-model": "APIResponse[UsageEventItem]"
       }
@@ -1987,7 +1987,7 @@
         ],
         "x-qveris-source": {
           "file": "backend/routers/auth.py",
-          "line": 3717
+          "line": 4005
         },
         "x-qveris-response-model": "APIResponse[TokenVerificationResponse]"
       }


### PR DESCRIPTION
Mirrors website-owned REST API, Cookbook, and OpenAPI docs after qveris-website release/online OpenAPI documents changed. Source run: https://github.com/WonderfulValley/qveris-website/actions/runs/29092093699.