### PR TITLE
Make CLI recovery hints endpoint-aware

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- Account and pricing recovery hints now follow the resolved API endpoint for the public sites and custom deployments instead of linking to an unrelated site. ([#221])
+
 ## [0.8.0] - 2026-07-14
 
 ### Changed
@@ -79,6 +83,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.2.0...cli-v0.3.0
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.1.0...cli-v0.2.0
 [0.1.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/cli-v0.1.0
+[#221]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/221
 [#204]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/204
 [#161]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/161
 [#144]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/144

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -1,4 +1,4 @@
-import { resolveBaseUrl } from "../config/endpoint.mjs";
+import { getSiteUrl, resolveBaseUrl } from "../config/endpoint.mjs";
 import { CliError } from "../errors/handler.mjs";
 import {
   computeRetryDelayMs,
@@ -70,11 +70,14 @@ async function requestJson(
         } catch {
           /* not JSON */
         }
-        if (status === 401 || status === 403) throw new CliError("AUTH_INVALID_KEY", errorDetail);
+        if (status === 401 || status === 403) {
+          const err = new CliError("AUTH_INVALID_KEY", errorDetail);
+          err.hint = `Check your key at ${getSiteUrl(baseUrl)}/account`;
+          throw err;
+        }
         if (status === 402) {
-          const pricingHost = baseUrl.includes("qveris.cn") ? "https://qveris.cn" : "https://qveris.ai";
           const err = new CliError("CREDITS_INSUFFICIENT", errorDetail);
-          err.hint = `Purchase credits at ${pricingHost}/pricing`;
+          err.hint = `Purchase credits at ${getSiteUrl(baseUrl)}/pricing`;
           throw err;
         }
         if (status === 429) throw new CliError("RATE_LIMITED", errorDetail);

--- a/packages/cli/src/client/preflight.mjs
+++ b/packages/cli/src/client/preflight.mjs
@@ -35,6 +35,15 @@ function codeToName(code) {
   return "connectivity";
 }
 
+function endpointRecoveryHint(code, baseUrl) {
+  const siteUrl = getSiteUrl(baseUrl);
+  if (code === "AUTH_INVALID_KEY") return `Check your key at ${siteUrl}/account`;
+  if (code === "CREDITS_INSUFFICIENT") {
+    return `Purchase credits at ${siteUrl}/pricing, then confirm balance with 'qveris credits'`;
+  }
+  return null;
+}
+
 async function defaultProbe({ apiKey, baseUrl }) {
   // "test" matches the probe query login/whoami use to validate a key.
   return discoverTools({ apiKey, baseUrl, query: "test", limit: 1, timeoutMs: 10000 });
@@ -94,7 +103,11 @@ export async function runPreflight({
     response = await probe({ apiKey: local.apiKey, baseUrl: local.baseUrl });
   } catch (err) {
     // A diagnostic must never crash: anything (even a non-Error) can be thrown.
-    const hint = err?.hint || (err?.code ? ERROR_CODES[err.code]?.hint : null) || null;
+    const hint =
+      endpointRecoveryHint(err?.code, local.baseUrl) ||
+      err?.hint ||
+      (err?.code ? ERROR_CODES[err.code]?.hint : null) ||
+      null;
     checks.push(check(codeToName(err?.code), "fail", err?.message || String(err), hint));
     return { checks, ok: false, contractVersion: CLI_CONTRACT_VERSION };
   }

--- a/packages/cli/src/config/endpoint.mjs
+++ b/packages/cli/src/config/endpoint.mjs
@@ -3,18 +3,22 @@ import { CliError } from "../errors/handler.mjs";
 
 /**
  * Get the account site associated with a resolved API URL.
- * Unknown endpoints fall back to the public account site.
+ * Public API subdomains map to their canonical sites. Custom endpoints keep
+ * their own origin so recovery links never cross into an unrelated service.
  * @param {string} baseUrl
  * @returns {string}
  */
 export function getSiteUrl(baseUrl) {
   try {
-    const { hostname } = new URL(baseUrl);
+    const url = new URL(baseUrl);
+    const { hostname } = url;
     if (hostname === "qveris.cn" || hostname.endsWith(".qveris.cn")) return "https://qveris.cn";
+    if (hostname === "qveris.ai" || hostname.endsWith(".qveris.ai")) return "https://qveris.ai";
+    return url.origin;
   } catch {
     // resolveBaseUrl validates URLs before this helper is called.
+    return new URL(DEFAULT_BASE_URL).origin;
   }
-  return "https://qveris.ai";
 }
 
 /**

--- a/packages/cli/src/errors/codes.mjs
+++ b/packages/cli/src/errors/codes.mjs
@@ -24,7 +24,7 @@ export const ERROR_CODES = {
   },
   AUTH_INVALID_KEY: {
     message: "Authentication failed",
-    hint: "Check your key at https://qveris.ai/account",
+    hint: "Check the API key for the configured endpoint",
     exit: EX_NOPERM,
   },
   NET_TIMEOUT: {
@@ -69,7 +69,7 @@ export const ERROR_CODES = {
   },
   CREDITS_INSUFFICIENT: {
     message: "Insufficient credits",
-    hint: "Purchase credits at https://qveris.ai/pricing, then confirm balance with 'qveris credits'",
+    hint: "Purchase credits for the configured endpoint, then confirm balance with 'qveris credits'",
     exit: EX_NOPERM,
   },
   SESSION_EXPIRED: {

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -171,7 +171,10 @@ test("API client converts HTTP failures into CLI errors", async () => {
     async () => {
       await assert.rejects(
         discoverTools({ apiKey: "sk-test", baseUrl: "https://unit.test/api/v1", query: "x" }),
-        (err) => err instanceof CliError && err.code === "AUTH_INVALID_KEY",
+        (err) =>
+          err instanceof CliError &&
+          err.code === "AUTH_INVALID_KEY" &&
+          err.hint === "Check your key at https://unit.test/account",
       );
     },
   );
@@ -187,7 +190,10 @@ test("API client converts HTTP failures into CLI errors", async () => {
           discoveryId: "search-1",
           parameters: {},
         }),
-        (err) => err instanceof CliError && err.code === "CREDITS_INSUFFICIENT" && err.hint.includes("/pricing"),
+        (err) =>
+          err instanceof CliError &&
+          err.code === "CREDITS_INSUFFICIENT" &&
+          err.hint === "Purchase credits at https://unit.test/pricing",
       );
     },
   );

--- a/packages/cli/test/core.test.mjs
+++ b/packages/cli/test/core.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { normalizeLegacyArgs } from "../src/compat/aliases.mjs";
 import { resolveApiKey } from "../src/client/auth.mjs";
-import { normalizeBaseUrl, resolveBaseUrl } from "../src/config/endpoint.mjs";
+import { getSiteUrl, normalizeBaseUrl, resolveBaseUrl } from "../src/config/endpoint.mjs";
 import {
   buildLedgerQuery,
   buildLedgerSummary,
@@ -80,6 +80,14 @@ test("endpoint normalization rejects unsafe or invalid base URLs", () => {
   assert.throws(() => normalizeBaseUrl("https://unit.test/api/v1?target=other"), /query parameters/);
   assert.throws(() => normalizeBaseUrl("https://unit.test/api/v1?"), /query parameters/);
   assert.throws(() => normalizeBaseUrl("https://unit.test/api/v1#"), /fragments/);
+});
+
+test("account site resolution preserves public boundaries and custom endpoint origins", () => {
+  assert.equal(getSiteUrl("https://qveris.ai/api/v1"), "https://qveris.ai");
+  assert.equal(getSiteUrl("https://api.qveris.ai/api/v1"), "https://qveris.ai");
+  assert.equal(getSiteUrl("https://qveris.cn/api/v1"), "https://qveris.cn");
+  assert.equal(getSiteUrl("https://api.qveris.cn/api/v1"), "https://qveris.cn");
+  assert.equal(getSiteUrl("https://enterprise.example:8443/api/v1"), "https://enterprise.example:8443");
 });
 
 test("legacy command and flag aliases normalize without changing usage search-id", () => {

--- a/packages/cli/test/preflight.test.mjs
+++ b/packages/cli/test/preflight.test.mjs
@@ -94,21 +94,48 @@ test("runPreflight: invalid key becomes an actionable fail from the error knowle
   assert.equal(ok, false);
   const fail = checks.find((x) => x.status === "fail");
   assert.equal(fail.name, "api_key_valid");
-  assert.ok(fail.hint); // ERROR_CODES.AUTH_INVALID_KEY.hint
+  assert.equal(fail.hint, "Check your key at https://qveris.ai/account");
+});
+
+test("runPreflight: invalid-key recovery follows public and custom endpoints", async () => {
+  const probe = async () => {
+    throw new CliError("AUTH_INVALID_KEY", "Authentication failed");
+  };
+  for (const [baseUrlFlag, expectedHint] of [
+    ["https://qveris.cn/api/v1", "Check your key at https://qveris.cn/account"],
+    ["https://enterprise.example:8443/api/v1", "Check your key at https://enterprise.example:8443/account"],
+  ]) {
+    const { checks } = await runPreflight({ apiKeyFlag: "sk-bad", baseUrlFlag, probe });
+    assert.equal(byName(checks).api_key_valid.hint, expectedHint);
+  }
 });
 
 test("runPreflight: insufficient credits maps to a credits fail with pricing hint", async () => {
   const probe = async () => {
-    const err = new CliError("CREDITS_INSUFFICIENT", "Insufficient credits");
-    err.hint = "Purchase credits at https://qveris.ai/pricing";
-    throw err;
+    throw new CliError("CREDITS_INSUFFICIENT", "Insufficient credits");
   };
   const { checks, ok } = await runPreflight({ apiKeyFlag: "sk-test", probe });
 
   assert.equal(ok, false);
   const fail = checks.find((x) => x.status === "fail");
   assert.equal(fail.name, "credits");
-  assert.match(fail.hint, /pricing/);
+  assert.equal(fail.hint, "Purchase credits at https://qveris.ai/pricing, then confirm balance with 'qveris credits'");
+});
+
+test("runPreflight: insufficient-credit recovery follows public and custom endpoints", async () => {
+  const probe = async () => {
+    throw new CliError("CREDITS_INSUFFICIENT", "Insufficient credits");
+  };
+  for (const [baseUrlFlag, expectedSite] of [
+    ["https://qveris.cn/api/v1", "https://qveris.cn"],
+    ["https://enterprise.example:8443/api/v1", "https://enterprise.example:8443"],
+  ]) {
+    const { checks } = await runPreflight({ apiKeyFlag: "sk-test", baseUrlFlag, probe });
+    assert.equal(
+      byName(checks).credits.hint,
+      `Purchase credits at ${expectedSite}/pricing, then confirm balance with 'qveris credits'`,
+    );
+  }
 });
 
 test("runPreflight: timeout maps to a connectivity fail with a hint", async () => {


### PR DESCRIPTION
## Summary

- derive account and pricing recovery links from the resolved API endpoint
- map public API subdomains to their matching canonical site and keep custom deployments on their own origin
- replace endpoint-free error templates with deployment-neutral guidance
- cover default, qveris.cn, and custom endpoints in API, preflight, and configuration tests

This fixes the cross-site doctor hint reported in #221 and applies the same boundary to login, credits, and API error paths.

## Root cause

The generic invalid-key template contained a hard-coded account URL, while the insufficient-credit path used a substring check to choose between two sites. Custom endpoints also fell back to a public site unrelated to the configured service.

## Validation

- ESLint and Prettier
- 85 CLI tests
- coverage thresholds: 71.68% statements, 66.13% branches, 83.25% functions
- public documentation region-boundary scan; only intentional historical changelog entries remain

## After merge

Release CLI 0.8.1, verify the package and tag, and repeat doctor smoke tests against the default, qveris.cn, and a custom endpoint before closing #221.
