### PR TITLE
Narrow the docs sync review fix

### DIFF
--- a/docs/en-US/ide-cli-setup.md
+++ b/docs/en-US/ide-cli-setup.md
@@ -10,7 +10,7 @@ For GUI IDEs, follow the instructions on the [Plugins page](/plugins) to install
 
 For CLI coding tools, follow the instructions at the following corresponding pages.
 
-- [Codex and ChatGPT desktop](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/codex-setup.md)
+- [Codex and ChatGPT desktop](codex-setup.md)
 - [Claude Code](claude-code-setup.md)
 - [OpenCode](opencode-setup.md)
 

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -132,7 +132,7 @@ qveris mcp validate --target cursor --probe
 For environment-specific setup guides, see:
 
 - [SETUP.md](../../agent/SETUP.md)
-- [Codex and ChatGPT desktop setup](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/codex-setup.md)
+- [Codex and ChatGPT desktop setup](codex-setup.md)
 - [Claude Code setup](claude-code-setup.md)
 - [OpenCode setup](opencode-setup.md)
 - [IDE / CLI setup](ide-cli-setup.md)

--- a/docs/zh-CN/ide-cli-setup.md
+++ b/docs/zh-CN/ide-cli-setup.md
@@ -10,7 +10,7 @@ QVeris 已集成到多种 IDE 和 CLI 编程工具中。通过自动配置 QVeri
 
 对于 CLI 编程工具，请访问以下对应页面查看配置说明。
 
-- [Codex 与 ChatGPT 桌面端](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/codex-setup.md)
+- [Codex 与 ChatGPT 桌面端](codex-setup.md)
 - [Claude Code](claude-code-setup.md)
 - [OpenCode](opencode-setup.md)
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -132,7 +132,7 @@ qveris mcp validate --target cursor --probe
 各环境的详细配置指南，请参考：
 
 - [智能体安装指南](../../agent/SETUP.md)
-- [Codex 与 ChatGPT 桌面端配置](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/zh-CN/codex-setup.md)
+- [Codex 与 ChatGPT 桌面端配置](codex-setup.md)
 - [Claude Code 配置](claude-code-setup.md)
 - [OpenCode 配置](opencode-setup.md)
 - [IDE / CLI 配置](ide-cli-setup.md)


### PR DESCRIPTION
## Summary

- restore relative setup links in the English and Chinese IDE/CLI and MCP guides
- retain angle brackets around every copy-paste prompt URL for reliable agent parsing

## Why

PR #218 over-corrected website review feedback by replacing relative documentation links with absolute GitHub URLs. Its angle-bracket formatting for prompt URLs is retained because it prevents trailing punctuation from being parsed as part of a URL and matches the documented prompt template. The website now has a separate route PR, WonderfulValley/qveris-website#1772, for the missing Codex page. Once that route is present, relative links are the correct hosted-navigation behavior.

Merge dependency: website #1772 should land first. It adds both `docs/en-US/codex-setup.md` and `docs/zh-CN/codex-setup.md` to `sources.toolkit_owned.paths`, checks in the synced documents, and registers `/docs/codex-setup`.

Relative to current `main`, this corrective PR changes exactly one navigation link in each of four documents. It does not change prompt formatting.

## Impact

Future toolkit-to-website syncs retain consistent relative documentation navigation and unambiguous URL boundaries in every copy-paste prompt.

## Validation

- `node scripts/check-doc-locales.mjs`
- downstream `node scripts/sync-docs.mjs --from-toolkit`
- downstream `node scripts/sync-docs.mjs --check --toolkit-dir ...`
- `git diff --check`
- public documentation region-boundary scans (only historical changelog references matched)
- comparison against current `main`: four relative-link restorations only
