### PR TITLE
Release CLI 0.8.1

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-15
+
 ### Fixed
 
 - Account and pricing recovery hints now follow the resolved API endpoint for the public sites and custom deployments instead of linking to an unrelated site. ([#221])
@@ -74,7 +76,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Initial release: `discover` / `inspect` / `call` from the terminal against the QVeris API.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.1...HEAD
+[0.8.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.0...cli-v0.8.1
 [0.8.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.7.0...cli-v0.8.0
 [0.7.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.6.1...cli-v0.7.0
 [0.6.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.6.0...cli-v0.6.1

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "bin": {
         "qveris": "bin/qveris.mjs"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "QVeris CLI for agent capability discovery, inspection, calling, and audit",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump `@qverisai/cli` from 0.8.0 to 0.8.1
- update the package lockfile
- move the endpoint-aware recovery-hint fix into the 0.8.1 changelog section

## Verification

- `npm test` — 85 passed
- `npm run lint`
- `npm pack --dry-run --json` — package metadata reports 0.8.1 and includes the expected CLI files

## After merge

Create and push the annotated tag `cli-v0.8.1`, then verify the publish workflow, npm provenance, GitHub Release, and installed CLI endpoint-aware hints.

Closes #221
