### PR TITLE
Align OpenClaw endpoint selection

### DIFF
--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ### Changed
 
+- Endpoint selection now uses `config.baseUrl`, then `QVERIS_BASE_URL`, then the built-in default. API keys and the deprecated `region` setting never reroute requests; unsafe endpoint overrides are rejected. ([#206])
 - Raised the supported host to OpenClaw `>=2026.6.11` and Node.js `>=22.19.0`, matching the plugin API used by the current code. The full-toolkit development requirement is now Node.js `>=22.22.2`; plugin CI and builds use Node.js 22. ([#210])
 - Pinned the tested OpenClaw host and plugin SDK metadata to `2026.6.11`, and aligned the peer, plugin API, and installer compatibility floors. ([#210])
 - Upgraded the Vitest, coverage, Vite, and esbuild development toolchain to audited releases. Published runtime dependencies are unchanged. ([#211])
@@ -30,6 +31,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 [Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.6.4...HEAD
 [2026.6.4]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/qveris-plugin-v2026.6.4
+[#206]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/206
 [#210]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/210
 [#211]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/211
 [#152]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/152

--- a/packages/openclaw-qveris-plugin/README.md
+++ b/packages/openclaw-qveris-plugin/README.md
@@ -23,7 +23,7 @@ The typical agent workflow is: `qveris_discover` → `qveris_inspect` (optional)
 
 - Node.js >= 22.19.0
 - OpenClaw >= 2026.6.11
-- A QVeris API key — sign up at [qveris.ai](https://qveris.ai) (global) or [qveris.cn](https://qveris.cn) (China)
+- A QVeris API key — sign up at [qveris.ai](https://qveris.ai)
 
 ---
 
@@ -75,8 +75,7 @@ Add the following to your `openclaw.json`:
       qveris: {
         enabled: true,
         config: {
-          apiKey: "qv-your-api-key-here",  // or use QVERIS_API_KEY env var
-          region: "cn"                      // "global" (qveris.ai) or "cn" (qveris.cn)
+          apiKey: "qv-your-api-key-here"  // or use QVERIS_API_KEY env var
         }
       }
     }
@@ -101,6 +100,12 @@ export QVERIS_API_KEY=qv-your-api-key-here
 
 The plugin checks `plugins.entries.qveris.config.apiKey` first, then falls back to `QVERIS_API_KEY`.
 
+To make the API endpoint explicit through the environment:
+
+```bash
+export QVERIS_BASE_URL=https://qveris.ai/api/v1
+```
+
 > **Security**: if no API key is found at startup, all three tools are silently omitted — no error is thrown.
 
 ---
@@ -112,8 +117,7 @@ All fields under `plugins.entries.qveris.config`:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `apiKey` | `string` | — | QVeris API key. Sensitive — use env var `QVERIS_API_KEY` as alternative. |
-| `region` | `"global"` \| `"cn"` | `"global"` | API region. `global` → `qveris.ai`, `cn` → `qveris.cn`. |
-| `baseUrl` | `string` | *(derived from region)* | Override API base URL. Use only when pointing at a private/staging endpoint. |
+| `baseUrl` | `string` | `QVERIS_BASE_URL`, then `https://qveris.ai/api/v1` | Explicit API base URL override. |
 | `searchTimeoutSeconds` | `number` | `5` | Timeout for `qveris_discover` calls. |
 | `executeTimeoutSeconds` | `number` | `60` | Default timeout for `qveris_call`. Can be overridden per-call via the `timeout_seconds` parameter. |
 | `searchLimit` | `number` | `10` | Max number of tools returned by `qveris_discover`. |
@@ -122,18 +126,25 @@ All fields under `plugins.entries.qveris.config`:
 | `fullContentMaxBytes` | `number` | `10485760` (10 MB) | Max size for full-content downloads. |
 | `fullContentTimeoutSeconds` | `number` | `30` | Timeout for full-content downloads. |
 
-### Region and base URL
+### Endpoint selection
 
-| Region | API base URL | Full-content download domain |
-|--------|-------------|------------------------------|
-| `global` | `https://qveris.ai/api/v1` | `qveris.ai` |
-| `cn` | `https://qveris.cn/api/v1` | `qveris.cn` |
+Endpoint precedence is deterministic:
+
+1. `plugins.entries.qveris.config.baseUrl`
+2. `QVERIS_BASE_URL`
+3. `https://qveris.ai/api/v1`
+
+API keys never change the endpoint. Overrides must be complete HTTP(S) URLs without credentials, whitespace,
+backslashes, query parameters, or fragments. Trailing slashes are removed.
+
+The legacy `region` field is deprecated and rejected with migration guidance. Remove `region`; when the default
+endpoint is not correct for the site that issued your key, set `baseUrl` or `QVERIS_BASE_URL` to that site's API URL.
 
 ---
 
 ## Minimal vs full config examples
 
-### Minimal (global region, env var key)
+### Minimal (env var key)
 
 ```bash
 export QVERIS_API_KEY=qv-...
@@ -144,26 +155,6 @@ export QVERIS_API_KEY=qv-...
   plugins: {
     allow: ["qveris"],
     entries: { qveris: { enabled: true } }
-  },
-  tools: { alsoAllow: ["qveris"] }
-}
-```
-
-### China region
-
-```json5
-{
-  plugins: {
-    allow: ["qveris"],
-    entries: {
-      qveris: {
-        enabled: true,
-        config: {
-          apiKey: "qv-...",
-          region: "cn"
-        }
-      }
-    }
   },
   tools: { alsoAllow: ["qveris"] }
 }
@@ -180,7 +171,6 @@ export QVERIS_API_KEY=qv-...
         enabled: true,
         config: {
           apiKey: "qv-...",
-          region: "global",
           autoMaterializeFullContent: true,
           fullContentMaxBytes: 20971520,    // 20 MB
           fullContentTimeoutSeconds: 60,

--- a/packages/openclaw-qveris-plugin/openclaw.plugin.json
+++ b/packages/openclaw-qveris-plugin/openclaw.plugin.json
@@ -17,9 +17,9 @@
       "sensitive": true,
       "placeholder": "qv-..."
     },
-    "region": {
-      "label": "QVeris Region",
-      "help": "API region: global (qveris.ai) or cn (qveris.cn)."
+    "baseUrl": {
+      "label": "QVeris API Base URL",
+      "help": "Optional explicit API endpoint (fallback: QVERIS_BASE_URL, then the public default)."
     }
   },
   "configSchema": {
@@ -27,7 +27,11 @@
     "additionalProperties": false,
     "properties": {
       "apiKey": { "type": ["string", "object"] },
-      "region": { "type": "string", "enum": ["global", "cn"] },
+      "region": {
+        "type": "string",
+        "deprecated": true,
+        "description": "Deprecated and rejected at runtime. Remove this field and set baseUrl or QVERIS_BASE_URL explicitly."
+      },
       "baseUrl": { "type": "string" },
       "autoMaterializeFullContent": { "type": "boolean" },
       "fullContentMaxBytes": { "type": "number" },

--- a/packages/openclaw-qveris-plugin/src/config.ts
+++ b/packages/openclaw-qveris-plugin/src/config.ts
@@ -1,12 +1,9 @@
 import { normalizeSecretInput } from "openclaw/plugin-sdk/provider-auth";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 
-export type QverisRegion = "global" | "cn";
+export const DEFAULT_QVERIS_BASE_URL = "https://qveris.ai/api/v1";
 
-export const QVERIS_REGION_DOMAINS: Record<QverisRegion, string> = {
-  global: "qveris.ai",
-  cn: "qveris.cn",
-};
+const QVERIS_PUBLIC_DOMAINS = ["qveris.ai", "qveris.cn"] as const;
 
 const DEFAULT_DISCOVER_TIMEOUT_SECONDS = 5;
 const DEFAULT_CALL_TIMEOUT_SECONDS = 60;
@@ -32,43 +29,63 @@ export function resolveQverisApiKey(pluginConfig: Record<string, unknown> | unde
   );
 }
 
-export function resolveQverisRegion(pluginConfig: Record<string, unknown> | undefined): QverisRegion {
-  return pluginConfig?.region === "cn" ? "cn" : "global";
+function hasOwn(config: Record<string, unknown> | undefined, key: string): boolean {
+  return config !== undefined && Object.prototype.hasOwnProperty.call(config, key);
 }
 
+function rejectLegacyRegion(pluginConfig: Record<string, unknown> | undefined): void {
+  if (hasOwn(pluginConfig, "region")) {
+    throw new Error("QVeris region is no longer supported; remove it and set baseUrl or QVERIS_BASE_URL explicitly");
+  }
+}
+
+function normalizeQverisBaseUrl(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error("QVeris API base URL must be a string");
+  }
+
+  const candidate = value.trim();
+  if (!candidate) {
+    throw new Error("QVeris API base URL must not be empty");
+  }
+  if (!/^https?:\/\/[^/?#\s\\]/i.test(candidate) || /\s/.test(candidate) || candidate.includes("\\")) {
+    throw new Error("QVeris API base URL must be a valid HTTP(S) URL");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    throw new Error("QVeris API base URL must be a valid HTTP(S) URL");
+  }
+
+  if (!new Set(["http:", "https:"]).has(url.protocol) || !url.hostname) {
+    throw new Error("QVeris API base URL must be a valid HTTP(S) URL");
+  }
+  if (url.username || url.password || candidate.includes("?") || candidate.includes("#")) {
+    throw new Error("QVeris API base URL must not contain credentials, a query, or a fragment");
+  }
+
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString().replace(/\/$/, "");
+}
+
+/** Priority: plugin config > QVERIS_BASE_URL > built-in default. */
 export function resolveQverisBaseUrl(pluginConfig: Record<string, unknown> | undefined): string {
-  const explicit = typeof pluginConfig?.baseUrl === "string" ? pluginConfig.baseUrl.trim() : "";
-  if (explicit) {
-    return explicit;
+  rejectLegacyRegion(pluginConfig);
+  if (hasOwn(pluginConfig, "baseUrl")) {
+    return normalizeQverisBaseUrl(pluginConfig?.baseUrl);
   }
-  const region = resolveQverisRegion(pluginConfig);
-  return `https://${QVERIS_REGION_DOMAINS[region]}/api/v1`;
+  if (typeof process.env.QVERIS_BASE_URL === "string") {
+    return normalizeQverisBaseUrl(process.env.QVERIS_BASE_URL);
+  }
+  return DEFAULT_QVERIS_BASE_URL;
 }
 
-/**
- * Returns the allowed domains for full-content downloads.
- * Includes the region domain plus the baseUrl domain if it resolves to a known QVeris domain.
- */
+/** Returns the trusted public QVeris domain matching the resolved API endpoint. */
 export function resolveFullContentAllowedDomains(pluginConfig: Record<string, unknown> | undefined): string[] {
-  const region = resolveQverisRegion(pluginConfig);
-  const domains = new Set<string>([QVERIS_REGION_DOMAINS[region]]);
-
-  const explicit = typeof pluginConfig?.baseUrl === "string" ? pluginConfig.baseUrl.trim() : "";
-  if (explicit) {
-    try {
-      const host = new URL(explicit).hostname.toLowerCase();
-      const allKnownDomains = Object.values(QVERIS_REGION_DOMAINS);
-      for (const d of allKnownDomains) {
-        if (host === d || host.endsWith(`.${d}`)) {
-          domains.add(d);
-        }
-      }
-    } catch {
-      // invalid baseUrl — ignore, region domain still in set
-    }
-  }
-
-  return [...domains];
+  const host = new URL(resolveQverisBaseUrl(pluginConfig)).hostname.toLowerCase();
+  return QVERIS_PUBLIC_DOMAINS.filter((domain) => host === domain || host.endsWith(`.${domain}`));
 }
 
 export function resolveDiscoverTimeoutSeconds(pluginConfig: Record<string, unknown> | undefined): number {

--- a/packages/openclaw-qveris-plugin/src/config.ts
+++ b/packages/openclaw-qveris-plugin/src/config.ts
@@ -29,12 +29,8 @@ export function resolveQverisApiKey(pluginConfig: Record<string, unknown> | unde
   );
 }
 
-function hasOwn(config: Record<string, unknown> | undefined, key: string): boolean {
-  return config !== undefined && Object.prototype.hasOwnProperty.call(config, key);
-}
-
 function rejectLegacyRegion(pluginConfig: Record<string, unknown> | undefined): void {
-  if (hasOwn(pluginConfig, "region")) {
+  if (pluginConfig?.region !== undefined && pluginConfig.region !== null) {
     throw new Error("QVeris region is no longer supported; remove it and set baseUrl or QVERIS_BASE_URL explicitly");
   }
 }
@@ -73,8 +69,8 @@ function normalizeQverisBaseUrl(value: unknown): string {
 /** Priority: plugin config > QVERIS_BASE_URL > built-in default. */
 export function resolveQverisBaseUrl(pluginConfig: Record<string, unknown> | undefined): string {
   rejectLegacyRegion(pluginConfig);
-  if (hasOwn(pluginConfig, "baseUrl")) {
-    return normalizeQverisBaseUrl(pluginConfig?.baseUrl);
+  if (pluginConfig?.baseUrl !== undefined && pluginConfig.baseUrl !== null) {
+    return normalizeQverisBaseUrl(pluginConfig.baseUrl);
   }
   if (typeof process.env.QVERIS_BASE_URL === "string") {
     return normalizeQverisBaseUrl(process.env.QVERIS_BASE_URL);

--- a/packages/openclaw-qveris-plugin/src/qveris-config.test.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-config.test.ts
@@ -75,6 +75,11 @@ describe("config resolution", () => {
     expect(resolveQverisBaseUrl({ baseUrl: "https://config.example/api/v1" })).toBe("https://config.example/api/v1");
   });
 
+  it.each([undefined, null])("treats an optional baseUrl value of %s as unset", (baseUrl) => {
+    vi.stubEnv("QVERIS_BASE_URL", "https://env.example/api/v1");
+    expect(resolveQverisBaseUrl({ baseUrl })).toBe("https://env.example/api/v1");
+  });
+
   it("does not derive the endpoint from API key metadata", () => {
     expect(resolveQverisBaseUrl({ apiKey: "sk-cn-example" })).toBe(DEFAULT_QVERIS_BASE_URL);
   });
@@ -87,6 +92,10 @@ describe("config resolution", () => {
 
   it.each(["global", "cn"])("rejects the legacy region setting %s with migration guidance", (region) => {
     expect(() => resolveQverisBaseUrl({ region })).toThrow(/region is no longer supported.*baseUrl.*QVERIS_BASE_URL/);
+  });
+
+  it.each([undefined, null])("treats an optional legacy region value of %s as unset", (region) => {
+    expect(resolveQverisBaseUrl({ region })).toBe(DEFAULT_QVERIS_BASE_URL);
   });
 
   it.each([

--- a/packages/openclaw-qveris-plugin/src/qveris-config.test.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-config.test.ts
@@ -1,13 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
 import {
+  DEFAULT_QVERIS_BASE_URL,
   resolveQverisApiKey,
   resolveQverisBaseUrl,
-  resolveQverisRegion,
   resolveDiscoverTimeoutSeconds,
   resolveCallTimeoutSeconds,
   resolveFullContentAllowedDomains,
-  QVERIS_REGION_DOMAINS,
 } from "./config.js";
 import { createQverisTools } from "./qveris-tools.js";
 
@@ -57,25 +56,51 @@ describe("config resolution", () => {
     expect(tools).toBeNull();
   });
 
-  it("resolves global region by default", () => {
-    expect(resolveQverisRegion(undefined)).toBe("global");
-    expect(resolveQverisRegion({})).toBe("global");
+  it("uses the built-in base URL by default", () => {
+    expect(resolveQverisBaseUrl(undefined)).toBe(DEFAULT_QVERIS_BASE_URL);
   });
 
-  it("resolves cn region when configured", () => {
-    expect(resolveQverisRegion({ region: "cn" })).toBe("cn");
+  it("uses QVERIS_BASE_URL when no plugin override is configured", () => {
+    vi.stubEnv("QVERIS_BASE_URL", "https://proxy.example/qveris/");
+    expect(resolveQverisBaseUrl(undefined)).toBe("https://proxy.example/qveris");
   });
 
-  it("builds global base URL from region domain", () => {
-    expect(resolveQverisBaseUrl(undefined)).toBe(`https://${QVERIS_REGION_DOMAINS.global}/api/v1`);
+  it("validates QVERIS_BASE_URL instead of silently falling back", () => {
+    vi.stubEnv("QVERIS_BASE_URL", "");
+    expect(() => resolveQverisBaseUrl(undefined)).toThrow(/must not be empty/);
   });
 
-  it("builds cn base URL from region", () => {
-    expect(resolveQverisBaseUrl({ region: "cn" })).toBe(`https://${QVERIS_REGION_DOMAINS.cn}/api/v1`);
+  it("prefers plugin baseUrl over QVERIS_BASE_URL", () => {
+    vi.stubEnv("QVERIS_BASE_URL", "https://env.example/api/v1");
+    expect(resolveQverisBaseUrl({ baseUrl: "https://config.example/api/v1" })).toBe("https://config.example/api/v1");
   });
 
-  it("uses explicit baseUrl when provided", () => {
-    expect(resolveQverisBaseUrl({ baseUrl: "https://proxy.example/qveris" })).toBe("https://proxy.example/qveris");
+  it("does not derive the endpoint from API key metadata", () => {
+    expect(resolveQverisBaseUrl({ apiKey: "sk-cn-example" })).toBe(DEFAULT_QVERIS_BASE_URL);
+  });
+
+  it("normalizes surrounding whitespace and trailing slashes", () => {
+    expect(resolveQverisBaseUrl({ baseUrl: "  https://proxy.example/qveris///  " })).toBe(
+      "https://proxy.example/qveris",
+    );
+  });
+
+  it.each(["global", "cn"])("rejects the legacy region setting %s with migration guidance", (region) => {
+    expect(() => resolveQverisBaseUrl({ region })).toThrow(/region is no longer supported.*baseUrl.*QVERIS_BASE_URL/);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["non-string", 42],
+    ["unsupported scheme", "ftp://qveris.ai/api/v1"],
+    ["protocol-relative", "//qveris.ai/api/v1"],
+    ["whitespace", "https://qveris.ai/a b"],
+    ["backslash", "https://qveris.ai\\api\\v1"],
+    ["credentials", "https://user:pass@qveris.ai/api/v1"],
+    ["query", "https://qveris.ai/api/v1?mode=test"],
+    ["fragment", "https://qveris.ai/api/v1#test"],
+  ])("rejects an invalid %s base URL", (_label, baseUrl) => {
+    expect(() => resolveQverisBaseUrl({ baseUrl })).toThrow(/QVeris API base URL/);
   });
 
   it("resolveDiscoverTimeoutSeconds returns default when not set", () => {
@@ -94,37 +119,20 @@ describe("config resolution", () => {
     expect(resolveCallTimeoutSeconds({ executeTimeoutSeconds: 120 })).toBe(120);
   });
 
-  it("full-content allowed domains includes region domain", () => {
-    const domains = resolveFullContentAllowedDomains(undefined);
-    expect(domains).toContain(QVERIS_REGION_DOMAINS.global);
+  it("allows the public domain matching the default endpoint", () => {
+    expect(resolveFullContentAllowedDomains(undefined)).toEqual(["qveris.ai"]);
   });
 
-  it("full-content allowed domains for cn region contains qveris.cn only", () => {
-    const domains = resolveFullContentAllowedDomains({ region: "cn" });
-    expect(domains).toContain(QVERIS_REGION_DOMAINS.cn);
-    expect(domains).not.toContain(QVERIS_REGION_DOMAINS.global);
+  it("allows the public domain matching QVERIS_BASE_URL", () => {
+    vi.stubEnv("QVERIS_BASE_URL", "https://qveris.cn/api/v1");
+    expect(resolveFullContentAllowedDomains(undefined)).toEqual(["qveris.cn"]);
   });
 
-  it("full-content allowed domains extends to baseUrl qveris domain", () => {
-    const domains = resolveFullContentAllowedDomains({
-      region: "global",
-      baseUrl: "https://qveris.cn/api/v1",
-    });
-    expect(domains).toContain(QVERIS_REGION_DOMAINS.global);
-    expect(domains).toContain(QVERIS_REGION_DOMAINS.cn);
+  it("allows the parent public domain for an explicit subdomain endpoint", () => {
+    expect(resolveFullContentAllowedDomains({ baseUrl: "https://api.qveris.cn/api/v1" })).toEqual(["qveris.cn"]);
   });
 
-  it("subdomain of region domain is allowed for cn region", () => {
-    const domains = resolveFullContentAllowedDomains({ region: "cn" });
-    const ossHostname = `oss.${QVERIS_REGION_DOMAINS.cn}`;
-    const allowed = domains.some((d) => ossHostname === d || ossHostname.endsWith(`.${d}`));
-    expect(allowed).toBe(true);
-  });
-
-  it("subdomain of region domain is allowed for global region", () => {
-    const domains = resolveFullContentAllowedDomains(undefined);
-    const ossHostname = `oss.${QVERIS_REGION_DOMAINS.global}`;
-    const allowed = domains.some((d) => ossHostname === d || ossHostname.endsWith(`.${d}`));
-    expect(allowed).toBe(true);
+  it("does not expand full-content trust for an unknown custom endpoint", () => {
+    expect(resolveFullContentAllowedDomains({ baseUrl: "https://proxy.example/qveris" })).toEqual([]);
   });
 });

--- a/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
@@ -1093,7 +1093,7 @@ describe("qveris_call materialization", () => {
     expect(analysis?.column_names).toEqual(["name", "age", "city"]);
   });
 
-  it("cn region routes API calls to qveris.cn and accepts oss.qveris.cn materialization URL", async () => {
+  it("an explicit baseUrl routes API calls and scopes full-content materialization", async () => {
     const CN_OSS_URL = "https://oss.qveris.cn/full-content/exec-cn-1.json";
     const cnInvokeResponse = {
       execution_id: "exec-cn-1",
@@ -1157,7 +1157,11 @@ describe("qveris_call materialization", () => {
     globalThis.fetch = fetchMock;
 
     const tools = createQverisTools({
-      api: fakeApi({ apiKey: "qv_test_key", region: "cn", autoMaterializeFullContent: true }),
+      api: fakeApi({
+        apiKey: "qv_test_key",
+        baseUrl: "https://qveris.cn/api/v1",
+        autoMaterializeFullContent: true,
+      }),
       ctx: fakeCtx({ workspaceDir: tmpDir }),
     });
 
@@ -1168,14 +1172,14 @@ describe("qveris_call materialization", () => {
     const result = await callTool.execute("c1", { tool_id: "cn-tool-x", params_to_tool: '{"q":"test"}' });
     const parsed = parseToolResult(result);
 
-    // All API calls must go to qveris.cn, not qveris.ai
+    // All API calls must use the explicit endpoint.
     const apiCalls = observedApiUrls.filter((u) => u.includes("/search") || u.includes("/tools/execute"));
     for (const apiUrl of apiCalls) {
       expect(apiUrl).toContain("qveris.cn");
       expect(apiUrl).not.toContain("qveris.ai");
     }
 
-    // Materialization from oss.qveris.cn must succeed
+    // Materialization from the endpoint's trusted public domain must succeed.
     expect(parsed.success).toBe(true);
     const mc = parsed.materialized_content as Record<string, unknown>;
     expect(mc.status).toBe("ready");


### PR DESCRIPTION
## Summary

- resolve endpoints as config.baseUrl, then QVERIS_BASE_URL, then the built-in public default
- validate and normalize endpoint overrides consistently with the other toolkit clients
- stop API keys and the legacy region setting from changing the endpoint
- formally deprecate region with an actionable migration error and remove it from the plugin UI
- scope full-content trust to the public domain matching the resolved endpoint
- make the package README global-facing and document the final precedence

## Why

OpenClaw still used region-derived routing after the other clients moved to deterministic endpoint configuration. Its runtime, manifest, and public documentation therefore described different behavior.

## Impact

Endpoint selection is explicit and predictable. Existing region configurations fail with migration guidance instead of silently connecting to another service. Unsafe URLs are rejected before requests are sent.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage` (74 tests)
- `NPM_CONFIG_OFFLINE=true npm run check:pack`
- public documentation region-boundary scans
- `git diff --check`

Stacked on #214.

Closes #206.
