### PR TITLE
Add global Codex and ChatGPT desktop setup docs

### DIFF
--- a/.github/workflows/sync-docs-to-website.yml
+++ b/.github/workflows/sync-docs-to-website.yml
@@ -26,6 +26,8 @@ on:
       - "docs/cn/zh-CN/ide-cli-setup.md"
       - "docs/en-US/claude-code-setup.md"
       - "docs/zh-CN/claude-code-setup.md"
+      - "docs/en-US/codex-setup.md"
+      - "docs/zh-CN/codex-setup.md"
       - "docs/en-US/opencode-setup.md"
       - "docs/zh-CN/opencode-setup.md"
       - "docs/cn/zh-CN/opencode-setup.md"

--- a/docs/en-US/codex-setup.md
+++ b/docs/en-US/codex-setup.md
@@ -68,7 +68,7 @@ Codex detects skills in `~/.agents/skills`. If the skill does not appear, restar
 **The server does not start:**
 
 - Verify Node.js: `node --version`
-- Run the server directly: `npx -y @qverisai/mcp`
+- Run the server directly: `QVERIS_API_KEY=your-api-key-here npx -y @qverisai/mcp`
 - Check that the API key is current and has no extra spaces
 
 **The skill does not appear:**

--- a/docs/en-US/codex-setup.md
+++ b/docs/en-US/codex-setup.md
@@ -1,0 +1,81 @@
+# Codex and ChatGPT Desktop Setup
+
+This guide configures the QVeris MCP server and skill for the ChatGPT desktop app, Codex CLI, and the Codex IDE extension. These local clients share the same Codex MCP configuration. ChatGPT on the web does not read local Codex configuration; it requires a separately hosted plugin or remote MCP integration.
+
+## Prerequisites
+
+- Node.js 18.2 or later
+- The ChatGPT desktop app, Codex CLI, or Codex IDE extension
+- A QVeris API key (create one in [Dashboard / API Keys](/account?page=api-keys))
+
+## 1. Add the QVeris MCP server
+
+Run the following command in a terminal, replacing `your-api-key-here` with your API key:
+
+```bash
+codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here -- npx -y @qverisai/mcp
+```
+
+QVeris automatically uses `https://qveris.ai/api/v1` for this setup. If you need to make the endpoint explicit, add it as another environment variable:
+
+```bash
+codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
+```
+
+The ChatGPT desktop app, Codex CLI, and IDE extension read this server from `~/.codex/config.toml`, so you only need to add it once. You can also add the same STDIO server from **Settings → MCP servers** in the desktop app or IDE extension. See the official [MCP configuration guide](https://learn.chatgpt.com/docs/extend/mcp) for client-specific steps.
+
+### Manual configuration
+
+Alternatively, add the following to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.qveris]
+command = "npx"
+args = ["-y", "@qverisai/mcp"]
+
+[mcp_servers.qveris.env]
+QVERIS_API_KEY = "your-api-key-here"
+```
+
+## 2. Install the QVeris skill
+
+Install the QVeris skill for your user account:
+
+**macOS and Linux:**
+
+```bash
+mkdir -p ~/.agents/skills/qveris
+curl -sL https://raw.githubusercontent.com/QVerisAI/qveris-agent-toolkit/main/skills/qveris/SKILL.md -o ~/.agents/skills/qveris/SKILL.md
+```
+
+**Windows PowerShell:**
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills\qveris"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/QVerisAI/qveris-agent-toolkit/main/skills/qveris/SKILL.md" -OutFile "$env:USERPROFILE\.agents\skills\qveris\SKILL.md"
+```
+
+Codex detects skills in `~/.agents/skills`. If the skill does not appear, restart the client. See the official [skills guide](https://learn.chatgpt.com/docs/build-skills) for supported locations and invocation methods.
+
+## Verification
+
+1. Run `codex mcp list` and confirm that `qveris` is enabled.
+2. In the ChatGPT desktop app or Codex terminal UI, enter `/mcp` and confirm that QVeris tools are connected.
+3. Ask Codex to use QVeris to discover a tool. You can explicitly invoke the skill by typing `$qveris` in your prompt.
+
+## Troubleshooting
+
+**The server does not start:**
+
+- Verify Node.js: `node --version`
+- Run the server directly: `npx -y @qverisai/mcp`
+- Check that the API key is current and has no extra spaces
+
+**The skill does not appear:**
+
+- Confirm that the file is at `~/.agents/skills/qveris/SKILL.md`
+- Restart the ChatGPT desktop app, Codex CLI, or IDE extension
+
+**ChatGPT web does not show QVeris:**
+
+- Local `config.toml` and STDIO servers are not available to ChatGPT on the web. Use one of the local clients listed above until a hosted QVeris plugin or remote MCP integration is published.

--- a/docs/en-US/ide-cli-setup.md
+++ b/docs/en-US/ide-cli-setup.md
@@ -10,6 +10,10 @@ For GUI IDEs, follow the instructions on the [Plugins page](/plugins) to install
 
 For CLI coding tools, follow the instructions at the following corresponding pages.
 
+- [Codex and ChatGPT desktop](codex-setup.md)
+- [Claude Code](claude-code-setup.md)
+- [OpenCode](opencode-setup.md)
+
 ## Automated Setup with Coding Agents
 
 You can also tell your coding agents to set it up for you. Simply provide them with the configuration guide URL and your API key:
@@ -21,6 +25,11 @@ Configure this for me <THE_URL_TO_CONFIGURATION_GUIDE>. The API key is <YOUR_API
 Most capable coding agents can finish the setup and resolve issues automatically.
 
 ### Example
+
+For Codex:
+```
+Configure this for me https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/codex-setup.md. The API key is sk-xxxxxxxxxxxxx
+```
 
 For Claude Code:
 ```

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -132,6 +132,7 @@ qveris mcp validate --target cursor --probe
 For environment-specific setup guides, see:
 
 - [SETUP.md](../../agent/SETUP.md)
+- [Codex and ChatGPT desktop setup](codex-setup.md)
 - [Claude Code setup](claude-code-setup.md)
 - [OpenCode setup](opencode-setup.md)
 - [IDE / CLI setup](ide-cli-setup.md)

--- a/docs/zh-CN/codex-setup.md
+++ b/docs/zh-CN/codex-setup.md
@@ -1,0 +1,81 @@
+# Codex 与 ChatGPT 桌面端配置指南
+
+本指南介绍如何为 ChatGPT 桌面端、Codex CLI 和 Codex IDE 扩展配置 QVeris MCP 服务器与技能。这些本地客户端共享同一份 Codex MCP 配置。ChatGPT 网页版不会读取本地 Codex 配置；网页版需要单独提供托管插件或远程 MCP 集成。
+
+## 前置条件
+
+- Node.js 18.2 或更高版本
+- 已安装 ChatGPT 桌面端、Codex CLI 或 Codex IDE 扩展
+- QVeris API 密钥（在[控制台/API 密钥](/account?page=api-keys)中创建）
+
+## 1. 添加 QVeris MCP 服务器
+
+在终端运行以下命令，并将 `your-api-key-here` 替换为你的 API 密钥：
+
+```bash
+codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here -- npx -y @qverisai/mcp
+```
+
+此配置会自动使用 `https://qveris.ai/api/v1`。如果需要显式指定端点，可以再传入一个环境变量：
+
+```bash
+codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
+```
+
+ChatGPT 桌面端、Codex CLI 和 IDE 扩展都会从 `~/.codex/config.toml` 读取该服务器，因此只需添加一次。也可以在桌面端或 IDE 扩展的 **Settings → MCP servers** 中添加同一个 STDIO 服务器。不同客户端的详细步骤请参考官方 [MCP 配置文档](https://learn.chatgpt.com/docs/extend/mcp)。
+
+### 手动配置
+
+也可以在 `~/.codex/config.toml` 中添加：
+
+```toml
+[mcp_servers.qveris]
+command = "npx"
+args = ["-y", "@qverisai/mcp"]
+
+[mcp_servers.qveris.env]
+QVERIS_API_KEY = "your-api-key-here"
+```
+
+## 2. 安装 QVeris 技能
+
+为当前用户安装 QVeris 技能：
+
+**macOS 和 Linux：**
+
+```bash
+mkdir -p ~/.agents/skills/qveris
+curl -sL https://raw.githubusercontent.com/QVerisAI/qveris-agent-toolkit/main/skills/qveris/SKILL.md -o ~/.agents/skills/qveris/SKILL.md
+```
+
+**Windows PowerShell：**
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills\qveris"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/QVerisAI/qveris-agent-toolkit/main/skills/qveris/SKILL.md" -OutFile "$env:USERPROFILE\.agents\skills\qveris\SKILL.md"
+```
+
+Codex 会自动发现 `~/.agents/skills` 中的技能。如果技能没有出现，请重启客户端。支持的目录和调用方式请参考官方[技能文档](https://learn.chatgpt.com/docs/build-skills)。
+
+## 验证
+
+1. 运行 `codex mcp list`，确认 `qveris` 已启用。
+2. 在 ChatGPT 桌面端或 Codex 终端界面中输入 `/mcp`，确认 QVeris 工具已连接。
+3. 让 Codex 使用 QVeris 发现工具。也可以在提示词中输入 `$qveris` 显式调用该技能。
+
+## 故障排查
+
+**服务器无法启动：**
+
+- 检查 Node.js：`node --version`
+- 直接运行服务器：`npx -y @qverisai/mcp`
+- 检查 API 密钥是否有效，且首尾没有多余空格
+
+**技能没有出现：**
+
+- 确认文件位于 `~/.agents/skills/qveris/SKILL.md`
+- 重启 ChatGPT 桌面端、Codex CLI 或 IDE 扩展
+
+**ChatGPT 网页版没有显示 QVeris：**
+
+- ChatGPT 网页版无法访问本地 `config.toml` 和 STDIO 服务器。在 QVeris 发布托管插件或远程 MCP 集成前，请使用上文列出的本地客户端。

--- a/docs/zh-CN/codex-setup.md
+++ b/docs/zh-CN/codex-setup.md
@@ -68,7 +68,7 @@ Codex 会自动发现 `~/.agents/skills` 中的技能。如果技能没有出现
 **服务器无法启动：**
 
 - 检查 Node.js：`node --version`
-- 直接运行服务器：`npx -y @qverisai/mcp`
+- 直接运行服务器：`QVERIS_API_KEY=your-api-key-here npx -y @qverisai/mcp`
 - 检查 API 密钥是否有效，且首尾没有多余空格
 
 **技能没有出现：**

--- a/docs/zh-CN/ide-cli-setup.md
+++ b/docs/zh-CN/ide-cli-setup.md
@@ -10,6 +10,10 @@ QVeris 已集成到多种 IDE 和 CLI 编程工具中。通过自动配置 QVeri
 
 对于 CLI 编程工具，请访问以下对应页面查看配置说明。
 
+- [Codex 与 ChatGPT 桌面端](codex-setup.md)
+- [Claude Code](claude-code-setup.md)
+- [OpenCode](opencode-setup.md)
+
 ## 通过编程智能体自动配置
 
 你也可以让编程智能体代为完成配置。只需将配置指南链接和你的 API 密钥提供给智能体：
@@ -21,6 +25,11 @@ QVeris 已集成到多种 IDE 和 CLI 编程工具中。通过自动配置 QVeri
 大多数有能力的编程智能体都能自动完成配置并解决遇到的问题。
 
 ### 示例
+
+Codex：
+```
+请按照 https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/codex-setup.md 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
+```
 
 Claude Code：
 ```

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -132,6 +132,7 @@ qveris mcp validate --target cursor --probe
 各环境的详细配置指南，请参考：
 
 - [智能体安装指南](../../agent/SETUP.md)
+- [Codex 与 ChatGPT 桌面端配置](codex-setup.md)
 - [Claude Code 配置](claude-code-setup.md)
 - [OpenCode 配置](opencode-setup.md)
 - [IDE / CLI 配置](ide-cli-setup.md)

--- a/scripts/check-doc-locales.mjs
+++ b/scripts/check-doc-locales.mjs
@@ -13,7 +13,9 @@
 //
 // Warnings (exit 0):
 //   - Files in zh-CN with no China-region variant in docs/cn/zh-CN. The region
-//     variant is intentionally a subset, so this is reported, not enforced.
+//     variant is intentionally a subset, so unclassified gaps are reported.
+//   - Products that are intentionally unavailable on the China-facing site are
+//     allowlisted and must remain absent there.
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -24,6 +26,10 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
 const EN = 'docs/en-US';
 const ZH = 'docs/zh-CN';
 const CN = 'docs/cn/zh-CN';
+const CN_INTENTIONAL_OMISSIONS = new Set([
+  'claude-code-setup.md',
+  'codex-setup.md',
+]);
 
 function mdFiles(rel) {
   const dir = path.resolve(REPO_ROOT, rel);
@@ -47,7 +53,16 @@ if (!en || !zh) {
 
 if (cn && zh) {
   for (const f of cn) if (!zh.has(f)) errors.push(`${CN}/${f} has no base file in ${ZH} (orphan region variant)`);
-  for (const f of zh) if (!cn.has(f)) warnings.push(`${ZH}/${f} has no China-region variant in ${CN}`);
+  for (const f of zh) {
+    if (!cn.has(f) && !CN_INTENTIONAL_OMISSIONS.has(f)) {
+      warnings.push(`${ZH}/${f} has no China-region variant in ${CN}`);
+    }
+  }
+
+  for (const f of CN_INTENTIONAL_OMISSIONS) {
+    if (!zh.has(f)) errors.push(`${f} is allowlisted as a China-facing omission but has no base file in ${ZH}`);
+    if (cn.has(f)) errors.push(`${CN}/${f} must remain absent (intentional China-facing omission)`);
+  }
 }
 
 for (const w of warnings) console.warn(`warning: ${w}`);
@@ -59,4 +74,4 @@ if (errors.length > 0) {
 }
 
 const counts = [en && `${EN}=${en.size}`, zh && `${ZH}=${zh.size}`, cn && `${CN}=${cn.size}`].filter(Boolean);
-console.log(`Locales consistent (${counts.join(', ')}); ${warnings.length} region-variant gap(s) reported.`);
+console.log(`Locales consistent (${counts.join(', ')}); ${warnings.length} unclassified region-variant gap(s), ${CN_INTENTIONAL_OMISSIONS.size} intentional omission(s).`);

--- a/skills/qveris/SKILL.md
+++ b/skills/qveris/SKILL.md
@@ -3,7 +3,7 @@ name: qveris
 description: "Discover, inspect, and call third-party API capabilities via the QVeris MCP server, then generate production code that calls the QVeris REST API for tasks like fetching weather data, stock prices, or public datasets. Use when the user needs to find an external API, integrate a web service, connect to a third-party REST endpoint, or retrieve data from an external source."
 ---
 
-For discovery query formulation, tool selection criteria, parameter handling, and error recovery, see [Agent Guidelines](../../agent/GUIDELINES.md).
+For more detailed discovery query formulation, tool selection criteria, parameter handling, and error recovery, see the [Agent Guidelines](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/GUIDELINES.md).
 
 When external functionality is needed, follow this two-phase workflow:
 


### PR DESCRIPTION
## Summary

- add matching global English and global Chinese setup pages for the ChatGPT desktop app, Codex CLI, and the Codex IDE extension
- document QVeris MCP and skill setup using the shared Codex configuration
- add the new pages to global setup navigation and the website sync trigger
- explicitly enforce that Codex and Claude Code setup pages remain absent from the China-facing docs

## Verification

- `node scripts/check-doc-locales.mjs`
- `git diff --check`
- region-boundary scans from `AGENTS.md` (remaining historical/OpenClaw hits are outside this change and are handled separately)
- verified MCP commands and configuration semantics against the current official product documentation and local CLI help

## Tracking

Part of #162. The issue remains open because it tracks additional documentation work.