### PR TITLE
docs: complete endpoint sync coverage

### DIFF
--- a/.github/workflows/sync-docs-to-website.yml
+++ b/.github/workflows/sync-docs-to-website.yml
@@ -13,10 +13,8 @@ on:
     paths:
       # Toolkit-owned docs. The website's docs/.source-manifest.json
       # (sources.toolkit_owned.paths) is the authority for what sync-docs.mjs
-      # actually mirrors; this trigger must be a SUPERSET of it so a toolkit
-      # edit reliably starts the sync. Paths the manifest does not list yet
-      # (python-sdk, the docs/cn/zh-CN CN-region variants) are included here so
-      # they trigger as soon as the website manifest is updated to mirror them.
+      # actually mirrors; this trigger must be a SUPERSET of it so every
+      # toolkit-owned documentation edit reliably starts the sync.
       - "docs/en-US/cli.md"
       - "docs/zh-CN/cli.md"
       - "docs/cn/zh-CN/cli.md"
@@ -31,8 +29,10 @@ on:
       - "docs/en-US/opencode-setup.md"
       - "docs/zh-CN/opencode-setup.md"
       - "docs/cn/zh-CN/opencode-setup.md"
-      # SDK docs (added after the manifest's last policy update; the website
-      # manifest must list these before sync-docs.mjs will mirror them).
+      - "docs/en-US/getting-started.md"
+      - "docs/zh-CN/getting-started.md"
+      - "docs/cn/zh-CN/getting-started.md"
+      # SDK docs mirrored by the website source manifest.
       - "docs/en-US/python-sdk.md"
       - "docs/zh-CN/python-sdk.md"
       - "docs/cn/zh-CN/python-sdk.md"

--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -115,7 +115,7 @@ async def main():
         selected = inspected.results[0]
         result = await client.call(
             selected.tool_id,
-            {"city": "London"},
+            {"city": "北京"},
             search_id=discovered.search_id,
         )
         print(result.execution_id, result.success, result.billing)
@@ -337,7 +337,7 @@ resp = requests.post(
     },
     json={
         "search_id": search_id,
-        "parameters": {"city": "London", "units": "metric"},
+        "parameters": {"city": "北京", "units": "metric"},
         "max_response_size": 20480,
     },
     timeout=60,

--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -62,7 +62,7 @@ async def main():
         params = (
             selected.examples.sample_parameters
             if selected.examples and selected.examples.sample_parameters
-            else {"city": "London"}
+            else {"city": "北京"}
         )
         result = await client.call(
             selected.tool_id,

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -112,7 +112,7 @@ async def main():
         selected = inspected.results[0]
         result = await client.call(
             selected.tool_id,
-            {"city": "London"},
+            {"city": "北京"},
             search_id=discovered.search_id,
         )
         print(result.execution_id, result.success, result.billing)
@@ -329,7 +329,7 @@ resp = requests.post(
     },
     json={
         "search_id": search_id,
-        "parameters": {"city": "London", "units": "metric"},
+        "parameters": {"city": "北京", "units": "metric"},
         "max_response_size": 20480,
     },
     timeout=60,

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -58,7 +58,7 @@ async def main():
         params = (
             selected.examples.sample_parameters
             if selected.examples and selected.examples.sample_parameters
-            else {"city": "London"}
+            else {"city": "北京"}
         )
         result = await client.call(
             selected.tool_id,


### PR DESCRIPTION
## Summary

- add all three `getting-started.md` variants to the toolkit-to-website workflow trigger
- keep the trigger as a superset of the website toolkit-owned source manifest
- localize Chinese weather examples so mirrored docs pass the website content checks

## Why

The website now mirrors getting-started and JavaScript SDK documentation in addition to the existing CLI, MCP, and Python SDK docs. Without the additional trigger paths, edits to getting-started documentation would not start the cross-repository sync.

Related to [WonderfulValley/qveris-website#1759](https://github.com/WonderfulValley/qveris-website/issues/1759).

## Validation

- verified the workflow covers all 23 toolkit-owned manifest paths
- `git diff --check`
- website mirror check: `node scripts/sync-docs.mjs --check --toolkit-dir ../qveris-agent-toolkit`
