### PR TITLE
docs(examples): runnable examples for js-sdk, MCP, CLI + runnable recipes (#159)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -24,6 +24,11 @@ on:
       - "packages/mcp/package-lock.json"
       - "packages/mcp/tsconfig.json"
       - "packages/openclaw-qveris-plugin/**"
+      - "packages/js-sdk/examples/**"
+      - "packages/js-sdk/tsconfig.examples.json"
+      - "packages/mcp/examples/**"
+      - "packages/mcp/tsconfig.examples.json"
+      - "packages/cli/examples/**"
       - ".prettierrc.json"
       - ".prettierignore"
       - "packages/*/eslint.config.mjs"
@@ -48,6 +53,11 @@ on:
       - "packages/mcp/package-lock.json"
       - "packages/mcp/tsconfig.json"
       - "packages/openclaw-qveris-plugin/**"
+      - "packages/js-sdk/examples/**"
+      - "packages/js-sdk/tsconfig.examples.json"
+      - "packages/mcp/examples/**"
+      - "packages/mcp/tsconfig.examples.json"
+      - "packages/cli/examples/**"
       - ".prettierrc.json"
       - ".prettierignore"
       - "packages/*/eslint.config.mjs"
@@ -111,6 +121,8 @@ jobs:
         run: npm ci
       - name: Type check
         run: npm run typecheck
+      - name: Type check examples
+        run: npm run typecheck:examples
       - name: JS SDK client tests
         run: npm test
 
@@ -134,6 +146,8 @@ jobs:
         run: npm ci
       - name: Type check
         run: npm run typecheck
+      - name: Type check examples
+        run: npm run typecheck:examples
       - name: MCP server tests
         run: npm test
 
@@ -217,3 +231,14 @@ jobs:
       - name: python-sdk coverage
         working-directory: packages/python-sdk
         run: uv run --extra dev pytest -q --cov=qveris --cov-fail-under=82
+
+  # Shellcheck the CLI scripting examples. The TypeScript examples are type
+  # checked in the js-sdk-tests / mcp-tests jobs; the Python examples are linted
+  # by the ruff step above; the recipe run.sh scripts are checked in
+  # ecosystem-validate.yml (which triggers on recipes/**).
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Shellcheck CLI example scripts
+        run: shellcheck packages/cli/examples/*.sh

--- a/.github/workflows/ecosystem-validate.yml
+++ b/.github/workflows/ecosystem-validate.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Test manifest validator
         run: node scripts/test-ecosystem-validator.mjs
+
+      - name: Shellcheck runnable recipe scripts
+        run: shellcheck recipes/*/run.sh

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ This repository (`QVerisAI/qveris-agent-toolkit`) is the primary monorepo for QV
 
 ### Recipes and ecosystem manifests
 
-Use [`recipes/`](recipes) for copy-paste workflow templates across finance research, risk/compliance, crypto monitoring, data analysis, and developer automation.
+Use [`recipes/`](recipes) for copy-paste workflow templates across finance research, risk/compliance, crypto monitoring, data analysis, and developer automation. The flagship recipes ship a runnable `run.sh`, and each package has runnable examples: [js-sdk](packages/js-sdk/examples), [MCP](packages/mcp/examples), [CLI](packages/cli/examples), and [Python SDK](packages/python-sdk/examples).
 
 Use [`ecosystem/`](ecosystem) for the versioned QVeris manifest schema, marketplace-ready listing fields, permission declarations, contribution guide, and compatibility matrix.
 

--- a/packages/cli/examples/README.md
+++ b/packages/cli/examples/README.md
@@ -1,0 +1,25 @@
+# QVeris CLI examples
+
+Scripting patterns for the `qveris` CLI. Each script is safe to run without an
+API key — it prints how to set one and exits — and the `call` step is gated
+behind `RUN_QVERIS_CALLS=1` so no example spends credits by accident.
+
+They assume `qveris` is on your `PATH` (`npm i -g @qverisai/cli`) and that `jq`
+is installed. Override the binary with `QVERIS_BIN`, e.g.
+`QVERIS_BIN="npx -y @qverisai/cli"`.
+
+```bash
+export QVERIS_API_KEY="sk-..."     # https://qveris.ai/account?page=api-keys
+./discover-inspect-call.sh
+MAX_COST=5 ./budget-guard.sh
+```
+
+## Scripts
+
+| File | Shows |
+|------|-------|
+| [`discover-inspect-call.sh`](discover-inspect-call.sh) | The full discover → inspect → call → audit loop with `--json` + `jq` |
+| [`budget-guard.sh`](budget-guard.sh) | Reading `expected_cost` and credit balance to refuse calls over budget |
+
+For copy-paste workflow templates, see the [recipes](../../../recipes/), whose
+flagship entries ship a runnable `run.sh`.

--- a/packages/cli/examples/budget-guard.sh
+++ b/packages/cli/examples/budget-guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Cost-aware calling: only execute a capability when it fits the budget.
+#
+# Reads the pre-call `expected_cost` and the account's remaining credits, and
+# refuses to call when the estimate exceeds MAX_COST or the balance. This is the
+# QVeris differentiator in practice — decide *before* spending.
+#
+#   QVERIS_API_KEY=sk-... MAX_COST=5 ./budget-guard.sh
+#   QVERIS_API_KEY=sk-... MAX_COST=5 RUN_QVERIS_CALLS=1 ./budget-guard.sh
+#
+set -euo pipefail
+
+# Support both an installed `qveris` and an override like `npx -y @qverisai/cli`.
+IFS=" " read -r -a qv <<<"${QVERIS_BIN:-qveris}"
+query="${1:-public company stock quote and market data API}"
+max_cost="${MAX_COST:-5}"
+
+if [[ -z "${QVERIS_API_KEY:-}" ]]; then
+  echo "Set QVERIS_API_KEY to run this example. https://qveris.ai/account?page=api-keys"
+  exit 0
+fi
+
+discovered="$("${qv[@]}" discover "$query" --limit 5 --json)"
+search_id="$(jq -r '.search_id' <<<"$discovered")"
+top="$(jq -c '.results[0] // empty' <<<"$discovered")"
+
+if [[ -z "$top" ]]; then
+  echo "No capabilities matched: $query"
+  exit 0
+fi
+
+tool_id="$(jq -r '.tool_id' <<<"$top")"
+# expected_cost may be a string or number; coerce to a number, default 0.
+expected_cost="$(jq -r '(.expected_cost // 0) | tonumber? // 0' <<<"$top")"
+remaining="$("${qv[@]}" credits --json | jq -r '.remaining_credits // 0')"
+
+echo "candidate:      $tool_id"
+echo "expected_cost:  $expected_cost credits (cap $max_cost)"
+echo "remaining:      $remaining credits"
+
+# Numeric comparisons via jq so float estimates compare correctly.
+if jq -e -n --argjson c "$expected_cost" --argjson m "$max_cost" '$c > $m' >/dev/null; then
+  echo "Skip: estimate exceeds MAX_COST."
+  exit 0
+fi
+if jq -e -n --argjson c "$expected_cost" --argjson r "$remaining" '$c > $r' >/dev/null; then
+  echo "Skip: not enough credits."
+  exit 0
+fi
+
+if [[ "${RUN_QVERIS_CALLS:-}" != "1" ]]; then
+  echo "Within budget. Set RUN_QVERIS_CALLS=1 to execute."
+  exit 0
+fi
+
+"${qv[@]}" call "$tool_id" --discovery-id "$search_id" --params '{"symbol":"AAPL"}' --json \
+  | jq '{execution_id, success, billing: .billing.summary}'

--- a/packages/cli/examples/discover-inspect-call.sh
+++ b/packages/cli/examples/discover-inspect-call.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Discover -> inspect -> call -> audit, scripted with the QVeris CLI and jq.
+#
+# Discovery and inspection are free. The call step is gated behind
+# RUN_QVERIS_CALLS=1 because it may consume credits.
+#
+#   QVERIS_API_KEY=sk-... ./discover-inspect-call.sh
+#   QVERIS_API_KEY=sk-... RUN_QVERIS_CALLS=1 ./discover-inspect-call.sh
+#
+set -euo pipefail
+
+# Support both an installed `qveris` and an override like `npx -y @qverisai/cli`.
+IFS=" " read -r -a qv <<<"${QVERIS_BIN:-qveris}"
+query="${1:-public company stock quote and market data API}"
+
+if [[ -z "${QVERIS_API_KEY:-}" ]]; then
+  echo "Set QVERIS_API_KEY to run this example. https://qveris.ai/account?page=api-keys"
+  exit 0
+fi
+
+# 1. Discover — capture the whole response so we can reuse its search_id.
+discovered="$("${qv[@]}" discover "$query" --limit 5 --json)"
+search_id="$(jq -r '.search_id' <<<"$discovered")"
+tool_id="$(jq -r '.results[0].tool_id // empty' <<<"$discovered")"
+
+if [[ -z "$tool_id" ]]; then
+  echo "No capabilities matched: $query"
+  exit 0
+fi
+
+echo "search_id: $search_id"
+echo "selected:  $tool_id"
+
+# 2. Inspect — read the current parameter schema before spending anything.
+#    Pass --discovery-id so the inspection is attributed to this discovery.
+#    inspect returns a search-shaped envelope; the tool is under .results[0].
+"${qv[@]}" inspect "$tool_id" --discovery-id "$search_id" --json \
+  | jq '.results[0] | {tool_id, name, expected_cost, success_rate: .stats.success_rate}'
+
+if [[ "${RUN_QVERIS_CALLS:-}" != "1" ]]; then
+  echo "Set RUN_QVERIS_CALLS=1 to execute the selected capability."
+  exit 0
+fi
+
+# 3. Call — execute the capability, then audit the settled charge.
+result="$("${qv[@]}" call "$tool_id" --discovery-id "$search_id" --params '{"symbol":"AAPL"}' --json)"
+execution_id="$(jq -r '.execution_id' <<<"$result")"
+echo "execution_id: $execution_id"
+
+# 4. Audit — usage reflects the final, settled charge (pre-call estimates can differ).
+#    --mode search filters to this execution; the records come back under .items.
+"${qv[@]}" usage --mode search --execution-id "$execution_id" --json | jq '{matched_records, items}'

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -99,7 +99,7 @@ npm install @qverisai/sdk ai zod
 ```
 
 ```typescript
-import { generateText } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { Qveris } from '@qverisai/sdk';
 import { getQverisTools } from '@qverisai/sdk/ai';
@@ -108,10 +108,17 @@ const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
 const { text } = await generateText({
   model: openai('gpt-4o'),
   tools: getQverisTools(qveris), // qveris_discover / qveris_inspect / qveris_call
-  maxSteps: 6,
+  stopWhen: stepCountIs(6),
   prompt: 'Find a stock quote capability and quote AAPL.',
 });
 ```
+
+## Examples
+
+Runnable scripts in [`examples/`](examples): the discover → inspect → call
+quickstart, a Vercel AI SDK agent, and rate-limit/observability. Each is safe to
+run without an API key (it explains how to set one), and any credit-spending
+call is gated behind `RUN_QVERIS_CALLS=1`.
 
 ## Version history note
 

--- a/packages/js-sdk/examples/README.md
+++ b/packages/js-sdk/examples/README.md
@@ -1,0 +1,30 @@
+# QVeris TypeScript SDK examples
+
+Runnable examples for `@qverisai/sdk`. Each script is safe to run without an API
+key — it prints how to set one and exits — so it also serves as a smoke test
+that the SDK imports and wires up. Discovery and inspection are free; the `call`
+step is additionally gated behind `RUN_QVERIS_CALLS=1` so no example spends
+credits by accident.
+
+## Run
+
+```bash
+export QVERIS_API_KEY="sk-..."          # https://qveris.ai/account?page=api-keys
+npx tsx examples/quickstart.ts          # discover -> inspect -> audit (no charge)
+RUN_QVERIS_CALLS=1 npx tsx examples/quickstart.ts   # also executes a capability
+```
+
+## Examples
+
+| File                                                       | Shows                                                                            |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [`quickstart.ts`](quickstart.ts)                           | The full discover → inspect → call → audit loop with routing signals             |
+| [`vercel-ai-agent.ts`](vercel-ai-agent.ts)                 | Exposing QVeris as Vercel AI SDK tools so a model can find and call capabilities |
+| [`retry-and-observability.ts`](retry-and-observability.ts) | Configuring rate-limit backoff and reading `rateLimitRetryCount`                 |
+
+`_shared.ts` holds the tiny helpers (client bootstrap, the `RUN_QVERIS_CALLS`
+gate) the examples share.
+
+The Vercel AI example needs a model provider of your choice, e.g.
+`npm i @ai-sdk/openai`; without one it prints the wired tool set instead of
+driving a model.

--- a/packages/js-sdk/examples/_shared.ts
+++ b/packages/js-sdk/examples/_shared.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared helpers for the QVeris TypeScript SDK examples.
+ *
+ * Every example is safe to run without an API key: it prints how to set one
+ * and returns instead of failing. Discovery and inspection are free; an actual
+ * `call` (which may consume credits) is additionally gated behind
+ * `RUN_QVERIS_CALLS=1` so running an example never spends credits by accident.
+ */
+
+import { Qveris, type ToolInfo } from '@qverisai/sdk';
+
+/**
+ * Build a client from `QVERIS_API_KEY`, or explain how to set one and return
+ * `null`. Examples call this first and bail out cleanly when unconfigured, so
+ * they double as a smoke test that the SDK imports and wires up correctly.
+ */
+export function getClientOrExplain(): Qveris | null {
+  if (!process.env.QVERIS_API_KEY) {
+    console.log('Set QVERIS_API_KEY to run this example against the QVeris API.');
+    console.log('  Global: https://qveris.ai/account?page=api-keys');
+    console.log('  China:  https://qveris.cn/account?page=api-keys');
+    return null;
+  }
+  return Qveris.fromEnv();
+}
+
+/** A `call` spends credits, so only execute one when explicitly opted in. */
+export function shouldCall(): boolean {
+  return process.env.RUN_QVERIS_CALLS === '1';
+}
+
+/** Prefer the capability's own sample parameters; fall back to a sensible default. */
+export function sampleParameters(tool: ToolInfo, fallback: Record<string, unknown>): Record<string, unknown> {
+  return tool.examples?.sample_parameters ?? fallback;
+}

--- a/packages/js-sdk/examples/quickstart.ts
+++ b/packages/js-sdk/examples/quickstart.ts
@@ -1,0 +1,61 @@
+/**
+ * Quickstart: the full discover -> inspect -> call -> audit loop.
+ *
+ * Discovery and inspection are free. The `call` step is gated behind
+ * `RUN_QVERIS_CALLS=1` because it may consume credits.
+ *
+ *   QVERIS_API_KEY=sk-... npx tsx examples/quickstart.ts
+ *   QVERIS_API_KEY=sk-... RUN_QVERIS_CALLS=1 npx tsx examples/quickstart.ts
+ */
+
+import { getClientOrExplain, sampleParameters, shouldCall } from './_shared.js';
+
+async function main(): Promise<void> {
+  const qveris = getClientOrExplain();
+  if (!qveris) return;
+
+  // 1. Discover — natural-language query, free, returns candidates + a search_id.
+  const discovered = await qveris.discover('public company stock quote and market data API', { limit: 5 });
+  console.log(`search_id: ${discovered.search_id}`);
+  console.log(`matches: ${discovered.results.length} / total=${discovered.total}`);
+  if (discovered.results.length === 0) return;
+
+  // 2. Inspect — read the current parameter schema and routing signals, free.
+  //    Pass the search_id so the inspection is attributed to this discovery.
+  const first = discovered.results[0];
+  const inspected = await qveris.inspect([first.tool_id], { searchId: discovered.search_id });
+  const tool = inspected.results[0] ?? first;
+  console.log(`selected: ${tool.tool_id} - ${tool.name || tool.description || 'unnamed'}`);
+  if (tool.stats) {
+    console.log(`quality: success_rate=${tool.stats.success_rate} latency_ms=${tool.stats.avg_execution_time_ms}`);
+  }
+  if (tool.expected_cost !== undefined) {
+    console.log(`expected_cost: ${tool.expected_cost}`);
+  }
+
+  const parameters = sampleParameters(tool, { symbol: 'AAPL' });
+  console.log(`params: ${JSON.stringify(parameters)}`);
+
+  if (!shouldCall()) {
+    console.log('Set RUN_QVERIS_CALLS=1 to execute the selected capability.');
+    return;
+  }
+
+  // 3. Call — execute the capability. May consume credits.
+  const result = await qveris.call(tool.tool_id, { parameters, searchId: discovered.search_id });
+  console.log(`execution_id: ${result.execution_id}`);
+  console.log(`success: ${result.success}`);
+  console.log(`billing: ${result.billing?.summary ?? 'n/a'}`);
+
+  // 4. Audit — the call response carries a pre-settlement estimate; usage and
+  //    the credits ledger reflect the final, settled charge.
+  const usage = await qveris.usage({ execution_id: result.execution_id, summary: true, limit: 5 });
+  console.log(`usage_records: ${usage.total}`);
+  const ledger = await qveris.ledger({ summary: true, limit: 5 });
+  console.log(`ledger_records: ${ledger.total}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/js-sdk/examples/retry-and-observability.ts
+++ b/packages/js-sdk/examples/retry-and-observability.ts
@@ -1,0 +1,43 @@
+/**
+ * Retry and observability: configuring rate-limit backoff and reading it back.
+ *
+ * A rate-limited (429) or transient (503) response is retried automatically
+ * with exponential backoff and jitter, honoring the server's `Retry-After`.
+ * Retried backoff is *pressure*, not failure — observe `rateLimitRetryCount`
+ * rather than treating the retried responses as errors.
+ *
+ *   QVERIS_API_KEY=sk-... npx tsx examples/retry-and-observability.ts
+ *   QVERIS_API_KEY=sk-... QVERIS_MAX_RETRIES=5 npx tsx examples/retry-and-observability.ts
+ */
+
+import { getClientOrExplain } from './_shared.js';
+import { Qveris } from '@qverisai/sdk';
+
+async function main(): Promise<void> {
+  if (!getClientOrExplain()) return;
+
+  // Configure backoff explicitly. `maxRetries` bounds how many times a 429/503
+  // is retried before the error surfaces; 0 disables retries entirely. The
+  // QVERIS_MAX_RETRIES environment variable does the same without code.
+  const qveris = Qveris.fromEnv({ maxRetries: 5, timeoutMs: 15_000 });
+
+  const startedAt = Date.now();
+  const discovered = await qveris.discover('weather forecast API', { limit: 3 });
+  const elapsedMs = Date.now() - startedAt;
+
+  console.log(`matches: ${discovered.results.length} in ${elapsedMs}ms`);
+  // Non-zero here means the client backed off and retried at least once. Track
+  // this as a load signal; it is not counted against success.
+  console.log(`rate_limit_retries: ${qveris.rateLimitRetryCount}`);
+
+  // Pair QVeris usage with your own tracing (OpenTelemetry, etc.) by wrapping
+  // calls in spans; the SDK stays transport-agnostic and adds no dependency.
+  for (const tool of discovered.results) {
+    console.log(`  ${tool.tool_id} score=${tool.final_score ?? 'n/a'} cost=${tool.expected_cost ?? 'n/a'}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/js-sdk/examples/retry-and-observability.ts
+++ b/packages/js-sdk/examples/retry-and-observability.ts
@@ -7,7 +7,6 @@
  * rather than treating the retried responses as errors.
  *
  *   QVERIS_API_KEY=sk-... npx tsx examples/retry-and-observability.ts
- *   QVERIS_API_KEY=sk-... QVERIS_MAX_RETRIES=5 npx tsx examples/retry-and-observability.ts
  */
 
 import { getClientOrExplain } from './_shared.js';
@@ -17,8 +16,8 @@ async function main(): Promise<void> {
   if (!getClientOrExplain()) return;
 
   // Configure backoff explicitly. `maxRetries` bounds how many times a 429/503
-  // is retried before the error surfaces; 0 disables retries entirely. The
-  // QVERIS_MAX_RETRIES environment variable does the same without code.
+  // is retried before the error surfaces; 0 disables retries entirely. (Unlike
+  // the CLI, the SDK reads this from the constructor only, not from the env.)
   const qveris = Qveris.fromEnv({ maxRetries: 5, timeoutMs: 15_000 });
 
   const startedAt = Date.now();

--- a/packages/js-sdk/examples/vercel-ai-agent.ts
+++ b/packages/js-sdk/examples/vercel-ai-agent.ts
@@ -1,0 +1,62 @@
+/**
+ * Vercel AI SDK agent: let a model discover and call QVeris capabilities.
+ *
+ * `getQverisTools` exposes the discover / inspect / call workflow as Vercel AI
+ * SDK tools, so one QVeris API key gives an agent access to thousands of
+ * external capabilities. Bring your own model provider (any `ai` provider):
+ *
+ *   npm i @ai-sdk/openai
+ *   QVERIS_API_KEY=sk-... OPENAI_API_KEY=sk-... npx tsx examples/vercel-ai-agent.ts
+ *
+ * Without a provider installed the example still runs: it prints the wired
+ * tool set instead of driving a model.
+ */
+
+import { generateText, stepCountIs } from 'ai';
+
+import { getQverisTools } from '@qverisai/sdk/ai';
+import { getClientOrExplain } from './_shared.js';
+
+// Derive the provider's model type from `generateText` itself, so this stays
+// correct across `ai` major versions without importing a named type.
+type ModelArg = Parameters<typeof generateText>[0]['model'];
+
+/** Load an optional model provider; return null if none is installed. */
+async function loadModel(): Promise<ModelArg | null> {
+  // A non-literal specifier keeps this type-checking whether or not the optional
+  // provider is installed; install @ai-sdk/openai (or any `ai` provider) to run.
+  const providerSpecifier: string = '@ai-sdk/openai';
+  try {
+    const provider = (await import(providerSpecifier)) as { openai: (id: string) => ModelArg };
+    return provider.openai('gpt-4o');
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  const qveris = getClientOrExplain();
+  if (!qveris) return;
+
+  const tools = getQverisTools(qveris);
+
+  const model = await loadModel();
+  if (!model) {
+    console.log('No model provider installed. Run `npm i @ai-sdk/openai` (or any `ai` provider) to drive the agent.');
+    console.log(`Wired QVeris tools: ${Object.keys(tools).join(', ')}`);
+    return;
+  }
+
+  const { text } = await generateText({
+    model,
+    tools,
+    stopWhen: stepCountIs(6),
+    prompt: 'Find a capability that returns a public stock quote, quote AAPL, and explain your choice and its cost.',
+  });
+  console.log(text);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -46,8 +46,9 @@
     "test:watch": "vitest",
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . && prettier --check \"src/**/*.ts\"",
-    "lint:fix": "eslint . --fix && prettier --write \"src/**/*.ts\"",
+    "typecheck:examples": "tsc -p tsconfig.examples.json --noEmit",
+    "lint": "eslint . && prettier --check \"src/**/*.ts\" \"examples/**/*.ts\"",
+    "lint:fix": "eslint . --fix && prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {

--- a/packages/js-sdk/src/integrations/ai.ts
+++ b/packages/js-sdk/src/integrations/ai.ts
@@ -9,7 +9,7 @@
  *
  * @example
  * ```typescript
- * import { generateText } from 'ai';
+ * import { generateText, stepCountIs } from 'ai';
  * import { openai } from '@ai-sdk/openai';
  * import { Qveris } from '@qverisai/sdk';
  * import { getQverisTools } from '@qverisai/sdk/ai';
@@ -18,7 +18,7 @@
  * const { text } = await generateText({
  *   model: openai('gpt-4o'),
  *   tools: getQverisTools(qveris),
- *   maxSteps: 6,
+ *   stopWhen: stepCountIs(6),
  *   prompt: 'Find a stock quote capability and quote AAPL.',
  * });
  * ```

--- a/packages/js-sdk/tsconfig.examples.json
+++ b/packages/js-sdk/tsconfig.examples.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@qverisai/sdk": ["./src/index.ts"],
+      "@qverisai/sdk/ai": ["./src/integrations/ai.ts"]
+    }
+  },
+  "include": ["examples/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -231,7 +231,7 @@ For backward compatibility, the old tool names are still supported but emit a de
 - With `QVERIS_MCP_CONFIRM_CALLS=true`, a charged `call` first asks the user to confirm via MCP **elicitation** (billing consent); declining cancels the call before any credits are spent. Off by default.
 - **Resources**: read `qveris://server-card` for the server's identity card, or `qveris://capability/{tool_id}` for a capability's full metadata (parameters, examples, stats, billing) without spending a tool call.
 
-## Session Management
+## Session Management
 
 Providing a consistent `session_id` in a same user session in any tool call enables:
 - Consistent user tracking across multiple tool calls
@@ -358,6 +358,14 @@ To override manually, set environment variables in your MCP client config:
 ```
 
 **Priority:** `QVERIS_BASE_URL` > `QVERIS_REGION` > API key prefix auto-detection > default (global)
+
+## Examples
+
+[`examples/agent-loop.ts`](examples/agent-loop.ts) drives this server over stdio
+the way an agent runtime does: spawn it, list the tools, then run
+discover → inspect → call by calling those tools. It is safe to run without an
+API key (tool listing works unconfigured), and the call step is gated behind
+`RUN_QVERIS_CALLS=1`.
 
 ## Requirements
 

--- a/packages/mcp/examples/README.md
+++ b/packages/mcp/examples/README.md
@@ -19,5 +19,8 @@ return an actionable error — so this runs unconfigured. The `call` step is
 additionally gated behind `RUN_QVERIS_CALLS=1` so it never spends credits by
 accident.
 
+By default it spawns the published `@qverisai/mcp`. To drive a local build,
+override the command: `QVERIS_MCP_COMMAND=node QVERIS_MCP_ARGS=dist/index.js`.
+
 To wire the server into an agent host instead of driving it from code, see the
 client-config snippets in the [package README](../README.md).

--- a/packages/mcp/examples/README.md
+++ b/packages/mcp/examples/README.md
@@ -1,0 +1,23 @@
+# QVeris MCP server examples
+
+Runnable examples for driving `@qverisai/mcp` the way an agent runtime does.
+
+## Agent loop
+
+[`agent-loop.ts`](agent-loop.ts) spawns the MCP server as a subprocess, speaks
+MCP over stdio, lists the tools, and runs the discover → inspect → call loop by
+calling those tools — the same shape a model follows.
+
+```bash
+npx tsx examples/agent-loop.ts                                   # lists tools (no key needed)
+QVERIS_API_KEY=sk-... npx tsx examples/agent-loop.ts             # discover -> inspect (no charge)
+QVERIS_API_KEY=sk-... RUN_QVERIS_CALLS=1 npx tsx examples/agent-loop.ts   # also executes a capability
+```
+
+The server starts even without `QVERIS_API_KEY` — tool listing works and calls
+return an actionable error — so this runs unconfigured. The `call` step is
+additionally gated behind `RUN_QVERIS_CALLS=1` so it never spends credits by
+accident.
+
+To wire the server into an agent host instead of driving it from code, see the
+client-config snippets in the [package README](../README.md).

--- a/packages/mcp/examples/agent-loop.ts
+++ b/packages/mcp/examples/agent-loop.ts
@@ -1,0 +1,95 @@
+/**
+ * Agent loop over the QVeris MCP server.
+ *
+ * Spawns `@qverisai/mcp` as a subprocess and speaks MCP to it over stdio —
+ * exactly how an agent runtime (Claude Desktop, Codex, a custom host) drives
+ * the server. It lists the tools, then runs the discover -> inspect -> call
+ * loop the same way a model would by calling the exposed tools.
+ *
+ * The server starts even without QVERIS_API_KEY (tool listing works; calls
+ * return an actionable error), so this is safe to run unconfigured. The `call`
+ * step is additionally gated behind RUN_QVERIS_CALLS=1 to avoid spending
+ * credits.
+ *
+ *   npx tsx examples/agent-loop.ts
+ *   QVERIS_API_KEY=sk-... npx tsx examples/agent-loop.ts
+ *   QVERIS_API_KEY=sk-... RUN_QVERIS_CALLS=1 npx tsx examples/agent-loop.ts
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+type DiscoverResult = { search_id?: string; results?: Array<{ tool_id: string; name?: string }> };
+type InspectResult = { results?: Array<{ params?: Array<{ name?: string }> }> };
+
+/** Forward only defined environment variables (the transport wants string values). */
+function childEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+}
+
+async function main(): Promise<void> {
+  const hasKey = Boolean(process.env.QVERIS_API_KEY);
+
+  // The subprocess inherits QVERIS_API_KEY through its environment.
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['-y', '@qverisai/mcp'],
+    env: childEnv(),
+  });
+  const client = new Client({ name: 'qveris-agent-loop-example', version: '0.1.0' });
+  await client.connect(transport);
+
+  try {
+    const { tools } = await client.listTools();
+    console.log(`tools: ${tools.map((tool) => tool.name).join(', ')}`);
+
+    if (!hasKey) {
+      console.log('Set QVERIS_API_KEY to run the discover -> inspect -> call loop.');
+      return;
+    }
+
+    // 1. discover — the model finds candidates from a natural-language query.
+    const discovered = await client.callTool({
+      name: 'discover',
+      arguments: { query: 'public company stock quote and market data API', limit: 5 },
+    });
+    const found = discovered.structuredContent as DiscoverResult | undefined;
+    const top = found?.results?.[0];
+    console.log(`search_id: ${found?.search_id ?? 'n/a'}; matches: ${found?.results?.length ?? 0}`);
+    if (!top) return;
+
+    // 2. inspect — read the current parameter schema before calling.
+    const inspected = await client.callTool({
+      name: 'inspect',
+      arguments: { tool_ids: [top.tool_id], search_id: found?.search_id },
+    });
+    const detail = (inspected.structuredContent as InspectResult | undefined)?.results?.[0];
+    const paramNames =
+      (detail?.params ?? [])
+        .map((param) => param.name)
+        .filter(Boolean)
+        .join(', ') || 'none';
+    console.log(`selected: ${top.tool_id} - ${top.name ?? 'unnamed'} (params: ${paramNames})`);
+
+    if (process.env.RUN_QVERIS_CALLS !== '1') {
+      console.log('Set RUN_QVERIS_CALLS=1 to execute the selected capability.');
+      return;
+    }
+
+    // 3. call — execute the capability. May consume credits.
+    const executed = await client.callTool({
+      name: 'call',
+      arguments: { tool_id: top.tool_id, search_id: found?.search_id, params_to_tool: { symbol: 'AAPL' } },
+    });
+    console.log(`result: ${JSON.stringify(executed.structuredContent ?? executed.content)}`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/mcp/examples/agent-loop.ts
+++ b/packages/mcp/examples/agent-loop.ts
@@ -21,6 +21,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 
 type DiscoverResult = { search_id?: string; results?: Array<{ tool_id: string; name?: string }> };
 type InspectResult = { results?: Array<{ params?: Array<{ name?: string }> }> };
+type ToolCallResult = Awaited<ReturnType<Client['callTool']>>;
 
 /** Forward only defined environment variables (the transport wants string values). */
 function childEnv(): Record<string, string> {
@@ -29,13 +30,31 @@ function childEnv(): Record<string, string> {
   );
 }
 
+/**
+ * Read a tool result as typed data. Prefer `structuredContent` (present when the
+ * tool declares an outputSchema, as QVeris's do), and fall back to parsing the
+ * text block so the example stays robust against servers that omit it.
+ */
+function readResult<T>(result: ToolCallResult): T | undefined {
+  if (result.structuredContent !== undefined) {
+    return result.structuredContent as T;
+  }
+  const first = Array.isArray(result.content) ? result.content[0] : undefined;
+  if (first?.type === 'text') {
+    return JSON.parse(first.text) as T;
+  }
+  return undefined;
+}
+
 async function main(): Promise<void> {
   const hasKey = Boolean(process.env.QVERIS_API_KEY);
 
-  // The subprocess inherits QVERIS_API_KEY through its environment.
+  // The subprocess inherits QVERIS_API_KEY through its environment. Override the
+  // command to test a local build, e.g.
+  // QVERIS_MCP_COMMAND=node QVERIS_MCP_ARGS=dist/index.js.
   const transport = new StdioClientTransport({
-    command: 'npx',
-    args: ['-y', '@qverisai/mcp'],
+    command: process.env.QVERIS_MCP_COMMAND ?? 'npx',
+    args: process.env.QVERIS_MCP_ARGS ? process.env.QVERIS_MCP_ARGS.split(' ') : ['-y', '@qverisai/mcp'],
     env: childEnv(),
   });
   const client = new Client({ name: 'qveris-agent-loop-example', version: '0.1.0' });
@@ -55,7 +74,7 @@ async function main(): Promise<void> {
       name: 'discover',
       arguments: { query: 'public company stock quote and market data API', limit: 5 },
     });
-    const found = discovered.structuredContent as DiscoverResult | undefined;
+    const found = readResult<DiscoverResult>(discovered);
     const top = found?.results?.[0];
     console.log(`search_id: ${found?.search_id ?? 'n/a'}; matches: ${found?.results?.length ?? 0}`);
     if (!top) return;
@@ -65,7 +84,7 @@ async function main(): Promise<void> {
       name: 'inspect',
       arguments: { tool_ids: [top.tool_id], search_id: found?.search_id },
     });
-    const detail = (inspected.structuredContent as InspectResult | undefined)?.results?.[0];
+    const detail = readResult<InspectResult>(inspected)?.results?.[0];
     const paramNames =
       (detail?.params ?? [])
         .map((param) => param.name)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -41,9 +41,10 @@
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit",
+    "typecheck:examples": "tsc -p tsconfig.examples.json --noEmit",
     "gen:openapi": "bash ../../scripts/regenerate-openapi-artifacts.sh",
-    "lint": "eslint . && prettier --check \"src/**/*.ts\"",
-    "lint:fix": "eslint . --fix && prettier --write \"src/**/*.ts\""
+    "lint": "eslint . && prettier --check \"src/**/*.ts\" \"examples/**/*.ts\"",
+    "lint:fix": "eslint . --fix && prettier --write \"src/**/*.ts\" \"examples/**/*.ts\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/tsconfig.examples.json
+++ b/packages/mcp/tsconfig.examples.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@qverisai/mcp": ["./src/index.ts"]
+    }
+  },
+  "include": ["examples/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/recipes/crypto-monitoring/README.md
+++ b/recipes/crypto-monitoring/README.md
@@ -15,7 +15,7 @@ qveris init --query "cryptocurrency market price and volume API" --params '{"sym
 qveris init \
   --query "cryptocurrency market price and volume API" \
   --params '{"symbol":"BTC","currency":"USD"}' \
-  --max-response-size 20480 \
+  --max-size 20480 \
   --json
 ```
 

--- a/recipes/data-analysis/README.md
+++ b/recipes/data-analysis/README.md
@@ -15,7 +15,7 @@ qveris init --query "company domain enrichment API" --params '{"domain":"qveris.
 qveris init \
   --query "company domain enrichment API" \
   --params '{"domain":"qveris.ai"}' \
-  --max-response-size 20480 \
+  --max-size 20480 \
   --json
 ```
 

--- a/recipes/developer-automation/README.md
+++ b/recipes/developer-automation/README.md
@@ -15,7 +15,7 @@ qveris init --query "GitHub repository metadata API" --params '{"owner":"QVerisA
 qveris init \
   --query "GitHub repository metadata API" \
   --params '{"owner":"QVerisAI","repo":"qveris-agent-toolkit"}' \
-  --max-response-size 20480 \
+  --max-size 20480 \
   --json
 ```
 

--- a/recipes/explainable-routing/qveris.manifest.json
+++ b/recipes/explainable-routing/qveris.manifest.json
@@ -83,6 +83,12 @@
       "path": "README.md#python-sdk",
       "language": "python",
       "command": "python explainable_routing.py"
+    },
+    {
+      "name": "CLI runnable recipe",
+      "path": "run.sh",
+      "language": "shell",
+      "command": "./run.sh"
     }
   ]
 }

--- a/recipes/explainable-routing/run.sh
+++ b/recipes/explainable-routing/run.sh
@@ -25,17 +25,21 @@ discovered="$("${qv[@]}" discover "$query" --limit 5 --json)"
 search_id="$(jq -r '.search_id' <<<"$discovered")"
 
 echo "Candidates (why_recommended / expected_cost / success_rate):"
-jq -r '.results[]
+jq -r '(.results // [])[]
   | "  \(.tool_id)\tcost=\(.expected_cost // "n/a")\tsuccess=\(.stats.success_rate // "n/a")\twhy=\(.why_recommended // "n/a")"' \
   <<<"$discovered"
 
 # Routing rule: among candidates within 1.5x of the cheapest estimate, take the
-# most reliable one. This is the choice we can explain and defend.
+# most reliable one. This is the choice we can explain and defend. Guard against
+# a missing/empty results array so an empty match set exits cleanly, not crashes.
 choice="$(jq -c '
-  .results as $r
-  | ($r | map((.expected_cost // 0 | tonumber? // 0)) | min) as $mincost
-  | [ $r[] | select((.expected_cost // 0 | tonumber? // 0) <= ($mincost * 1.5)) ]
-  | sort_by(.stats.success_rate // 0) | reverse | .[0] // empty' <<<"$discovered")"
+  (.results // []) as $r
+  | if ($r | length) == 0 then empty
+    else
+      ($r | map((.expected_cost // 0 | tonumber? // 0)) | min) as $mincost
+      | [ $r[] | select((.expected_cost // 0 | tonumber? // 0) <= ($mincost * 1.5)) ]
+      | sort_by(.stats.success_rate // 0) | reverse | .[0]
+    end // empty' <<<"$discovered")"
 
 if [[ -z "$choice" ]]; then
   echo "No capabilities matched: $query"

--- a/recipes/explainable-routing/run.sh
+++ b/recipes/explainable-routing/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Explainable routing: discover candidates, pick one with a transparent,
+# cost-aware rule, and explain the choice before spending credits.
+#
+# The rule below picks the most reliable capability among the cheapest tier
+# (expected_cost within 1.5x of the minimum). Discovery is free; the optional
+# call is gated behind RUN_QVERIS_CALLS=1.
+#
+#   QVERIS_API_KEY=sk-... ./run.sh
+#   QVERIS_API_KEY=sk-... RUN_QVERIS_CALLS=1 ./run.sh
+#
+set -euo pipefail
+
+# Support both an installed `qveris` and an override like `npx -y @qverisai/cli`.
+IFS=" " read -r -a qv <<<"${QVERIS_BIN:-qveris}"
+query="${1:-public company stock quote and market data API}"
+
+if [[ -z "${QVERIS_API_KEY:-}" ]]; then
+  echo "Set QVERIS_API_KEY to run this recipe. https://qveris.ai/account?page=api-keys"
+  exit 0
+fi
+
+discovered="$("${qv[@]}" discover "$query" --limit 5 --json)"
+search_id="$(jq -r '.search_id' <<<"$discovered")"
+
+echo "Candidates (why_recommended / expected_cost / success_rate):"
+jq -r '.results[]
+  | "  \(.tool_id)\tcost=\(.expected_cost // "n/a")\tsuccess=\(.stats.success_rate // "n/a")\twhy=\(.why_recommended // "n/a")"' \
+  <<<"$discovered"
+
+# Routing rule: among candidates within 1.5x of the cheapest estimate, take the
+# most reliable one. This is the choice we can explain and defend.
+choice="$(jq -c '
+  .results as $r
+  | ($r | map((.expected_cost // 0 | tonumber? // 0)) | min) as $mincost
+  | [ $r[] | select((.expected_cost // 0 | tonumber? // 0) <= ($mincost * 1.5)) ]
+  | sort_by(.stats.success_rate // 0) | reverse | .[0] // empty' <<<"$discovered")"
+
+if [[ -z "$choice" ]]; then
+  echo "No capabilities matched: $query"
+  exit 0
+fi
+
+tool_id="$(jq -r '.tool_id' <<<"$choice")"
+echo ""
+echo "Chosen: $tool_id"
+jq -r '"Because: \(.why_recommended // "highest reliability in the cheapest tier") " +
+       "(expected_cost=\(.expected_cost // "n/a"), success_rate=\(.stats.success_rate // "n/a"))"' <<<"$choice"
+
+if [[ "${RUN_QVERIS_CALLS:-}" != "1" ]]; then
+  echo "Set RUN_QVERIS_CALLS=1 to execute the chosen capability."
+  exit 0
+fi
+
+"${qv[@]}" call "$tool_id" --discovery-id "$search_id" --params '{"symbol":"AAPL"}' --json \
+  | jq '{execution_id, success, billing: .billing.summary}'

--- a/recipes/finance-research/README.md
+++ b/recipes/finance-research/README.md
@@ -17,7 +17,7 @@ Use the first-call flow when you want QVeris to discover, inspect, select, and c
 qveris init \
   --query "public company stock quote and market data API" \
   --params '{"symbol":"AAPL"}' \
-  --max-response-size 20480 \
+  --max-size 20480 \
   --json
 ```
 

--- a/recipes/finance-research/qveris.manifest.json
+++ b/recipes/finance-research/qveris.manifest.json
@@ -83,6 +83,12 @@
       "path": "README.md#python-sdk",
       "language": "python",
       "command": "python finance_research.py"
+    },
+    {
+      "name": "CLI runnable recipe",
+      "path": "run.sh",
+      "language": "shell",
+      "command": "./run.sh"
     }
   ]
 }

--- a/recipes/finance-research/run.sh
+++ b/recipes/finance-research/run.sh
@@ -29,9 +29,10 @@ if [[ "${RUN_QVERIS_CALLS:-}" != "1" ]]; then
 fi
 
 # One-shot first call: discover -> inspect -> select -> call in one command.
-result="$("${qv[@]}" init --query "$query" --params '{"symbol":"AAPL"}' --max-response-size 20480 --json)"
-execution_id="$(jq -r '.execution_id // empty' <<<"$result")"
-echo "$result" | jq '{tool_id, execution_id, success}'
+# init nests its output: selected_tool.tool_id and call.{execution_id,success}.
+result="$("${qv[@]}" init --query "$query" --params '{"symbol":"AAPL"}' --max-size 20480 --json)"
+execution_id="$(jq -r '.call.execution_id // empty' <<<"$result")"
+echo "$result" | jq '{tool_id: .selected_tool.tool_id, execution_id: .call.execution_id, success: .call.success}'
 
 # Audit the settled charge. --mode search filters to this execution; the records
 # come back under .items.

--- a/recipes/finance-research/run.sh
+++ b/recipes/finance-research/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Finance research first-call path: discover -> inspect -> call -> audit for a
+# public company market-data capability.
+#
+# Without RUN_QVERIS_CALLS=1 this does a free discover-only dry run. With it, it
+# runs the one-shot `qveris init` first-call flow, which discovers, selects, and
+# calls in a single command (and may consume credits).
+#
+#   QVERIS_API_KEY=sk-... ./run.sh
+#   QVERIS_API_KEY=sk-... RUN_QVERIS_CALLS=1 ./run.sh
+#
+set -euo pipefail
+
+# Support both an installed `qveris` and an override like `npx -y @qverisai/cli`.
+IFS=" " read -r -a qv <<<"${QVERIS_BIN:-qveris}"
+query="${1:-public company stock quote and market data API}"
+
+if [[ -z "${QVERIS_API_KEY:-}" ]]; then
+  echo "Set QVERIS_API_KEY to run this recipe. https://qveris.ai/account?page=api-keys"
+  exit 0
+fi
+
+if [[ "${RUN_QVERIS_CALLS:-}" != "1" ]]; then
+  echo "Dry run (discover only). Set RUN_QVERIS_CALLS=1 for the full first-call flow."
+  "${qv[@]}" discover "$query" --limit 5 --json \
+    | jq -r '.results[] | "  \(.tool_id)\tcost=\(.expected_cost // "n/a")"'
+  exit 0
+fi
+
+# One-shot first call: discover -> inspect -> select -> call in one command.
+result="$("${qv[@]}" init --query "$query" --params '{"symbol":"AAPL"}' --max-response-size 20480 --json)"
+execution_id="$(jq -r '.execution_id // empty' <<<"$result")"
+echo "$result" | jq '{tool_id, execution_id, success}'
+
+# Audit the settled charge. --mode search filters to this execution; the records
+# come back under .items.
+if [[ -n "$execution_id" ]]; then
+  "${qv[@]}" usage --mode search --execution-id "$execution_id" --json | jq '{matched_records, items}'
+fi

--- a/recipes/risk-compliance/README.md
+++ b/recipes/risk-compliance/README.md
@@ -15,7 +15,7 @@ qveris init --query "sanctions screening or adverse media compliance API" --para
 qveris init \
   --query "sanctions screening or adverse media compliance API" \
   --params '{"name":"Acme Trading Ltd"}' \
-  --max-response-size 20480 \
+  --max-size 20480 \
   --json
 ```
 


### PR DESCRIPTION
Closes #159 — the last P1 item.

## Problem

Examples were Python-only (14 scripts). js-sdk, MCP and CLI had zero example directories; `recipes/` entries were manifest+README with no runnable code and no CI validation of the runnable code (the manifest *schema* was already validated in `ecosystem-validate.yml`).

## What's added

**js-sdk** (`packages/js-sdk/examples/`)
- `quickstart.ts` — discover → inspect → call → audit with routing signals
- `vercel-ai-agent.ts` — QVeris as Vercel AI SDK tools via the existing `@qverisai/sdk/ai` integration
- `retry-and-observability.ts` — `maxRetries` config + reading `rateLimitRetryCount`
- `_shared.ts`, `README.md`

**MCP** (`packages/mcp/examples/`)
- `agent-loop.ts` — spawns the server over stdio and drives discover → inspect → call the way an agent runtime does

**CLI** (`packages/cli/examples/`)
- `discover-inspect-call.sh`, `budget-guard.sh` (cost-aware), `README.md`

**Recipes** — `explainable-routing` and `finance-research` each ship a runnable `run.sh` (the former with a transparent "most reliable within 1.5× of cheapest" routing rule), registered in their manifest.

## Offline-safe by design

Every example no-ops with a clear message when `QVERIS_API_KEY` is unset, and any credit-spending `call` is gated behind `RUN_QVERIS_CALLS=1` — mirroring the existing `packages/python-sdk/examples/_shared.py` pattern. So they double as smoke tests that the SDK/CLI/MCP surface imports and wires up.

## CI validation (offline — no key, no credits)

- TypeScript examples type-checked via per-package `tsconfig.examples.json` (added to the `js-sdk-tests` / `mcp-tests` jobs). `paths` maps the public specifiers (`@qverisai/sdk`, `@qverisai/sdk/ai`, `@qverisai/mcp`) to `./src`, so examples import the **public** package names (copy-paste accurate) yet type-check against source without a build.
- CLI scripts: `shellcheck` (new `examples` job in `contract-tests.yml`).
- Recipe `run.sh`: `shellcheck` in `ecosystem-validate.yml` (already triggers on `recipes/**`).
- `prettier`/`eslint` now cover example `.ts`; python examples were already ruff-linted.
- Path triggers widened so example/recipe changes actually run these checks.

## Also

Fixed the Vercel AI snippet in the js-sdk README and the `ai.ts` JSDoc: the installed/current `ai` major is v7, which uses `stopWhen: stepCountIs(n)` rather than the v4 `maxSteps`.

## Review notes

Staff-reviewed. Beyond the review, verifying each example's field paths against the actual CLI output caught three real shape bugs (now fixed): `inspect --json` nests tools under `.results[]`; `usage` exposes `matched_records` (not `total`); and auditing a specific execution needs `--mode search --execution-id` per the CLI's own help.

## Local verification

js-sdk + mcp: full lint, `typecheck`, `typecheck:examples`, and tests pass (120 mcp tests). Manifest validation, `shellcheck` 0.11, and workflow YAML all clean.