### PR TITLE
Migrate Python publishing to PyPI Trusted Publisher

### DIFF
--- a/.github/workflows/python-sdk-publish.yml
+++ b/.github/workflows/python-sdk-publish.yml
@@ -50,15 +50,16 @@ jobs:
       - name: Compile package and examples
         run: uv run python -m compileall qveris examples
 
-  publish:
+  build:
     needs: test
     # Event-scoped: a workflow_dispatch (even one targeting a tag ref) runs
-    # tests only; publishing requires an actual tag push.
+    # tests only; building release artifacts requires an actual tag push.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
-      contents: write # For creating GitHub Releases
-      id-token: write # For PyPI trusted publishing
+      contents: read
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
     defaults:
       run:
         working-directory: packages/python-sdk
@@ -78,7 +79,8 @@ jobs:
           enable-cache: true
           cache-dependency-glob: packages/python-sdk/uv.lock
 
-      - name: Verify package version matches tag
+      - name: Verify release metadata
+        id: metadata
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#python-sdk-v}"
           PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
@@ -86,23 +88,54 @@ jobs:
             echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)"
             exit 1
           fi
-          echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
-
-      - name: Verify CHANGELOG has an entry for this version
-        run: |
-          if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no '## [$VERSION]' section — move the Unreleased notes into a release section before tagging"
+          if ! grep -qE "^## \[$PKG_VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$PKG_VERSION]' section — move the Unreleased notes into a release section before tagging"
             exit 1
           fi
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build package
         run: uv build
+
+      - name: Upload release distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-sdk-distributions
+          path: packages/python-sdk/dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qveris
+    permissions:
+      contents: write # For creating GitHub Releases
+      id-token: write # For PyPI trusted publishing
+    defaults:
+      run:
+        working-directory: packages/python-sdk
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download release distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-sdk-distributions
+          path: packages/python-sdk/dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/python-sdk/dist
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: true
 
       # Release body = Install section + Highlights from the annotated tag
       # message (git tag -a python-sdk-vX.Y.Z -m "- bullet"), if any, +

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,6 +34,39 @@ Each package releases independently via an annotated git tag; the matching GitHu
 
 5. The publish workflow verifies **version == tag** and **CHANGELOG has the section**, runs the full test matrix (ubuntu + windows), publishes, and creates the GitHub Release. Python releases also require a current `uv.lock`. MCP releases verify `server.json` uses the same version and publish its metadata to the official MCP Registry with GitHub OIDC.
 
