### PR TITLE
Release OpenClaw plugin 2026.7.15

### DIFF
--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+## [2026.7.15] - 2026-07-15
+
 ### Changed
 
 - Endpoint selection now uses `config.baseUrl`, then `QVERIS_BASE_URL`, then the built-in default. API keys and the deprecated `region` setting never reroute requests; unsafe endpoint overrides are rejected. ([#206])
@@ -29,7 +31,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 - First published build with compiled `dist/` output. ([#90])
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.6.4...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.15...HEAD
+[2026.7.15]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.6.4...qveris-plugin-v2026.7.15
 [2026.6.4]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/qveris-plugin-v2026.6.4
 [#206]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/206
 [#210]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/210

--- a/packages/openclaw-qveris-plugin/package-lock.json
+++ b/packages/openclaw-qveris-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.6.4",
+  "version": "2026.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/qveris",
-      "version": "2026.6.4",
+      "version": "2026.7.15",
       "dependencies": {
         "@sinclair/typebox": "0.34.50"
       },

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.6.4",
+  "version": "2026.7.15",
   "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- release `@qverisai/qveris` as `2026.7.15`
- move the accumulated OpenClaw changes from Unreleased into a dated changelog section
- synchronize `package.json` and `package-lock.json`

This release includes the deterministic endpoint behavior tracked by #206, the OpenClaw compatibility updates, and the audited test/build toolchain changes already merged into `main`.

## Validation

- lint and formatting checks
- TypeScript typecheck
- 78 unit tests
- coverage: 93.19% statements, 77.24% branches, 96.07% functions
- offline build and package-content validation (19 files)
- package and lockfile version consistency check
- public documentation region-boundary scan; only intentional historical changelog entries remain

## After merge

Create and push the annotated tag `qveris-plugin-v2026.7.15`, monitor the publish workflow, and verify the npm version, provenance, GitHub Release, and installed endpoint behavior before closing #206.
