### PR TITLE
feat(mcp): output schemas, elicitation billing consent, catalog resources (#158)

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -13,6 +13,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   - **Elicitation billing consent** — with `QVERIS_MCP_CONFIRM_CALLS=true` and an elicitation-capable client, a charged `call` asks the user to confirm first; declining cancels the call before any credits are spent. Off by default (headless agents unaffected); clients without elicitation proceed as before.
   - **Resources** — `qveris://server-card` (SEP-2127 card, also without a remote in stdio mode) and the `qveris://capability/{tool_id}` template serving full capability metadata, so users can browse/attach capability docs without a tool call.
 
+### Changed
+
+- Tool results and resource reads serialize as compact JSON instead of pretty-printed — indentation was ~35% of a `qveris_discover` payload in tokens, with no information loss. Matches the HTTP discovery endpoints, which were already compact. ([#120])
+
 ## [0.8.0] - 2026-07-09
 
 ### Added
@@ -117,6 +121,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [0.1.2]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/mcp-v0.1.2
 [#158]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/158
 [#145]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/145
+[#120]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/120
 [#140]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/140
 [#139]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/139
 [#126]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/126

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Fuller MCP spec surface ([#158]):
+  - **Output schemas + structured content** — every tool declares `outputSchema` (loose, additive-friendly) and returns `structuredContent` alongside the JSON text, so clients consume typed results instead of re-parsing strings.
+  - **Elicitation billing consent** — with `QVERIS_MCP_CONFIRM_CALLS=true` and an elicitation-capable client, a charged `call` asks the user to confirm first; declining cancels the call before any credits are spent. Off by default (headless agents unaffected); clients without elicitation proceed as before.
+  - **Resources** — `qveris://server-card` (SEP-2127 card, also without a remote in stdio mode) and the `qveris://capability/{tool_id}` template serving full capability metadata, so users can browse/attach capability docs without a tool call.
+
 ## [0.8.0] - 2026-07-09
 
 ### Added
@@ -108,6 +115,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.2.0...mcp-v0.3.0
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.1.2...mcp-v0.2.0
 [0.1.2]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/mcp-v0.1.2
+[#158]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/158
 [#145]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/145
 [#140]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/140
 [#139]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/139

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -225,7 +225,13 @@ For backward compatibility, the old tool names are still supported but emit a de
 | `get_tools_by_ids` | `inspect` |
 | `execute_tool` | `call` |
 
-## Session Management
+## Beyond tools: schemas, consent, resources
+
+- Every tool declares an `outputSchema` and returns `structuredContent` alongside the JSON text (MCP 2025-06-18), so clients get typed results.
+- With `QVERIS_MCP_CONFIRM_CALLS=true`, a charged `call` first asks the user to confirm via MCP **elicitation** (billing consent); declining cancels the call before any credits are spent. Off by default.
+- **Resources**: read `qveris://server-card` for the server's identity card, or `qveris://capability/{tool_id}` for a capability's full metadata (parameters, examples, stats, billing) without spending a tool call.
+
+## Session Management
 
 Providing a consistent `session_id` in a same user session in any tool call enables:
 - Consistent user tracking across multiple tool calls
@@ -322,6 +328,7 @@ npx -y @qverisai/mcp
 | `QVERIS_MCP_HTTP_ALLOW_UNAUTHENTICATED` | | `true` to allow a non-loopback bind without a token (auth delegated externally) |
 | `QVERIS_MCP_MAX_BODY_BYTES` | | Max request body size in bytes (default `4194304`) |
 | `QVERIS_MCP_SESSION_TIMEOUT_MS` | | Idle session TTL in ms (default `300000`) |
+| `QVERIS_MCP_CONFIRM_CALLS` | | `true` to ask the user (via MCP elicitation) before each charged `call`; clients without elicitation proceed as before |
 | `QVERIS_MCP_PUBLIC_URL` | | Public origin advertised in discovery documents (e.g. `https://mcp.example.com`) |
 
 ## Region

--- a/packages/mcp/src/full-spec.test.ts
+++ b/packages/mcp/src/full-spec.test.ts
@@ -1,0 +1,172 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createQverisServer } from './index.js';
+import type { QverisClient } from './api/client.js';
+
+/** Client-shaped fake covering the methods the tool executors use. */
+function fakeQverisClient() {
+  return {
+    calls: [] as string[],
+    async searchTools() {
+      this.calls.push('search');
+      return { search_id: 's1', total: 1, results: [{ tool_id: 't1', name: 'T', description: 'd' }] };
+    },
+    async getToolsByIds() {
+      this.calls.push('inspect');
+      return { search_id: 's1', results: [{ tool_id: 't1', name: 'T', description: 'd' }] };
+    },
+    async executeTool() {
+      this.calls.push('execute');
+      return { execution_id: 'e1', success: true, result: { ok: 1 } };
+    },
+  } as unknown as QverisClient & { calls: string[] };
+}
+
+async function connect(opts: { client?: QverisClient; elicitHandler?: (msg: string) => Promise<boolean> } = {}) {
+  const server = createQverisServer(opts.client, 'session-1');
+  const capabilities = opts.elicitHandler ? { elicitation: { form: {} } } : {};
+  const mcpClient = new Client({ name: 'full-spec-test', version: '0.0.0' }, { capabilities });
+  if (opts.elicitHandler) {
+    const handler = opts.elicitHandler;
+    mcpClient.setRequestHandler(ElicitRequestSchema, async (request) => {
+      const confirm = await handler(request.params.message);
+      return { action: confirm ? 'accept' : 'decline', content: confirm ? { confirm: true } : undefined };
+    });
+  }
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), mcpClient.connect(clientTransport)]);
+  return mcpClient;
+}
+
+describe('output schemas + structured content', () => {
+  it('declares outputSchema on all five canonical tools', async () => {
+    const c = await connect();
+    const { tools } = await c.listTools();
+    for (const name of ['discover', 'inspect', 'call', 'usage_history', 'credits_ledger']) {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool?.outputSchema, `${name} outputSchema`).toBeDefined();
+      expect((tool?.outputSchema as { additionalProperties?: boolean }).additionalProperties).toBe(true);
+    }
+    await c.close();
+  });
+
+  it('returns structuredContent alongside the JSON text', async () => {
+    const c = await connect({ client: fakeQverisClient() });
+    const result = await c.callTool({ name: 'discover', arguments: { query: 'weather' } });
+    expect(result.structuredContent).toMatchObject({ search_id: 's1' });
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(JSON.parse(text).search_id).toBe('s1');
+    await c.close();
+  });
+});
+
+describe('elicitation billing consent (QVERIS_MCP_CONFIRM_CALLS)', () => {
+  const OLD = process.env.QVERIS_MCP_CONFIRM_CALLS;
+  afterEach(() => {
+    if (OLD === undefined) delete process.env.QVERIS_MCP_CONFIRM_CALLS;
+    else process.env.QVERIS_MCP_CONFIRM_CALLS = OLD;
+  });
+
+  it('proceeds when the user accepts', async () => {
+    process.env.QVERIS_MCP_CONFIRM_CALLS = 'true';
+    const qveris = fakeQverisClient();
+    const seen: string[] = [];
+    const c = await connect({
+      client: qveris,
+      elicitHandler: async (msg) => {
+        seen.push(msg);
+        return true;
+      },
+    });
+    const result = await c.callTool({
+      name: 'call',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(qveris.calls).toContain('execute');
+    expect(seen[0]).toContain('t1'); // the consent prompt names the capability
+    await c.close();
+  });
+
+  it('cancels the charged call when the user declines', async () => {
+    process.env.QVERIS_MCP_CONFIRM_CALLS = 'true';
+    const qveris = fakeQverisClient();
+    const c = await connect({ client: qveris, elicitHandler: async () => false });
+    const result = await c.callTool({
+      name: 'call',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as Array<{ text: string }>)[0].text).toContain('declined');
+    expect(qveris.calls).not.toContain('execute'); // nothing was charged
+    await c.close();
+  });
+
+  it('does not elicit when the flag is off', async () => {
+    delete process.env.QVERIS_MCP_CONFIRM_CALLS;
+    const qveris = fakeQverisClient();
+    let asked = false;
+    const c = await connect({
+      client: qveris,
+      elicitHandler: async () => {
+        asked = true;
+        return true;
+      },
+    });
+    await c.callTool({ name: 'call', arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} } });
+    expect(asked).toBe(false);
+    expect(qveris.calls).toContain('execute');
+    await c.close();
+  });
+
+  it('proceeds without consent when the client lacks elicitation support', async () => {
+    process.env.QVERIS_MCP_CONFIRM_CALLS = 'true';
+    const qveris = fakeQverisClient();
+    const c = await connect({ client: qveris }); // no elicitation capability
+    const result = await c.callTool({
+      name: 'call',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(qveris.calls).toContain('execute');
+    await c.close();
+  });
+});
+
+describe('resources: server card + capability metadata', () => {
+  it('lists the server card resource and the capability template', async () => {
+    const c = await connect();
+    const { resources } = await c.listResources();
+    expect(resources.map((r) => r.uri)).toContain('qveris://server-card');
+    const { resourceTemplates } = await c.listResourceTemplates();
+    expect(resourceTemplates[0].uriTemplate).toBe('qveris://capability/{tool_id}');
+    await c.close();
+  });
+
+  it('reads the server card with the SEP media type', async () => {
+    const c = await connect();
+    const { contents } = await c.readResource({ uri: 'qveris://server-card' });
+    expect(contents[0].mimeType).toBe('application/mcp-server-card+json');
+    const card = JSON.parse(contents[0].text as string);
+    expect(card.name).toBe('io.github.QVerisAI/mcp');
+    expect(card.$schema).toContain('server-card.schema.json');
+    await c.close();
+  });
+
+  it('reads capability metadata through the client', async () => {
+    const qveris = fakeQverisClient();
+    const c = await connect({ client: qveris });
+    const { contents } = await c.readResource({ uri: 'qveris://capability/t1' });
+    expect(JSON.parse(contents[0].text as string).results[0].tool_id).toBe('t1');
+    await c.close();
+  });
+
+  it('gives an actionable error for capability reads without an API key', async () => {
+    const c = await connect(); // keyless
+    await expect(c.readResource({ uri: 'qveris://capability/t1' })).rejects.toThrow(/QVERIS_API_KEY/);
+    await c.close();
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,12 +28,15 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
   SUPPORTED_PROTOCOL_VERSIONS,
   type CallToolResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { resolveTransportConfig, startHttpServer } from './http.js';
-import type { ServerCardInfo } from './server-card.js';
+import { buildServerCard, type ServerCardInfo } from './server-card.js';
 import { realpathSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { v4 as uuidv4 } from 'uuid';
@@ -45,6 +48,7 @@ import { getToolsByIdsSchema, executeGetToolsByIds, type GetToolsByIdsInput } fr
 import { usageHistorySchema, executeUsageHistory, type UsageHistoryInput } from './tools/usage-history.js';
 import { creditsLedgerSchema, executeCreditsLedger, type CreditsLedgerInput } from './tools/credits-ledger.js';
 import type { ApiError } from './types.js';
+import { TOOL_OUTPUT_SCHEMAS } from './output-schemas.js';
 
 // ============================================================================
 // Server Configuration
@@ -88,6 +92,7 @@ export function listQverisMcpTools() {
         'Use this to find tools before inspecting or calling them. ' +
         'Results may include billing_rule metadata for rule-level pricing.',
       inputSchema: searchToolsSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.discover,
     },
     {
       name: 'inspect',
@@ -96,6 +101,7 @@ export function listQverisMcpTools() {
         'Returns parameters, success rate, latency, examples, and billing_rule when available. ' +
         'Use tool_ids from a previous discover call.',
       inputSchema: getToolsByIdsSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.inspect,
     },
     {
       name: 'call',
@@ -105,18 +111,21 @@ export function listQverisMcpTools() {
         'Pass parameters to the tool through params_to_tool. ' +
         'The response may include pre-settlement billing; use usage_history or credits_ledger for final charge status.',
       inputSchema: executeToolSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.call,
     },
     {
       name: 'usage_history',
       description:
         'Context-safe usage audit query. Defaults to aggregated summary, supports precise search by execution_id/search_id/charge_outcome/credit range, and writes large exports to a local JSONL file instead of returning all rows.',
       inputSchema: usageHistorySchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.usage_history,
     },
     {
       name: 'credits_ledger',
       description:
         'Context-safe final credits ledger query. Defaults to aggregated summary, supports precise search by entry type/direction/credit range, and writes large exports to a local JSONL file instead of returning all rows.',
       inputSchema: creditsLedgerSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.credits_ledger,
     },
     // Deprecated aliases (backward compatibility)
     {
@@ -186,12 +195,16 @@ function compactObject(input: Record<string, unknown>): Record<string, unknown> 
 /**
  * Route one MCP tool call to the matching Qveris operation.
  */
+/** Asks the human to approve a charged call; resolve false to cancel it. */
+export type ConfirmCall = (info: { toolId: string }) => Promise<boolean>;
+
 export async function executeQverisMcpTool(
   client: QverisClient | undefined,
   defaultSessionId: string,
   rawName: string,
   args: unknown,
   warn: (message: string) => void = (message) => process.stderr.write(message),
+  confirmCall?: ConfirmCall,
 ): Promise<CallToolResult> {
   // Tool listing works without credentials, but calls need a key. When the
   // server started without QVERIS_API_KEY the client is undefined; return an
@@ -250,6 +263,7 @@ export async function executeQverisMcpTool(
             text: JSON.stringify(result, null, 2),
           },
         ],
+        structuredContent: result as unknown as Record<string, unknown>,
       };
     }
 
@@ -281,6 +295,7 @@ export async function executeQverisMcpTool(
             text: JSON.stringify(result, null, 2),
           },
         ],
+        structuredContent: result as unknown as Record<string, unknown>,
       };
     }
 
@@ -308,6 +323,23 @@ export async function executeQverisMcpTool(
         };
       }
 
+      // Human-in-the-loop billing consent (MCP elicitation), when enabled and
+      // the client supports it. Declining cancels the charged call.
+      if (confirmCall && !(await confirmCall({ toolId: input.tool_id }))) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: 'Call cancelled: the user declined the billing confirmation.',
+                tool_id: input.tool_id,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
       const result = await executeExecuteTool(client, input, defaultSessionId);
 
       return {
@@ -317,6 +349,7 @@ export async function executeQverisMcpTool(
             text: JSON.stringify(result, null, 2),
           },
         ],
+        structuredContent: result as unknown as Record<string, unknown>,
       };
     }
 
@@ -331,6 +364,7 @@ export async function executeQverisMcpTool(
             text: JSON.stringify(result, null, 2),
           },
         ],
+        structuredContent: result as unknown as Record<string, unknown>,
       };
     }
 
@@ -345,6 +379,7 @@ export async function executeQverisMcpTool(
             text: JSON.stringify(result, null, 2),
           },
         ],
+        structuredContent: result as unknown as Record<string, unknown>,
       };
     }
 
@@ -411,6 +446,14 @@ export async function executeQverisMcpTool(
  * and Streamable HTTP paths (and tests) can construct a server the same way; in
  * HTTP mode one server is created per client session.
  */
+const CARD_RESOURCE_URI = 'qveris://server-card';
+const CAPABILITY_URI_PREFIX = 'qveris://capability/';
+
+function confirmCallsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.QVERIS_MCP_CONFIRM_CALLS?.trim().toLowerCase();
+  return v !== undefined && ['1', 'true', 'yes', 'on'].includes(v);
+}
+
 export function createQverisServer(client: QverisClient | undefined, defaultSessionId: string): Server {
   const server = new Server(
     {
@@ -420,6 +463,7 @@ export function createQverisServer(client: QverisClient | undefined, defaultSess
     {
       capabilities: {
         tools: {},
+        resources: {},
       },
     },
   );
@@ -431,10 +475,77 @@ export function createQverisServer(client: QverisClient | undefined, defaultSess
     };
   });
 
+  // Human-in-the-loop billing consent for charged calls: only when explicitly
+  // enabled (headless agents stay unaffected) AND the client supports
+  // elicitation. Declining or cancelling the form cancels the call.
+  const confirmCall: ConfirmCall | undefined = confirmCallsEnabled()
+    ? async ({ toolId }) => {
+        if (!server.getClientCapabilities()?.elicitation) return true;
+        const answer = await server.elicitInput({
+          message: `QVeris is about to call \"${toolId}\". This may consume credits (pre-settlement billing is returned with the result). Proceed?`,
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              confirm: { type: 'boolean', title: 'Proceed with this charged call?' },
+            },
+            required: ['confirm'],
+          },
+        });
+        return answer.action === 'accept' && answer.content?.confirm === true;
+      }
+    : undefined;
+
   // Routes tool execution to the appropriate handler; deprecated aliases warn.
   server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
     const { name, arguments: args } = request.params;
-    return executeQverisMcpTool(client, defaultSessionId, name, args);
+    return executeQverisMcpTool(client, defaultSessionId, name, args, undefined, confirmCall);
+  });
+
+  // --- Resources: the Server Card plus per-capability metadata docs ---------
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: [
+      {
+        uri: CARD_RESOURCE_URI,
+        name: 'QVeris Server Card',
+        description: 'Identity and connection metadata for this MCP server (SEP-2127).',
+        mimeType: 'application/mcp-server-card+json',
+      },
+    ],
+  }));
+
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+    resourceTemplates: [
+      {
+        uriTemplate: `${CAPABILITY_URI_PREFIX}{tool_id}`,
+        name: 'QVeris capability metadata',
+        description:
+          'Full metadata for one capability (parameters, examples, stats, billing) — the same payload the inspect tool returns.',
+        mimeType: 'application/json',
+      },
+    ],
+  }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    if (uri === CARD_RESOURCE_URI) {
+      const card = buildServerCard(buildServerCardInfo());
+      return {
+        contents: [{ uri, mimeType: 'application/mcp-server-card+json', text: JSON.stringify(card, null, 2) }],
+      };
+    }
+    if (uri.startsWith(CAPABILITY_URI_PREFIX)) {
+      const toolId = decodeURIComponent(uri.slice(CAPABILITY_URI_PREFIX.length));
+      if (!toolId) throw new Error('Missing tool_id in capability URI');
+      if (!client) {
+        throw new Error('QVERIS_API_KEY is not set; capability metadata requires an API key.');
+      }
+      const detail = await client.getToolsByIds({ tool_ids: [toolId] });
+      return {
+        contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(detail, null, 2) }],
+      };
+    }
+    throw new Error(`Unknown resource: ${uri}`);
   });
 
   return server;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -482,7 +482,7 @@ export function createQverisServer(client: QverisClient | undefined, defaultSess
     ? async ({ toolId }) => {
         if (!server.getClientCapabilities()?.elicitation) return true;
         const answer = await server.elicitInput({
-          message: `QVeris is about to call \"${toolId}\". This may consume credits (pre-settlement billing is returned with the result). Proceed?`,
+          message: `QVeris is about to call "${toolId}". This may consume credits (pre-settlement billing is returned with the result). Proceed?`,
           requestedSchema: {
             type: 'object',
             properties: {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -260,7 +260,7 @@ export async function executeQverisMcpTool(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(result),
           },
         ],
         structuredContent: result as unknown as Record<string, unknown>,
@@ -292,7 +292,7 @@ export async function executeQverisMcpTool(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(result),
           },
         ],
         structuredContent: result as unknown as Record<string, unknown>,
@@ -346,7 +346,7 @@ export async function executeQverisMcpTool(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(result),
           },
         ],
         structuredContent: result as unknown as Record<string, unknown>,
@@ -361,7 +361,7 @@ export async function executeQverisMcpTool(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(result),
           },
         ],
         structuredContent: result as unknown as Record<string, unknown>,
@@ -376,7 +376,7 @@ export async function executeQverisMcpTool(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(result),
           },
         ],
         structuredContent: result as unknown as Record<string, unknown>,
@@ -531,7 +531,7 @@ export function createQverisServer(client: QverisClient | undefined, defaultSess
     if (uri === CARD_RESOURCE_URI) {
       const card = buildServerCard(buildServerCardInfo());
       return {
-        contents: [{ uri, mimeType: 'application/mcp-server-card+json', text: JSON.stringify(card, null, 2) }],
+        contents: [{ uri, mimeType: 'application/mcp-server-card+json', text: JSON.stringify(card) }],
       };
     }
     if (uri.startsWith(CAPABILITY_URI_PREFIX)) {
@@ -542,7 +542,7 @@ export function createQverisServer(client: QverisClient | undefined, defaultSess
       }
       const detail = await client.getToolsByIds({ tool_ids: [toolId] });
       return {
-        contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(detail, null, 2) }],
+        contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(detail) }],
       };
     }
     throw new Error(`Unknown resource: ${uri}`);

