### PR TITLE
feat(mcp): add per-session HTTP server factory

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
+- An embedding API for independently operated Streamable HTTP services: asynchronous per-session server factories can require a caller bearer, receive it only during session construction, and rely on fingerprint binding to reject later credential changes. Credential validation and client policy stay outside the toolkit.
 - Fuller MCP spec surface ([#158]):
   - **Output schemas + structured content** — every tool declares `outputSchema` (loose, additive-friendly) and returns `structuredContent` alongside the JSON text, so clients consume typed results instead of re-parsing strings.
   - **Elicitation billing consent** — with `QVERIS_MCP_CONFIRM_CALLS=true` and an elicitation-capable client, a charged `call` asks the user to confirm first; declining cancels the call before any credits are spent. Off by default (headless agents unaffected); clients without elicitation proceed as before.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -300,6 +300,7 @@ npx -y @qverisai/mcp
 
 - The endpoint is `POST/GET/DELETE {path}` (default `/mcp`); `GET /health` returns an unauthenticated liveness probe.
 - **Inbound auth:** set `QVERIS_MCP_HTTP_AUTH_TOKEN` to require `Authorization: Bearer <token>` on the MCP endpoint. The server **refuses to start** when binding a non-loopback host without a token, unless you set `QVERIS_MCP_HTTP_ALLOW_UNAUTHENTICATED=true` to delegate auth to an external proxy/gateway. Your `QVERIS_API_KEY` is the server's *outbound* credential to QVeris — it is **not** an inbound check, so anyone reaching an unauthenticated endpoint would spend your credits.
+- **Embedding API:** the package root exports `startHttpServer`, `resolveTransportConfig`, `QverisClient`, and the session-auth types. An independently operated service can set `requireSessionBearer` on its resolved transport config and provide an asynchronous session factory. The transport requires a bearer, passes it only to that factory, stores only a credential fingerprint for session binding, and rejects credential changes. The embedding service owns validation, client construction, rate limits, deployment, and operations.
 - DNS-rebinding protection is **on by default** (localhost + the bound host/port are allow-listed). When exposing the server publicly, add your public host via `QVERIS_MCP_ALLOWED_HOSTS`.
 - Requests are capped at 4 MiB by default (`QVERIS_MCP_MAX_BODY_BYTES`), and idle sessions are evicted after 5 minutes (`QVERIS_MCP_SESSION_TIMEOUT_MS`).
 - **Discovery:** registries and crawlers can learn about the server without connecting:
@@ -397,4 +398,3 @@ MIT © [QVerisAI](https://github.com/QVerisAI)
 
 - 🐛 [Issue Tracker](https://github.com/QVerisAI/qveris-agent-toolkit/issues)
 - 💬 Contact: contact@qveris.ai
-

--- a/packages/mcp/src/http.test.ts
+++ b/packages/mcp/src/http.test.ts
@@ -3,7 +3,14 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createQverisServer } from './index.js';
-import { resolveTransportConfig, startHttpServer, type RunningHttpServer } from './http.js';
+import {
+  resolveTransportConfig,
+  SessionAuthenticationError,
+  SessionAuthenticationUnavailableError,
+  SessionRateLimitError,
+  startHttpServer,
+  type RunningHttpServer,
+} from './http.js';
 
 describe('resolveTransportConfig', () => {
   it('defaults to stdio with no flags or env', () => {
@@ -42,6 +49,7 @@ describe('resolveTransportConfig', () => {
     expect(config.enableDnsRebindingProtection).toBe(true);
     expect(config.enableJsonResponse).toBe(false);
     expect(config.authToken).toBeUndefined();
+    expect(config.requireSessionBearer).toBe(false);
     expect(config.allowUnauthenticated).toBe(false);
     expect(config.maxBodyBytes).toBe(4 * 1024 * 1024);
     expect(config.sessionTimeoutMs).toBe(5 * 60 * 1000);
@@ -111,12 +119,31 @@ describe('startHttpServer (end-to-end over Streamable HTTP)', () => {
     protocolVersions: ['2025-11-25'],
   };
 
-  async function startServer(extraEnv: Record<string, string> = {}, cardInfo?: typeof CARD_INFO): Promise<void> {
-    const config = resolveTransportConfig({ QVERIS_MCP_TRANSPORT: 'http', QVERIS_MCP_HTTP_PORT: '0', ...extraEnv }, []);
+  async function startServer(
+    extraEnv: Record<string, string> = {},
+    cardInfo?: typeof CARD_INFO,
+    makeServer: Parameters<typeof startHttpServer>[1] = (sessionId) => createQverisServer(undefined, sessionId),
+    requireSessionBearer = false,
+  ): Promise<void> {
+    const config = {
+      ...resolveTransportConfig({ QVERIS_MCP_TRANSPORT: 'http', QVERIS_MCP_HTTP_PORT: '0', ...extraEnv }, []),
+      requireSessionBearer,
+    };
     // Server has no QVERIS_API_KEY, so tool listing works but calls return an
     // actionable error — exactly the credential-less path we want to exercise.
-    running = await startHttpServer(config, (sessionId) => createQverisServer(undefined, sessionId), cardInfo);
+    running = await startHttpServer(config, makeServer, cardInfo);
   }
+
+  const initializeBody = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: 'raw-test-client', version: '0.0.0' },
+    },
+  };
 
   async function connectClient(bearer?: string): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
     if (!running) await startServer();
@@ -199,6 +226,147 @@ describe('startHttpServer (end-to-end over Streamable HTTP)', () => {
     await health.text();
   });
 
+  it('passes each required bearer only to its own session factory', async () => {
+    const sessionKeys: string[] = [];
+    await startServer(
+      {},
+      undefined,
+      (sessionId, auth) => {
+        sessionKeys.push(auth.bearerToken ?? '');
+        return createQverisServer(undefined, sessionId);
+      },
+      true,
+    );
+
+    const first = await connectClient('user-key-a');
+    const second = await connectClient('user-key-b');
+    expect(first.transport.sessionId).not.toBe(second.transport.sessionId);
+    expect(sessionKeys).toEqual(['user-key-a', 'user-key-b']);
+    await first.client.close();
+    await second.client.close();
+  });
+
+  it('requires a bearer when the embedding service enables session auth', async () => {
+    await startServer({}, undefined, undefined, true);
+    const res = await fetch(`http://127.0.0.1:${running!.port}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: JSON.stringify(initializeBody),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toBe('Bearer');
+    await res.text();
+  });
+
+  it('rejects a credential change on an established session', async () => {
+    await startServer({}, undefined, undefined, true);
+    const { client, transport } = await connectClient('user-key-a');
+    const res = await fetch(`http://127.0.0.1:${running!.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer user-key-b',
+        'Mcp-Session-Id': transport.sessionId!,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(401);
+    expect((await res.json()) as object).toMatchObject({ error: { message: 'Session credential mismatch' } });
+    await client.close();
+  });
+
+  it('maps rejected and unavailable credential validation safely', async () => {
+    await startServer(
+      {},
+      undefined,
+      () => {
+        throw new SessionAuthenticationError('upstream details must not escape');
+      },
+      true,
+    );
+    const rejected = await fetch(`http://127.0.0.1:${running!.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer invalid-key',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(initializeBody),
+    });
+    expect(rejected.status).toBe(401);
+    expect(await rejected.text()).not.toContain('upstream details');
+    await running?.close();
+    running = undefined;
+
+    await startServer(
+      {},
+      undefined,
+      () => {
+        throw new SessionAuthenticationUnavailableError('internal network details');
+      },
+      true,
+    );
+    const unavailable = await fetch(`http://127.0.0.1:${running!.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer user-key',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(initializeBody),
+    });
+    expect(unavailable.status).toBe(503);
+    expect(unavailable.headers.get('retry-after')).toBe('5');
+    expect(await unavailable.text()).not.toContain('internal network details');
+  });
+
+  it('maps embedding-service session limits to a retryable response', async () => {
+    await startServer(
+      {},
+      undefined,
+      () => {
+        throw new SessionRateLimitError('internal limiter details', 17);
+      },
+      true,
+    );
+    const res = await fetch(`http://127.0.0.1:${running!.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer caller-credential',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(initializeBody),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('retry-after')).toBe('17');
+    expect(await res.text()).not.toContain('internal limiter details');
+  });
+
+  it('normalizes invalid embedding-service retry windows before writing the header', async () => {
+    await startServer(
+      {},
+      undefined,
+      () => {
+        throw new SessionRateLimitError('internal limiter details', Number.NaN);
+      },
+      true,
+    );
+    const res = await fetch(`http://127.0.0.1:${running!.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer caller-credential',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(initializeBody),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('retry-after')).toBe('60');
+    await res.text();
+  });
+
   it('returns 413 for an oversized request body', async () => {
     await startServer({ QVERIS_MCP_MAX_BODY_BYTES: '512' });
     const res = await fetch(`http://127.0.0.1:${running!.port}/mcp`, {
@@ -249,6 +417,45 @@ describe('startHttpServer (end-to-end over Streamable HTTP)', () => {
     const res = await fetch(`http://127.0.0.1:${running!.port}/health`);
     expect(res.status).toBe(200);
     await res.text();
+  });
+
+  it('allows a non-loopback bind with mandatory per-session bearer auth', async () => {
+    await startServer({ QVERIS_MCP_HTTP_HOST: '0.0.0.0' }, undefined, undefined, true);
+    const res = await fetch(`http://127.0.0.1:${running!.port}/health`);
+    expect(res.status).toBe(200);
+    await res.text();
+  });
+
+  it('rejects auth options that conflict with per-session bearer auth', async () => {
+    const withSharedToken = {
+      ...resolveTransportConfig(
+        {
+          QVERIS_MCP_TRANSPORT: 'http',
+          QVERIS_MCP_HTTP_PORT: '0',
+          QVERIS_MCP_HTTP_AUTH_TOKEN: 'shared-token',
+        },
+        [],
+      ),
+      requireSessionBearer: true,
+    };
+    await expect(
+      startHttpServer(withSharedToken, (sessionId) => createQverisServer(undefined, sessionId)),
+    ).rejects.toThrow(/cannot be combined/);
+
+    const withUnauthenticated = {
+      ...resolveTransportConfig(
+        {
+          QVERIS_MCP_TRANSPORT: 'http',
+          QVERIS_MCP_HTTP_PORT: '0',
+          QVERIS_MCP_HTTP_ALLOW_UNAUTHENTICATED: 'true',
+        },
+        [],
+      ),
+      requireSessionBearer: true,
+    };
+    await expect(
+      startHttpServer(withUnauthenticated, (sessionId) => createQverisServer(undefined, sessionId)),
+    ).rejects.toThrow(/cannot be enabled/);
   });
 
   it('serves the Server Card unauthenticated with the right media type and CORS', async () => {

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -9,10 +9,10 @@
  * {@link StreamableHTTPServerTransport} (and its own Qveris {@link Server}),
  * keyed by the `Mcp-Session-Id` header the SDK assigns on `initialize`.
  *
- * Inbound auth is an optional shared bearer token (`QVERIS_MCP_HTTP_AUTH_TOKEN`).
- * When binding a non-loopback host the server refuses to start unless a token is
- * set (or auth is explicitly delegated to an external layer). OAuth 2.1 and the
- * `.well-known` Server Card are tracked as follow-ups to issue #107.
+ * Embedders may require a bearer per session and receive it only in the
+ * asynchronous server factory. The transport binds an irreversible credential
+ * fingerprint to the MCP session so later requests cannot switch identities.
+ * Validation and client construction remain the embedding service's policy.
  *
  * @module @qverisai/mcp/http
  */
@@ -50,6 +50,8 @@ export interface TransportConfig {
   enableJsonResponse: boolean;
   /** Shared bearer token required on the MCP endpoint; unset = no inbound auth. */
   authToken?: string;
+  /** Require a caller bearer and bind it to each new MCP session. Embedders set this directly. */
+  requireSessionBearer?: boolean;
   /** Allow a non-loopback bind without a token (auth delegated externally). */
   allowUnauthenticated: boolean;
   /** Max accepted request body size in bytes (413 beyond it). */
@@ -58,6 +60,34 @@ export interface TransportConfig {
   sessionTimeoutMs: number;
   /** Public origin (e.g. behind a TLS proxy) used in discovery documents. */
   publicUrl?: string;
+}
+
+/** Credential context supplied only while constructing a new MCP session. */
+export interface HttpSessionAuth {
+  /** Present only when requireSessionBearer is enabled. Never logged or persisted by the transport. */
+  bearerToken?: string;
+}
+
+/** The embedding service rejected the credential supplied for a new session. */
+export class SessionAuthenticationError extends Error {
+  override readonly name = 'SessionAuthenticationError';
+}
+
+/** The embedding service could not validate a supplied credential safely. */
+export class SessionAuthenticationUnavailableError extends Error {
+  override readonly name = 'SessionAuthenticationUnavailableError';
+}
+
+/** The embedding service rate-limited creation of a new authenticated session. */
+export class SessionRateLimitError extends Error {
+  override readonly name = 'SessionRateLimitError';
+  readonly retryAfterSeconds: number;
+
+  constructor(message: string, retryAfterSeconds = 60) {
+    super(message);
+    this.retryAfterSeconds =
+      Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0 ? Math.min(86_400, Math.ceil(retryAfterSeconds)) : 60;
+  }
 }
 
 const DEFAULT_PORT = 3000;
@@ -172,6 +202,7 @@ export function resolveTransportConfig(env: NodeJS.ProcessEnv, argv: string[] = 
     enableDnsRebindingProtection: parseBool(env.QVERIS_MCP_DNS_REBINDING_PROTECTION, true),
     enableJsonResponse: parseBool(env.QVERIS_MCP_HTTP_JSON, false),
     authToken: env.QVERIS_MCP_HTTP_AUTH_TOKEN?.trim() || undefined,
+    requireSessionBearer: false,
     allowUnauthenticated: parseBool(env.QVERIS_MCP_HTTP_ALLOW_UNAUTHENTICATED, false),
     maxBodyBytes: parsePositiveInt(env.QVERIS_MCP_MAX_BODY_BYTES, DEFAULT_MAX_BODY_BYTES),
     sessionTimeoutMs: parsePositiveInt(env.QVERIS_MCP_SESSION_TIMEOUT_MS, DEFAULT_SESSION_TIMEOUT_MS),
@@ -223,15 +254,29 @@ function jsonRpcError(id: unknown, code: number, message: string) {
 
 /** Constant-time bearer check against the configured token. */
 function bearerMatches(authHeader: string | undefined, token: string): boolean {
-  if (!authHeader) return false;
-  const prefix = 'bearer ';
-  if (!authHeader.toLowerCase().startsWith(prefix)) return false;
-  const provided = authHeader.slice(prefix.length).trim();
+  const provided = readBearerToken(authHeader);
+  if (!provided) return false;
   // Compare fixed-length SHA-256 digests so the comparison is constant-time
   // *and* doesn't leak the expected token's length via an early length check.
   const providedHash = createHash('sha256').update(provided).digest();
   const expectedHash = createHash('sha256').update(token).digest();
   return timingSafeEqual(providedHash, expectedHash);
+}
+
+function readBearerToken(authHeader: string | undefined): string | undefined {
+  if (!authHeader) return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+  const token = match?.[1]?.trim();
+  return token || undefined;
+}
+
+function credentialFingerprint(token: string): Buffer {
+  return createHash('sha256').update(token).digest();
+}
+
+function credentialMatches(fingerprint: Buffer | undefined, token: string | undefined): boolean {
+  if (!fingerprint || !token) return false;
+  return timingSafeEqual(fingerprint, credentialFingerprint(token));
 }
 
 /** Handle to a running HTTP server. */
@@ -258,19 +303,25 @@ export interface RunningHttpServer {
  */
 export async function startHttpServer(
   config: TransportConfig,
-  makeServer: (sessionId: string) => Server,
+  makeServer: (sessionId: string, auth: HttpSessionAuth) => Server | Promise<Server>,
   cardInfo?: ServerCardInfo,
   logger: (message: string) => void = (message) => process.stderr.write(message),
 ): Promise<RunningHttpServer> {
   const nonLoopback = !isLoopbackHost(config.host);
-  if (nonLoopback && !config.authToken && !config.allowUnauthenticated) {
+  if (config.requireSessionBearer && config.authToken) {
+    throw new Error('Shared authToken cannot be combined with per-session bearer authentication.');
+  }
+  if (config.requireSessionBearer && config.allowUnauthenticated) {
+    throw new Error('allowUnauthenticated cannot be enabled with per-session bearer authentication.');
+  }
+  if (nonLoopback && !config.requireSessionBearer && !config.authToken && !config.allowUnauthenticated) {
     throw new Error(
       `Refusing to start: HTTP transport is binding a non-loopback host (${config.host}) with no authentication. ` +
         `Set QVERIS_MCP_HTTP_AUTH_TOKEN to require a bearer token, or set ` +
         `QVERIS_MCP_HTTP_ALLOW_UNAUTHENTICATED=true if an external layer (proxy/gateway) authenticates requests.`,
     );
   }
-  if (nonLoopback && !config.authToken) {
+  if (nonLoopback && !config.requireSessionBearer && !config.authToken) {
     logger(
       '[qveris] WARNING: HTTP transport exposed on a non-loopback host without an auth token. ' +
         'Ensure an external auth layer protects the endpoint.\n',
@@ -290,6 +341,7 @@ export async function startHttpServer(
   }
 
   const transports = new Map<string, StreamableHTTPServerTransport>();
+  const sessionCredentialFingerprints = new Map<string, Buffer>();
   const lastSeen = new Map<string, number>();
   const inflight = new Map<string, number>(); // requests currently being handled per session
   let boundPort = config.port;
@@ -317,10 +369,12 @@ export async function startHttpServer(
   const evict = (sessionId: string): void => {
     lastSeen.delete(sessionId);
     inflight.delete(sessionId);
+    sessionCredentialFingerprints.delete(sessionId);
     if (transports.get(sessionId)) transports.delete(sessionId);
   };
 
-  const createTransport = async (): Promise<StreamableHTTPServerTransport> => {
+  const createTransport = async (auth: HttpSessionAuth): Promise<StreamableHTTPServerTransport> => {
+    const fingerprint = auth.bearerToken ? credentialFingerprint(auth.bearerToken) : undefined;
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       enableJsonResponse: config.enableJsonResponse,
@@ -329,6 +383,7 @@ export async function startHttpServer(
       allowedOrigins: config.allowedOrigins,
       onsessioninitialized: (sessionId) => {
         transports.set(sessionId, transport);
+        if (fingerprint) sessionCredentialFingerprints.set(sessionId, fingerprint);
         lastSeen.set(sessionId, Date.now());
         logger(`[qveris] MCP session initialized: ${sessionId}\n`);
       },
@@ -340,9 +395,16 @@ export async function startHttpServer(
         logger(`[qveris] MCP session closed: ${sessionId}\n`);
       }
     };
-    const server = makeServer(randomUUID());
-    await server.connect(transport);
-    return transport;
+    let server: Server | undefined;
+    try {
+      server = await makeServer(randomUUID(), auth);
+      await server.connect(transport);
+      return transport;
+    } catch (error) {
+      await transport.close().catch(() => undefined);
+      if (server) await server.close().catch(() => undefined);
+      throw error;
+    }
   };
 
   const handler = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
@@ -410,8 +472,29 @@ export async function startHttpServer(
         return;
       }
 
+      const sessionBearer = config.requireSessionBearer ? readBearerToken(req.headers['authorization']) : undefined;
+      if (config.requireSessionBearer && !sessionBearer) {
+        req.resume();
+        writeJson(res, 401, jsonRpcError(null, -32001, 'Bearer credential required'), {
+          'WWW-Authenticate': 'Bearer',
+        });
+        return;
+      }
+
       const sessionId = req.headers['mcp-session-id'];
       const existing = typeof sessionId === 'string' ? transports.get(sessionId) : undefined;
+      if (
+        config.requireSessionBearer &&
+        existing &&
+        typeof sessionId === 'string' &&
+        !credentialMatches(sessionCredentialFingerprints.get(sessionId), sessionBearer)
+      ) {
+        req.resume();
+        writeJson(res, 401, jsonRpcError(null, -32001, 'Session credential mismatch'), {
+          'WWW-Authenticate': 'Bearer',
+        });
+        return;
+      }
       if (typeof sessionId === 'string' && existing) lastSeen.set(sessionId, Date.now());
 
       if (req.method === 'POST') {
@@ -445,7 +528,29 @@ export async function startHttpServer(
             writeJson(res, 400, jsonRpcError(null, -32000, 'Missing session ID: first request must be initialize'));
             return;
           }
-          transport = await createTransport();
+          try {
+            transport = await createTransport({ bearerToken: sessionBearer });
+          } catch (error) {
+            if (error instanceof SessionAuthenticationError) {
+              writeJson(res, 401, jsonRpcError(null, -32001, 'Invalid session credential'), {
+                'WWW-Authenticate': 'Bearer',
+              });
+              return;
+            }
+            if (error instanceof SessionAuthenticationUnavailableError) {
+              writeJson(res, 503, jsonRpcError(null, -32002, 'Credential validation temporarily unavailable'), {
+                'Retry-After': '5',
+              });
+              return;
+            }
+            if (error instanceof SessionRateLimitError) {
+              writeJson(res, 429, jsonRpcError(null, -32003, 'Session creation rate limit exceeded'), {
+                'Retry-After': String(error.retryAfterSeconds),
+              });
+              return;
+            }
+            throw error;
+          }
         }
 
         // Guard only requests against an existing session (a known id); a fresh
@@ -535,6 +640,7 @@ export async function startHttpServer(
       await transport.close().catch(() => undefined);
     }
     transports.clear();
+    sessionCredentialFingerprints.clear();
     lastSeen.clear();
     inflight.clear();
     await new Promise<void>((resolve) => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -59,10 +59,10 @@ import { createRequire } from 'node:module';
 const SERVER_NAME = 'qveris';
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
-const SERVER_VERSION: string = pkg.version;
+export const SERVER_VERSION: string = pkg.version;
 
 /** Discovery metadata (Server Card + Catalog) derived from package.json. */
-function buildServerCardInfo(): ServerCardInfo {
+export function getQverisServerCardInfo(): ServerCardInfo {
   const repoUrl: string | undefined = pkg.repository?.url?.replace(/^git\+/, '').replace(/\.git$/, '');
   return {
     name: pkg.mcpName ?? 'io.github.QVerisAI/mcp',
@@ -529,7 +529,7 @@ export function createQverisServer(client: QverisClient | undefined, defaultSess
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const uri = request.params.uri;
     if (uri === CARD_RESOURCE_URI) {
-      const card = buildServerCard(buildServerCardInfo());
+      const card = buildServerCard(getQverisServerCardInfo());
       return {
         contents: [{ uri, mimeType: 'application/mcp-server-card+json', text: JSON.stringify(card) }],
       };
@@ -576,7 +576,11 @@ export async function main(): Promise<void> {
 
   // Streamable HTTP: one Qveris server per MCP session, keyed by Mcp-Session-Id.
   if (transportConfig.mode === 'http') {
-    await startHttpServer(transportConfig, (sessionId) => createQverisServer(client, sessionId), buildServerCardInfo());
+    await startHttpServer(
+      transportConfig,
+      (sessionId) => createQverisServer(client, sessionId),
+      getQverisServerCardInfo(),
+    );
     return;
   }
 
@@ -590,6 +594,14 @@ export async function main(): Promise<void> {
   console.error(`Qveris MCP Server v${SERVER_VERSION} started (stdio)`);
   console.error(`Session ID: ${defaultSessionId}`);
 }
+
+// Public embedding surface for independently operated HTTP services. The
+// toolkit owns protocol/session mechanics; embedders own credential policy,
+// client construction, deployment, and operations.
+export { QverisClient, resolveTransportConfig, startHttpServer };
+export { SessionAuthenticationError, SessionAuthenticationUnavailableError, SessionRateLimitError } from './http.js';
+export type { HttpSessionAuth, RunningHttpServer, TransportConfig } from './http.js';
+export type { ServerCardInfo } from './server-card.js';
 
 /**
  * Type guard for API errors.


### PR DESCRIPTION
## Summary

- expose the Streamable HTTP transport and server/client primitives from the package root for embedded integrations
- allow callers to require a bearer credential and construct each MCP session asynchronously
- bind established sessions to an irreversible credential fingerprint and reject credential changes
- provide typed authentication, temporary-unavailability, and rate-limit errors with safe HTTP mappings
- export stable Server Card metadata for custom HTTP deployments
- preserve existing CLI, stdio, shared-token, health, Server Card, and catalog behavior

## Scope

This change adds generic protocol and session-runtime extension points. Credential validation, tenant policy, and deployment configuration remain the responsibility of the embedding application.

## Review hardening

- keep manually constructed transport configuration source-compatible
- close partially initialized transports and servers when an async session factory fails
- normalize retry windows before exposing them as HTTP headers

## Validation

- `pnpm --dir packages/mcp test` (128 passed)
- `pnpm --dir packages/mcp typecheck`
- `pnpm --dir packages/mcp lint`
- `pnpm --dir packages/mcp build`
