### PR TITLE
Fix OpenClaw npm provenance metadata

### DIFF
--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -17,6 +17,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ### Fixed
 
+- Declared the public repository metadata required for npm to verify the package's signed provenance bundle.
 - Builds now use the locked local `esbuild` dependency instead of downloading a build tool through `npx`; CI verifies the package can build in npm offline mode. ([#210])
 - Corrected the local source installation path in the README. ([#210])
 - The package is now installable and testable standalone: the `openclaw` dev dependency used the `workspace:*` protocol (a leftover from the OpenClaw monorepo) which made `npm install` fail; it now targets the published package. The three vitest suites (63 tests) and `tsc --noEmit` are wired into `npm test` / `npm run typecheck` and run in CI. ([#152])

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -2,6 +2,15 @@
   "name": "@qverisai/qveris",
   "version": "2026.7.15",
   "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QVerisAI/qveris-agent-toolkit",
+    "directory": "packages/openclaw-qveris-plugin"
+  },
+  "homepage": "https://qveris.ai",
+  "bugs": {
+    "url": "https://github.com/QVerisAI/qveris-agent-toolkit/issues"
+  },
   "type": "module",
   "engines": {
     "node": ">=22.19.0"

--- a/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
@@ -2,6 +2,13 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+const expectedRepositoryUrl = "https://github.com/QVerisAI/qveris-agent-toolkit";
+if (packageJson.repository?.url !== expectedRepositoryUrl) {
+  fail("package.json repository.url must match the public provenance repository:", [
+    `expected: ${expectedRepositoryUrl}`,
+    `received: ${packageJson.repository?.url ?? packageJson.repository}`,
+  ]);
+}
 const extensions = packageJson.openclaw?.extensions;
 if (!Array.isArray(extensions) || !extensions.includes("./dist/index.js")) {
   fail("package.json openclaw.extensions must include the compiled runtime entry:", ['expected "./dist/index.js"']);


### PR DESCRIPTION
## Summary

- declare the public repository, package directory, homepage, and issue tracker in the OpenClaw package metadata
- make the offline pack check reject a missing or mismatched `repository.url`
- record the provenance metadata correction in the 2026.7.15 changelog

## Why

The `qveris-plugin-v2026.7.15` publish run passed version validation, tests, and package-content checks, but npm rejected the signed provenance bundle because `package.json` had no repository URL. npm expected the URL carried by the workflow provenance.

Failed run: https://github.com/QVerisAI/qveris-agent-toolkit/actions/runs/29387548182

## Verification

- `npm test` — 78 passed
- `npm run typecheck`
- `npm run lint`
- `npm run check:pack` — 19 expected files; repository metadata assertion passed

## After merge

Because the failed tag points to the pre-fix commit and no package version was published, the existing `qveris-plugin-v2026.7.15` tag must be moved to the merge commit and pushed with an explicit force update to trigger a corrected publish. This should only be done with maintainer approval.

Follow-up for #206.
