### PR TITLE
Fix coding-agent docs sync links

### DIFF
--- a/docs/en-US/ide-cli-setup.md
+++ b/docs/en-US/ide-cli-setup.md
@@ -10,7 +10,7 @@ For GUI IDEs, follow the instructions on the [Plugins page](/plugins) to install
 
 For CLI coding tools, follow the instructions at the following corresponding pages.
 
-- [Codex and ChatGPT desktop](codex-setup.md)
+- [Codex and ChatGPT desktop](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/codex-setup.md)
 - [Claude Code](claude-code-setup.md)
 - [OpenCode](opencode-setup.md)
 
@@ -28,15 +28,15 @@ Most capable coding agents can finish the setup and resolve issues automatically
 
 For Codex:
 ```
-Configure this for me https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/codex-setup.md. The API key is sk-xxxxxxxxxxxxx
+Configure this for me <https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/codex-setup.md>. The API key is sk-xxxxxxxxxxxxx
 ```
 
 For Claude Code:
 ```
-Configure this for me https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/claude-code-setup.md. The API key is sk-xxxxxxxxxxxxx
+Configure this for me <https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/claude-code-setup.md>. The API key is sk-xxxxxxxxxxxxx
 ```
 
 For OpenCode:
 ```
-Configure this for me https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/opencode-setup.md. The API key is sk-xxxxxxxxxxxxx
+Configure this for me <https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/opencode-setup.md>. The API key is sk-xxxxxxxxxxxxx
 ```

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -132,7 +132,7 @@ qveris mcp validate --target cursor --probe
 For environment-specific setup guides, see:
 
 - [SETUP.md](../../agent/SETUP.md)
-- [Codex and ChatGPT desktop setup](codex-setup.md)
+- [Codex and ChatGPT desktop setup](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/codex-setup.md)
 - [Claude Code setup](claude-code-setup.md)
 - [OpenCode setup](opencode-setup.md)
 - [IDE / CLI setup](ide-cli-setup.md)

--- a/docs/zh-CN/ide-cli-setup.md
+++ b/docs/zh-CN/ide-cli-setup.md
@@ -10,7 +10,7 @@ QVeris 已集成到多种 IDE 和 CLI 编程工具中。通过自动配置 QVeri
 
 对于 CLI 编程工具，请访问以下对应页面查看配置说明。
 
-- [Codex 与 ChatGPT 桌面端](codex-setup.md)
+- [Codex 与 ChatGPT 桌面端](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/codex-setup.md)
 - [Claude Code](claude-code-setup.md)
 - [OpenCode](opencode-setup.md)
 
@@ -28,15 +28,15 @@ QVeris 已集成到多种 IDE 和 CLI 编程工具中。通过自动配置 QVeri
 
 Codex：
 ```
-请按照 https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/codex-setup.md 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
+请按照 <https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/codex-setup.md> 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
 ```
 
 Claude Code：
 ```
-请按照 https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/claude-code-setup.md 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
+请按照 <https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/claude-code-setup.md> 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
 ```
 
 OpenCode：
 ```
-请按照 https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/opencode-setup.md 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
+请按照 <https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/opencode-setup.md> 帮我完成配置。API 密钥是 sk-xxxxxxxxxxxxx
 ```

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -132,7 +132,7 @@ qveris mcp validate --target cursor --probe
 各环境的详细配置指南，请参考：
 
 - [智能体安装指南](../../agent/SETUP.md)
-- [Codex 与 ChatGPT 桌面端配置](codex-setup.md)
+- [Codex 与 ChatGPT 桌面端配置](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/codex-setup.md)
 - [Claude Code 配置](claude-code-setup.md)
 - [OpenCode 配置](opencode-setup.md)
 - [IDE / CLI 配置](ide-cli-setup.md)


### PR DESCRIPTION
## Summary

- replace relative Codex setup links in synced English and Chinese docs with authoritative toolkit URLs
- wrap all copy-paste coding-agent guide URLs in angle brackets so trailing punctuation is not parsed as part of the URL

## Why

The website docs sync does not mirror `codex-setup.md`, so relative links added by the toolkit generated missing website routes. The new Codex prompt example also placed a period directly after a bare URL, which some automated consumers may include in the URL.

## Impact

The next toolkit-to-website sync will link readers to the existing toolkit setup guides instead of missing website pages. English and Chinese prompt examples now use unambiguous URL boundaries.

## Validation

- `node scripts/check-doc-locales.mjs`
- downstream `node scripts/sync-docs.mjs --from-toolkit`
- downstream `node scripts/sync-docs.mjs --check --toolkit-dir ...`
- targeted checks for stale relative `codex-setup.md` links and bare prompt URLs
- `git diff --check`
- public documentation region-boundary scans (only historical changelog references matched)

The website-wide link checker still reports existing allowlist gaps in `getting-started.md` and `js-sdk.md`; none are in the four changed files.

Source fix for review feedback on WonderfulValley/qveris-website#1776.