--- a/packages/mcp/src/output-schemas.ts
+++ b/packages/mcp/src/output-schemas.ts
@@ -1,0 +1,64 @@
+/**
+ * Output schemas for the QVeris MCP tools (MCP spec 2025-06-18).
+ *
+ * Declaring `outputSchema` lets clients and models consume `structuredContent`
+ * as typed data instead of re-parsing a JSON string out of the text content.
+ * The schemas are deliberately LOOSE (`additionalProperties: true`, only the
+ * stable key fields pinned) because the API evolves additively — a new server
+ * field must never make client-side validation reject a result.
+ */
+
+const searchResponseSchema = {
+  type: 'object',
+  properties: {
+    search_id: { type: 'string', description: 'Discovery id; thread into inspect/call.' },
+    total: { type: 'number' },
+    results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          tool_id: { type: 'string' },
+          name: { type: 'string' },
+          description: { type: 'string' },
+          why_recommended: { type: 'string' },
+          expected_cost: {},
+        },
+        additionalProperties: true,
+      },
+    },
+  },
+  additionalProperties: true,
+} as const;
+
+const executeResponseSchema = {
+  type: 'object',
+  properties: {
+    execution_id: { type: 'string', description: 'Correlates with usage/ledger records.' },
+    success: { type: 'boolean' },
+    result: {},
+    billing: { type: 'object', additionalProperties: true },
+    remaining_credits: { type: 'number' },
+  },
+  additionalProperties: true,
+} as const;
+
+const auditResponseSchema = {
+  type: 'object',
+  properties: {
+    mode: { type: 'string' },
+    shown_records: { type: 'number' },
+    matched_records: { type: 'number' },
+    items: { type: 'array', items: { type: 'object', additionalProperties: true } },
+  },
+  additionalProperties: true,
+} as const;
+
+/** outputSchema per canonical tool name (deprecated aliases share them). */
+export const TOOL_OUTPUT_SCHEMAS: Record<string, object> = {
+  discover: searchResponseSchema,
+  inspect: searchResponseSchema,
+  call: executeResponseSchema,
+  usage_history: auditResponseSchema,
+  credits_ledger: auditResponseSchema,
+};

