### PR TITLE
docs: pin China SDK integration endpoints

### DIFF
--- a/docs/cn/zh-CN/js-sdk.md
+++ b/docs/cn/zh-CN/js-sdk.md
@@ -142,7 +142,10 @@ import { openai } from '@ai-sdk/openai';
 import { Qveris } from '@qverisai/sdk';
 import { getQverisTools } from '@qverisai/sdk/ai';
 
-const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
+const qveris = new Qveris({
+  apiKey: process.env.QVERIS_API_KEY!,
+  baseUrl: 'https://qveris.cn/api/v1',
+});
 const { text } = await generateText({
   model: openai('gpt-4o'),
   tools: getQverisTools(qveris), // qveris_discover / qveris_inspect / qveris_call

--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -272,10 +272,10 @@ pip install 'qveris[langchain]'
 ```
 
 ```python
-from qveris import QverisClient
+from qveris import QverisClient, QverisConfig
 from qveris.integrations.langchain import get_qveris_tools
 
-client = QverisClient()
+client = QverisClient(QverisConfig(base_url="https://qveris.cn/api/v1"))
 tools = get_qveris_tools(client)  # 3 个异步工具：qveris_discover / qveris_inspect / qveris_call
 # 把 `tools` 绑定到 LangChain 或 LangGraph agent，用完 `await client.close()`
 ```
@@ -290,10 +290,10 @@ pip install 'qveris[openai-agents]'
 
 ```python
 from agents import Agent, Runner
-from qveris import QverisClient
+from qveris import QverisClient, QverisConfig
 from qveris.integrations.openai_agents import get_qveris_tools
 
-client = QverisClient()
+client = QverisClient(QverisConfig(base_url="https://qveris.cn/api/v1"))
 agent = Agent(name="Assistant", tools=get_qveris_tools(client))
 result = await Runner.run(agent, "Find a stock quote capability and quote AAPL.")
 await client.close()
@@ -307,10 +307,10 @@ pip install 'qveris[crewai]'
 
 ```python
 from crewai import Agent
-from qveris import QverisClient
+from qveris import QverisClient, QverisConfig
 from qveris.integrations.crewai import get_qveris_tools, aclose
 
-client = QverisClient()
+client = QverisClient(QverisConfig(base_url="https://qveris.cn/api/v1"))
 agent = Agent(role="Researcher", goal="...", backstory="...", tools=get_qveris_tools(client))
 # 同步运行你的 crew（crew.kickoff()），然后：
 aclose(client)


### PR DESCRIPTION
## Summary

- import `QverisConfig` in all three China-facing Python framework integration examples
- explicitly configure `https://qveris.cn/api/v1` for LangChain, OpenAI Agents SDK, and CrewAI clients
- configure the same endpoint in the China-facing Vercel AI SDK example

## Why

The Python and JavaScript clients default to the global API endpoint when `QVERIS_BASE_URL` is absent. A reader who copies an individual China-facing integration example could therefore send requests to the wrong deployment even though the surrounding page documents the required environment variable.

Making the endpoint explicit keeps each executable example self-contained and consistent with the quickstart. Global documentation and SDK runtime defaults are unchanged.

## Validation

- `node scripts/check-doc-locales.mjs`
- documentation region-boundary scans
- `git diff --check`