+## Python: PyPI Trusted Publisher
+
+The Python publish job authenticates to PyPI with GitHub OIDC. It must not receive a username, password, or long-lived API token.
+
+### One-time configuration
+
+1. In the GitHub repository, create an environment named `pypi` and restrict deployments to tags matching `python-sdk-v*`.
+2. On the existing PyPI `qveris` project, open **Manage → Publishing**, add a GitHub Actions publisher, and enter these values exactly:
+
+   | Field | Value |
+   |-------|-------|
+   | Owner | `QVerisAI` |
+   | Repository | `qveris-agent-toolkit` |
+   | Workflow | `python-sdk-publish.yml` |
+   | Environment | `pypi` |
+
+3. Confirm the workflow's `publish` job declares `environment: pypi`, grants `id-token: write` at job scope, and omits `username` and `password` from `pypa/gh-action-pypi-publish`. Release distributions must be built in the separate, unprivileged `build` job and transferred through a short-lived workflow artifact.
+
+The environment name is part of the OIDC identity. A mismatch between GitHub and PyPI causes an `invalid-publisher` exchange failure.
+
+### Release verification and token retirement
+
+1. Publish a controlled patch release through the normal annotated `python-sdk-v<version>` tag flow.
+2. Confirm the publish job exchanged a Trusted Publisher identity without reading `PYPI_API_TOKEN`.
+3. On the PyPI release page, verify both the wheel and source distribution show publish attestations tied to `QVerisAI/qveris-agent-toolkit` and `python-sdk-publish.yml`.
+4. Confirm the PyPI version, GitHub tag, and GitHub Release agree.
+5. Only after those checks pass, revoke the old PyPI project token and delete the `PYPI_API_TOKEN` GitHub Actions secret.
+
+### Recovery
+
+- For `invalid-publisher`, compare the PyPI owner, repository, workflow filename, and environment with the workflow values above; do not weaken the environment or add a token first.
+- If PyPI or GitHub OIDC has an incident and an urgent release cannot wait, create a temporary project-scoped PyPI token, restore the action's `password` input in a reviewed hotfix, and revoke both the token and hotfix immediately after the release. Never use an account-wide token.
+
 ## Notes
 
 - `CHANGELOG.md` ships inside each package (npm `files` whitelist; Python sdist and wheel, plus a PyPI `Changelog` project link), so registry users can read version diffs offline.

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-15
+
+### Changed
+
+- Releases now use PyPI Trusted Publishing with short-lived GitHub OIDC credentials and attestations for both wheel and source distributions. Package APIs and runtime behavior are unchanged. ([#222])
+
 ## [0.3.1] - 2026-07-14
 
 ### Fixed
@@ -45,11 +51,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Generated OpenAPI contract models with drift CI. ([#48])
 - `Agent` runtime: LLM tool loop over the QVeris workflow with streaming events.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.1...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.2...HEAD
+[0.3.2]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.1...python-sdk-v0.3.2
 [0.3.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.0...python-sdk-v0.3.1
 [0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.1...python-sdk-v0.3.0
 [0.2.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.0...python-sdk-v0.2.1
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/python-sdk-v0.2.0
+[#222]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/222
 [#204]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/204
 [#157]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/157
 [#142]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/142

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qveris"
-version = "0.3.1"
+version = "0.3.2"
 description = "QVeris Python SDK for agent capability discovery, calling, and audit"
 requires-python = ">=3.8"
 license = "MIT"

--- a/packages/python-sdk/uv.lock
+++ b/packages/python-sdk/uv.lock
@@ -5575,7 +5575,7 @@ wheels = [
 
 [[package]]
 name = "qveris"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- migrate Python publishing from the long-lived `PYPI_API_TOKEN` to PyPI Trusted Publishing
- bind the publish job to the `pypi` GitHub environment and keep `id-token: write` scoped to that job
- build distributions in an unprivileged job, transfer them through a one-day workflow artifact, and explicitly enable attestations
- document the exact PyPI publisher identity, verification procedure, token retirement, and emergency rollback
- prepare Python SDK 0.3.2 as the controlled OIDC verification release

The repository environment `pypi` has already been created and restricted to `python-sdk-v*` tags.

## Required before merge

On the existing PyPI `qveris` project, add this GitHub Actions Trusted Publisher under **Manage → Publishing**:

| Field | Value |
|-------|-------|
| Owner | `QVerisAI` |
| Repository | `qveris-agent-toolkit` |
| Workflow | `python-sdk-publish.yml` |
| Environment | `pypi` |

The PR should remain draft until this external publisher registration is confirmed. Do not revoke `PYPI_API_TOKEN` yet.

## Validation

- workflow YAML parsed successfully
- workflow contains no `PYPI_API_TOKEN`, username, or password input
- GitHub `pypi` environment and `python-sdk-v*` tag policy verified through the API
- `uv lock --check`
- Ruff lint and formatting checks
- 97 Python tests passed, 1 skipped
- wheel and source distribution built for 0.3.2; both contain the changelog and package metadata

## After merge

Push the annotated `python-sdk-v0.3.2` tag, monitor the OIDC publish job, verify attestations on both PyPI files, and confirm PyPI/tag/GitHub Release consistency. Only then revoke the old PyPI token, delete the GitHub secret, and close #222.