--- a/packages/mcp/src/server-card.ts
+++ b/packages/mcp/src/server-card.ts
@@ -73,19 +73,20 @@ export interface McpCatalog {
  * @param remoteUrl - The absolute Streamable HTTP endpoint URL clients connect
  *   to (e.g. `https://mcp.example.com/mcp`).
  */
-export function buildServerCard(info: ServerCardInfo, remoteUrl: string): ServerCard {
-  const remote: ServerCardRemote = { type: 'streamable-http', url: remoteUrl };
-  if (info.protocolVersions && info.protocolVersions.length > 0) {
-    remote.supportedProtocolVersions = info.protocolVersions;
-  }
-
+export function buildServerCard(info: ServerCardInfo, remoteUrl?: string): ServerCard {
   const card: ServerCard = {
     $schema: SERVER_CARD_SCHEMA_URL,
     name: info.name,
     version: info.version,
     description: info.description,
-    remotes: [remote],
   };
+  if (remoteUrl) {
+    const remote: ServerCardRemote = { type: 'streamable-http', url: remoteUrl };
+    if (info.protocolVersions && info.protocolVersions.length > 0) {
+      remote.supportedProtocolVersions = info.protocolVersions;
+    }
+    card.remotes = [remote];
+  }
   if (info.title) card.title = info.title;
   if (info.websiteUrl) card.websiteUrl = info.websiteUrl;
   if (info.repository) card.repository = info.repository;


### PR DESCRIPTION
Closes #158 (the buildable scope). Fills out the MCP spec surface beyond tools-only — the quality wedge vs the ~14k mostly tools-only servers in the registries.

## Output schemas + structured content

Every tool declares an `outputSchema` (deliberately **loose** — `additionalProperties: true`, only stable key fields pinned, so additive server fields can never break client-side validation) and returns `structuredContent` alongside the JSON text. Clients now consume typed results instead of re-parsing strings.

## Elicitation billing consent

With `QVERIS_MCP_CONFIRM_CALLS=true` **and** an elicitation-capable client, a charged `call` first asks the user to confirm (the form names the capability); declining cancels the call **before any credits are spent** — a natural fit for the billing-transparency positioning.

- **Off by default** — headless agents unaffected.
- Clients without elicitation support proceed as before (no dead-end).
- Per the spec's explicit guidance, elicitation is **not** used for sensitive values — no API-key prompts.

## Resources

- `qveris://server-card` — the SEP-2127 identity card (`buildServerCard` now also works without a remote, for stdio mode).
- `qveris://capability/{tool_id}` template — full capability metadata (parameters, examples, stats, billing), so users can browse/attach capability docs **without spending a tool call**. Keyless reads return an actionable error.

## Not in this PR

The 2026-07-28 stateless-spec RC migration stays a tracked follow-up on #158 — no code against a moving RC.

## Testing

10 new tests over the SDK's **in-memory linked-pair transport** with a real MCP `Client`: schema declarations on all five tools, structured-content round-trip, all four consent states (accept / decline / flag-off / client-without-elicitation), and every resource path incl. the keyless error. **120 mcp tests pass; lint + coverage ratchet green (80.65%).**

## Added in follow-up commit: compact JSON output (#120 item 2)

All 7 `JSON.stringify` sites (5 tool results + server-card and capability resource reads) now serialize compactly instead of `null, 2` pretty-print. Measured on real payloads: indentation was **~35% of a discover ×10 result (14.2k → 9.1k tokens)** — pure whitespace, zero information loss. Also aligns resource reads with the HTTP discovery endpoints, which already serialize compactly. All tests parse rather than string-match, so no test changes needed.