### PR TITLE
docs: js-sdk API reference, troubleshooting/FAQ, locale drift check (#162)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,36 @@
+name: Docs checks
+
+# Guard the docs locale structure (en-US / zh-CN / cn/zh-CN) against silent
+# drift. See #162 and scripts/check-doc-locales.mjs.
+
+on:
+  pull_request:
+    paths:
+      - "docs/en-US/**"
+      - "docs/zh-CN/**"
+      - "docs/cn/**"
+      - "scripts/check-doc-locales.mjs"
+      - ".github/workflows/docs-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/en-US/**"
+      - "docs/zh-CN/**"
+      - "docs/cn/**"
+      - "scripts/check-doc-locales.mjs"
+      - ".github/workflows/docs-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  locales:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - name: Check doc locale consistency
+        run: node scripts/check-doc-locales.mjs

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@
 ### ⚙️ I'm a developer integrating via CLI / MCP / API / SDK
 
 > → **[QVeris CLI](packages/cli)** — `npm install -g @qverisai/cli` or `curl -fsSL https://qveris.ai/cli/install | bash`
-> → [MCP Server Doc](docs/mcp-server.md)
-> → [REST API Doc](docs/rest-api.md)
+> → [MCP Server Doc](docs/en-US/mcp-server.md)
+> → [REST API Doc](docs/en-US/rest-api.md)
 > → [Python SDK](packages/python-sdk)
 
 ---
@@ -203,10 +203,12 @@ Full CLI documentation: [packages/cli/README.md](packages/cli/README.md)
 | Method | Use case | Docs |
 |--------|----------|------|
 | **CLI** (recommended) | Claude Code / OpenClaw / any agent with exec | [CLI docs](packages/cli/README.md) |
-| MCP Server | Cursor / Claude Desktop / MCP-only clients | [MCP docs](docs/mcp-server.md) |
+| MCP Server | Cursor / Claude Desktop / MCP-only clients | [MCP docs](docs/en-US/mcp-server.md) |
 | Python SDK | Python projects, agent frameworks | [Python SDK docs](packages/python-sdk/README.md) |
 | TypeScript SDK | Node.js / TypeScript projects | [JS SDK docs](packages/js-sdk/README.md) |
-| REST API | Any language, custom integrations | [REST API docs](docs/rest-api.md) |
+| REST API | Any language, custom integrations | [REST API docs](docs/en-US/rest-api.md) |
+
+Stuck? See [Troubleshooting & FAQ](docs/troubleshooting.md).
 
 ### Core protocol
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,69 @@
+# Troubleshooting & FAQ
+
+Common issues across the QVeris CLI, SDKs, and MCP server. See also the
+per-surface docs in [`docs/en-US`](en-US) and the runnable
+[examples](../packages/js-sdk/examples).
+
+## Authentication
+
+**`QVERIS_API_KEY is not set` / 401 / "API key is required".**
+Create a key at [qveris.ai/account?page=api-keys](https://qveris.ai/account?page=api-keys)
+(global) or [qveris.cn/account?page=api-keys](https://qveris.cn/account?page=api-keys)
+(China), then export it:
+
+```bash
+export QVERIS_API_KEY="sk-..."
+```
+
+**Wrong region / cross-region key errors.**
+The region is auto-detected from the key prefix (`sk-cn-…` → China, otherwise
+global). Override with `QVERIS_REGION=global|cn` or `QVERIS_BASE_URL`. A global
+key will not work against `qveris.cn` and vice versa.
+
+## Billing
+
+**402 / "insufficient credits".**
+Discovery and inspection are free; `call` spends credits. The free tier includes
+1,000 credits. The error message includes the top-up link. Check your balance
+with `qveris credits` or `qveris.credits()`.
+
+**The pre-call estimate and the final charge differ.**
+The `call` response carries a *pre-settlement* `billing` estimate. The final,
+settled charge is in `qveris usage --mode search --execution-id <id>` (CLI) or
+`usage()` / `ledger()` (SDK).
+
+## Rate limits
+
+**429 / "rate limited".**
+The CLI, SDKs, and MCP server retry automatically: they honor `Retry-After`,
+otherwise back off exponentially with jitter, bounded by `maxRetries`
+(constructor option in the SDKs) / `QVERIS_MAX_RETRIES` (CLI, default 3; `0`
+disables). Backoff is *pressure*, not failure — the JS SDK exposes
+`rateLimitRetryCount`. If you still hit limits, lower concurrency.
+
+## Discovery & calls
+
+**`discover` returns no results.**
+Describe the *capability* you need ("public company stock quote API"), not the
+parameters you plan to pass. Broaden the query and raise `--limit` / `limit`.
+
+**`call` returns `success: false` or invalid-parameter errors.**
+`inspect` the tool first and pass exactly the parameters its schema declares;
+`examples.sample_parameters` shows a working shape. `error_message` explains the
+failure.
+
+**Large responses look truncated.**
+Responses are capped by `max_response_size` (`--max-size` in the CLI, default
+20480 bytes; `-1` for unlimited). Raise it if you need the full payload.
+
+## MCP server
+
+**The client shows no QVeris tools.**
+Tool *listing* works without a key; tool *calls* need `QVERIS_API_KEY` in the
+server's env. Verify your config with `qveris mcp validate --target <client>`,
+and regenerate it with `qveris mcp configure --target <client> --write`.
+
+## Environment
+
+**Node version errors.**
+The packages require Node `>=18.2.0` (see `.nvmrc`). Check with `node -v`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,8 +53,10 @@ parameters you plan to pass. Broaden the query and raise `--limit` / `limit`.
 failure.
 
 **Large responses look truncated.**
-Responses are capped by `max_response_size` (`--max-size` in the CLI, default
-20480 bytes; `-1` for unlimited). Raise it if you need the full payload.
+Responses are capped by `max_response_size` (`--max-size` in the CLI). The
+default is 20480 bytes for `--json`/non-interactive use, but only 4096 bytes in
+an interactive terminal — so a truncated result in a TTY is hitting the 4 KB
+cap. Raise it (`-1` for unlimited) if you need the full payload.
 
 ## MCP server
 
@@ -66,4 +68,4 @@ and regenerate it with `qveris mcp configure --target <client> --write`.
 ## Environment
 
 **Node version errors.**
-The packages require Node `>=18.2.0` (see `.nvmrc`). Check with `node -v`.
+The packages require Node `>=18.2.0`. Check with `node -v`.

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -52,6 +52,29 @@ const ledger = await qveris.ledger({ direction: 'consume', summary: true });
 const credits = await qveris.credits();
 ```
 
+## API reference
+
+Construct with `new Qveris({ apiKey })` or `Qveris.fromEnv(overrides?)` (reads
+`QVERIS_API_KEY`, auto-detects the region from the key prefix).
+
+| Method | Billed | Returns | Notes |
+| --- | --- | --- | --- |
+| `discover(query, options?)` | Free | `SearchResponse` | `options`: `limit`, `sessionId`, `timeoutMs`. Results carry `why_recommended`, `expected_cost`, `stats`. |
+| `inspect(toolIds, options?)` | Free | `SearchResponse` | `toolIds` is one id or an array; `options`: `searchId`, `sessionId`, `timeoutMs`. An empty array resolves locally with no request. |
+| `call(toolId, options)` | Credits | `ExecuteResponse` | `options`: `parameters` (required), `searchId`, `maxResponseSize`, `sessionId`, `timeoutMs`. |
+| `credits()` | Free | `CreditsResponse` | Current balance and bucket details. |
+| `usage(filters?)` | Free | `UsageEventsResponse` | Request-level audit; filter by `execution_id`, `search_id`, dates, `summary`, `limit`. |
+| `ledger(filters?)` | Free | `CreditsLedgerResponse` | Settled credit movements; filter by `direction`, dates, `summary`, `limit`. |
+
+Read-only members: `qveris.rateLimitRetryCount` (see [Rate limiting](#rate-limiting--retries)).
+
+Key response fields:
+
+- **`SearchResponse`** — `search_id`, `total`, `results: ToolInfo[]` (`tool_id`, `name`, `description`, `params`, `examples.sample_parameters`, `stats.success_rate`, `stats.avg_execution_time_ms`, `expected_cost`, `why_recommended`).
+- **`ExecuteResponse`** — `execution_id`, `success`, `result`, `billing` (pre-settlement estimate; the final charge is in `usage()` / `ledger()`).
+
+All types are exported from the package root (`import type { SearchResponse, ExecuteResponse, ToolInfo } from '@qverisai/sdk'`).
+
 ## Configuration
 
 | Option / env var | Description |

--- a/scripts/check-doc-locales.mjs
+++ b/scripts/check-doc-locales.mjs
@@ -18,8 +18,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const EN = 'docs/en-US';
 const ZH = 'docs/zh-CN';
 const CN = 'docs/cn/zh-CN';

--- a/scripts/check-doc-locales.mjs
+++ b/scripts/check-doc-locales.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Guard the docs locale structure against silent drift.
+//
+// Structure (see #162):
+//   docs/en-US      — English, source of truth
+//   docs/zh-CN      — global Chinese (qveris.ai), full mirror of en-US
+//   docs/cn/zh-CN   — China-region Chinese (qveris.cn), a region variant of zh-CN
+//
+// Hard failures (exit 1):
+//   - en-US and zh-CN must have the SAME set of .md files (a full-locale pair).
+//   - Every file in docs/cn/zh-CN must also exist in docs/zh-CN (no orphan
+//     region files pointing at nothing).
+//
+// Warnings (exit 0):
+//   - Files in zh-CN with no China-region variant in docs/cn/zh-CN. The region
+//     variant is intentionally a subset, so this is reported, not enforced.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const EN = 'docs/en-US';
+const ZH = 'docs/zh-CN';
+const CN = 'docs/cn/zh-CN';
+
+function mdFiles(rel) {
+  const dir = path.resolve(REPO_ROOT, rel);
+  if (!fs.existsSync(dir)) return null;
+  return new Set(fs.readdirSync(dir).filter((f) => f.endsWith('.md')));
+}
+
+const en = mdFiles(EN);
+const zh = mdFiles(ZH);
+const cn = mdFiles(CN);
+
+const errors = [];
+const warnings = [];
+
+if (!en || !zh) {
+  errors.push(`Missing a required locale directory: ${!en ? EN : ZH}`);
+} else {
+  for (const f of en) if (!zh.has(f)) errors.push(`${ZH}/${f} is missing (present in ${EN})`);
+  for (const f of zh) if (!en.has(f)) errors.push(`${EN}/${f} is missing (present in ${ZH})`);
+}
+
+if (cn && zh) {
+  for (const f of cn) if (!zh.has(f)) errors.push(`${CN}/${f} has no base file in ${ZH} (orphan region variant)`);
+  for (const f of zh) if (!cn.has(f)) warnings.push(`${ZH}/${f} has no China-region variant in ${CN}`);
+}
+
+for (const w of warnings) console.warn(`warning: ${w}`);
+
+if (errors.length > 0) {
+  for (const e of errors) console.error(`error: ${e}`);
+  console.error(`\n${errors.length} locale drift error(s).`);
+  process.exit(1);
+}
+
+const counts = [en && `${EN}=${en.size}`, zh && `${ZH}=${zh.size}`, cn && `${CN}=${cn.size}`].filter(Boolean);
+console.log(`Locales consistent (${counts.join(', ')}); ${warnings.length} region-variant gap(s) reported.`);


### PR DESCRIPTION
Addresses #162 (P2 Docs).

## What's here

- **js-sdk README API reference** — a per-method table (signature, billed?, return type) plus the key response-field shapes (`SearchResponse`, `ExecuteResponse`). This was the depth gap vs the cli (527-line) and mcp (400-line) READMEs; the sections the issue named (audit, config, retries, integrations) already landed in #197.
- **Troubleshooting & FAQ** ([`docs/troubleshooting.md`](../blob/docs/js-sdk-readme-locale-check/docs/troubleshooting.md)) — auth, region, billing, 429 backoff, discovery/call pitfalls, MCP config, Node version. Linked from the root README. Placed **outside** the localized dirs so it doesn't create a translation-parity obligation.
- **Locale drift guard** — `scripts/check-doc-locales.mjs` + `docs-check.yml` (triggers only on `docs/**`, so it doesn't fire the heavy suite). Enforces `docs/en-US` ↔ `docs/zh-CN` as a matching pair (hard), and **reports** (soft) files in `zh-CN` lacking a `docs/cn/zh-CN` China-region variant — surfacing exactly the missing `claude-code-setup.md` the issue noted.
- **Fixed two broken links** in the root README (`docs/{mcp-server,rest-api}.md` → `docs/en-US/…`).

## Scope decisions (called out from the issue)

- **2-vs-3 locale consolidation is intentionally NOT done.** Investigation showed `docs/cn/zh-CN` is **real China-region content** (qveris.cn URLs, cn install script, cn API base — files differ substantially from `docs/zh-CN`) and is wired into `sync-docs-to-website.yml`, which PRs to the website repo. Deleting it would destroy China content and break the cross-repo sync. Whether to move to "2 locales + a region banner" is a product/website decision; the new check now guards against further drift in the meantime.
- **Generated API reference (typedoc/sphinx) + website sync is deferred.** It needs the website-side hosting/sync pipeline (not in this repo) and is the lowest-ROI item; the hand-written API-reference section covers the immediate need for readers on npm.

## Verification

`node scripts/check-doc-locales.mjs` passes (exit 0, reports the 1 known cn gap); `docs-check.yml` is valid YAML; prettier clean on the changed markdown; root README links all resolve.