### PR TITLE
Add API-key-compatible credential providers

### DIFF
--- a/docs/en-US/js-sdk-api.md
+++ b/docs/en-US/js-sdk-api.md
@@ -10,6 +10,52 @@ workflows.
 
 ## Classes
 
+### ApiKeyCredentialProvider
+
+A credential provider backed by a static QVeris API key.
+
+#### Implements
+
+- [`CredentialProvider`](#credentialprovider)
+
+#### Constructors
+
+##### Constructor
+
+> **new ApiKeyCredentialProvider**(`apiKey`): [`ApiKeyCredentialProvider`](#apikeycredentialprovider)
+
+###### Parameters
+
+###### apiKey
+
+`string`
+
+###### Returns
+
+[`ApiKeyCredentialProvider`](#apikeycredentialprovider)
+
+#### Methods
+
+##### getCredential()
+
+> **getCredential**(`_context`): `Promise`\<`string`\>
+
+###### Parameters
+
+###### \_context
+
+[`CredentialContext`](#credentialcontext)
+
+###### Returns
+
+`Promise`\<`string`\>
+
+###### Implementation of
+
+[`CredentialProvider`](#credentialprovider).[`getCredential`](#getcredential-1)
+
+***
+
 ### Qveris
 
 QVeris API client.
@@ -40,7 +86,7 @@ const outcome = await qveris.call(tool.tool_id, {
 
 ###### config
 
-[`QverisClientConfig`](#qverisclientconfig)
+[`QverisClientOptions`](#qverisclientoptions)
 
 ###### Returns
 
@@ -179,7 +225,7 @@ An explicit baseUrl override takes priority over QVERIS_BASE_URL.
 
 ###### overrides?
 
-`Omit`\<[`QverisClientConfig`](#qverisclientconfig), `"apiKey"`\>
+`Omit`\<[`QverisClientOptions`](#qverisclientoptions), `"apiKey"` \| `"credentialProvider"`\>
 
 ###### Returns
 
@@ -706,6 +752,48 @@ Per-request timeout override in milliseconds (default 120s)
 ##### summary?
 
 > `optional` **summary?**: `string` \| `null`
+
+***
+
+### CredentialContext
+
+Context supplied whenever the client requests a credential.
+
+#### Properties
+
+##### resource
+
+> **resource**: `string`
+
+API resource the credential will be sent to.
+
+##### scopes
+
+> **scopes**: readonly `string`[]
+
+Requested authorization scopes. Empty until a public scope contract is available.
+
+***
+
+### CredentialProvider
+
+Supplies a bearer credential for an API request.
+
+#### Methods
+
+##### getCredential()
+
+> **getCredential**(`context`): `string` \| `Promise`\<`string`\>
+
+###### Parameters
+
+###### context
+
+[`CredentialContext`](#credentialcontext)
+
+###### Returns
+
+`string` \| `Promise`\<`string`\>
 
 ***
 
@@ -1772,6 +1860,14 @@ Error response from the Qveris API.
 > **ExecuteResult** = [`ExecuteResultData`](#executeresultdata) \| [`ExecuteResultTruncated`](#executeresulttruncated)
 
 Union type for execution results (either full data or truncated).
+
+***
+
+### QverisClientOptions
+
+> **QverisClientOptions** = `Omit`\<[`QverisClientConfig`](#qverisclientconfig), `"apiKey"`\> & \{ `apiKey`: `string`; `credentialProvider?`: `never`; \} \| \{ `apiKey?`: `never`; `credentialProvider`: [`CredentialProvider`](#credentialprovider); \}
+
+Configuration accepted by the QVeris REST client.
 
 ## Functions
 

--- a/docs/en-US/python-sdk-api.md
+++ b/docs/en-US/python-sdk-api.md
@@ -10,7 +10,7 @@ This reference is generated from the public Python objects and docstrings. See t
 
 <a id="qveris.QverisClient"></a>
 
-### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None)
+### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None, \*, credential_provider: CredentialProvider | None = None)
 
 Async client for Qveris API.
 

--- a/docs/zh-CN/js-sdk-api.md
+++ b/docs/zh-CN/js-sdk-api.md
@@ -8,6 +8,52 @@
 
 ## 类
 
+### ApiKeyCredentialProvider
+
+A credential provider backed by a static QVeris API key.
+
+#### 实现
+
+- [`CredentialProvider`](#credentialprovider)
+
+#### 构造函数
+
+##### 构造函数
+
+> **new ApiKeyCredentialProvider**(`apiKey`): [`ApiKeyCredentialProvider`](#apikeycredentialprovider)
+
+###### 参数
+
+###### apiKey
+
+`string`
+
+###### 返回
+
+[`ApiKeyCredentialProvider`](#apikeycredentialprovider)
+
+#### 方法
+
+##### getCredential()
+
+> **getCredential**(`_context`): `Promise`\<`string`\>
+
+###### 参数
+
+###### \_context
+
+[`CredentialContext`](#credentialcontext)
+
+###### 返回
+
+`Promise`\<`string`\>
+
+###### 实现了
+
+[`CredentialProvider`](#credentialprovider).[`getCredential`](#getcredential-1)
+
+***
+
 ### Qveris
 
 QVeris API client.
@@ -38,7 +84,7 @@ const outcome = await qveris.call(tool.tool_id, {
 
 ###### config
 
-[`QverisClientConfig`](#qverisclientconfig)
+[`QverisClientOptions`](#qverisclientoptions)
 
 ###### 返回
 
@@ -177,7 +223,7 @@ An explicit baseUrl override takes priority over QVERIS_BASE_URL.
 
 ###### overrides?
 
-`Omit`\<[`QverisClientConfig`](#qverisclientconfig), `"apiKey"`\>
+`Omit`\<[`QverisClientOptions`](#qverisclientoptions), `"apiKey"` \| `"credentialProvider"`\>
 
 ###### 返回
 
@@ -704,6 +750,48 @@ Per-request timeout override in milliseconds (default 120s)
 ##### summary?
 
 > `optional` **summary?**: `string` \| `null`
+
+***
+
+### CredentialContext
+
+Context supplied whenever the client requests a credential.
+
+#### 属性
+
+##### resource
+
+> **resource**: `string`
+
+API resource the credential will be sent to.
+
+##### scopes
+
+> **scopes**: readonly `string`[]
+
+Requested authorization scopes. Empty until a public scope contract is available.
+
+***
+
+### CredentialProvider
+
+Supplies a bearer credential for an API request.
+
+#### 方法
+
+##### getCredential()
+
+> **getCredential**(`context`): `string` \| `Promise`\<`string`\>
+
+###### 参数
+
+###### context
+
+[`CredentialContext`](#credentialcontext)
+
+###### 返回
+
+`string` \| `Promise`\<`string`\>
 
 ***
 
@@ -1770,6 +1858,14 @@ Error response from the Qveris API.
 > **ExecuteResult** = [`ExecuteResultData`](#executeresultdata) \| [`ExecuteResultTruncated`](#executeresulttruncated)
 
 Union type for execution results (either full data or truncated).
+
+***
+
+### QverisClientOptions
+
+> **QverisClientOptions** = `Omit`\<[`QverisClientConfig`](#qverisclientconfig), `"apiKey"`\> & \{ `apiKey`: `string`; `credentialProvider?`: `never`; \} \| \{ `apiKey?`: `never`; `credentialProvider`: [`CredentialProvider`](#credentialprovider); \}
+
+Configuration accepted by the QVeris REST client.
 
 ## 函数
 

--- a/docs/zh-CN/python-sdk-api.md
+++ b/docs/zh-CN/python-sdk-api.md
@@ -10,7 +10,7 @@
 
 <a id="qveris.QverisClient"></a>
 
-### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None)
+### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None, \*, credential_provider: CredentialProvider | None = None)
 
 Async client for Qveris API.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Account and pricing recovery hints now follow the resolved API endpoint for the public sites and custom deployments instead of linking to an unrelated site. ([#221])
 
+### Changed
+
+- Routed authenticated requests through an internal credential-provider boundary while preserving all existing API-key resolution and endpoint-selection behavior. ([#226])
+
 ## [0.8.0] - 2026-07-14
 
 ### Changed
@@ -84,6 +88,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.1.0...cli-v0.2.0
 [0.1.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/cli-v0.1.0
 [#221]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/221
+[#226]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/226
 [#204]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/204
 [#161]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/161
 [#144]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/144

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -1,5 +1,6 @@
 import { getSiteUrl, resolveBaseUrl } from "../config/endpoint.mjs";
 import { CliError } from "../errors/handler.mjs";
+import { getCredential, resolveCredentialProvider } from "./auth.mjs";
 import {
   computeRetryDelayMs,
   DEFAULT_BASE_DELAY_MS,
@@ -10,8 +11,8 @@ import {
   sleep,
 } from "./retry.mjs";
 
-function getBaseUrl(baseUrlFlag, apiKey) {
-  return resolveBaseUrl({ baseUrlFlag, apiKey }).baseUrl;
+function getBaseUrl(baseUrlFlag) {
+  return resolveBaseUrl({ baseUrlFlag }).baseUrl;
 }
 
 async function requestJson(
@@ -21,7 +22,7 @@ async function requestJson(
     query = {},
     body,
     timeoutMs = 30000,
-    apiKey,
+    credentialProvider,
     baseUrl,
     // Retry rate-limited (429) / transient (503) responses: honor Retry-After,
     // otherwise exponential backoff with jitter, bounded by maxRetries.
@@ -36,6 +37,12 @@ async function requestJson(
   }
 
   for (let attempt = 0; ; attempt++) {
+    // Credential acquisition is outside the API request timeout and happens
+    // on every attempt so retries can refresh short-lived tokens.
+    const credential = await getCredential(credentialProvider, {
+      resource: baseUrl,
+      scopes: [],
+    });
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     let retryDelayMs;
@@ -44,7 +51,7 @@ async function requestJson(
       const response = await fetch(url.toString(), {
         method,
         headers: {
-          Authorization: `Bearer ${apiKey}`,
+          Authorization: `Bearer ${credential}`,
           "Content-Type": "application/json",
         },
         ...(body === undefined ? {} : { body: JSON.stringify(body) }),
@@ -119,20 +126,45 @@ export function unwrapApiResponse(response) {
   return response;
 }
 
-export async function discoverTools({ apiKey, baseUrl: baseUrlFlag, query, limit = 5, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
-  return requestJson("/search", { apiKey, baseUrl, body: { query, limit }, timeoutMs });
+export async function discoverTools({
+  apiKey,
+  credentialProvider,
+  baseUrl: baseUrlFlag,
+  query,
+  limit = 5,
+  timeoutMs = 30000,
+}) {
+  const baseUrl = getBaseUrl(baseUrlFlag);
+  return requestJson("/search", {
+    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
+    baseUrl,
+    body: { query, limit },
+    timeoutMs,
+  });
 }
 
-export async function inspectToolsByIds({ apiKey, baseUrl: baseUrlFlag, toolIds, discoveryId, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
+export async function inspectToolsByIds({
+  apiKey,
+  credentialProvider,
+  baseUrl: baseUrlFlag,
+  toolIds,
+  discoveryId,
+  timeoutMs = 30000,
+}) {
+  const baseUrl = getBaseUrl(baseUrlFlag);
   const body = { tool_ids: toolIds };
   if (discoveryId) body.search_id = discoveryId;
-  return requestJson("/tools/by-ids", { apiKey, baseUrl, body, timeoutMs });
+  return requestJson("/tools/by-ids", {
+    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
+    baseUrl,
+    body,
+    timeoutMs,
+  });
 }
 
 export async function callTool({
   apiKey,
+  credentialProvider,
   baseUrl: baseUrlFlag,
   toolId,
   discoveryId,
@@ -140,9 +172,9 @@ export async function callTool({
   maxResponseSize = 102400,
   timeoutMs = 120000,
 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
+  const baseUrl = getBaseUrl(baseUrlFlag);
   return requestJson("/tools/execute", {
-    apiKey,
+    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
     baseUrl,
     query: { tool_id: toolId },
     body: {
@@ -154,32 +186,44 @@ export async function callTool({
   });
 }
 
-export async function getCredits({ apiKey, baseUrl: baseUrlFlag, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
+export async function getCredits({ apiKey, credentialProvider, baseUrl: baseUrlFlag, timeoutMs = 30000 }) {
+  const baseUrl = getBaseUrl(baseUrlFlag);
   return requestJson("/auth/credits", {
     method: "GET",
-    apiKey,
+    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
     baseUrl,
     timeoutMs,
   });
 }
 
-export async function getUsageHistory({ apiKey, baseUrl: baseUrlFlag, query = {}, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
+export async function getUsageHistory({
+  apiKey,
+  credentialProvider,
+  baseUrl: baseUrlFlag,
+  query = {},
+  timeoutMs = 30000,
+}) {
+  const baseUrl = getBaseUrl(baseUrlFlag);
   return requestJson("/auth/usage/history/v2", {
     method: "GET",
-    apiKey,
+    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
     baseUrl,
     query,
     timeoutMs,
   });
 }
 
-export async function getCreditsLedger({ apiKey, baseUrl: baseUrlFlag, query = {}, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag, apiKey);
+export async function getCreditsLedger({
+  apiKey,
+  credentialProvider,
+  baseUrl: baseUrlFlag,
+  query = {},
+  timeoutMs = 30000,
+}) {
+  const baseUrl = getBaseUrl(baseUrlFlag);
   return requestJson("/auth/credits/ledger", {
     method: "GET",
-    apiKey,
+    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
     baseUrl,
     query,
     timeoutMs,

--- a/packages/cli/src/client/auth.mjs
+++ b/packages/cli/src/client/auth.mjs
@@ -23,3 +23,41 @@ export function isPlaceholderApiKey(value) {
   const trimmed = value.trim();
   return PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
+
+export function createApiKeyCredentialProvider(apiKey) {
+  const value = typeof apiKey === "string" ? apiKey.trim() : "";
+  if (!value || /[\r\n]/.test(value)) {
+    throw new CliError("AUTH_MISSING_KEY");
+  }
+  return {
+    async getCredential() {
+      return value;
+    },
+  };
+}
+
+export function resolveCredentialProvider({ apiKey, credentialProvider } = {}) {
+  if (apiKey !== undefined && credentialProvider !== undefined) {
+    throw new CliError("API_ERROR", "Configure either apiKey or credentialProvider, not both");
+  }
+  if (credentialProvider !== undefined) {
+    if (typeof credentialProvider?.getCredential !== "function") {
+      throw new CliError("API_ERROR", "credentialProvider must implement getCredential()");
+    }
+    return credentialProvider;
+  }
+  return createApiKeyCredentialProvider(apiKey);
+}
+
+export async function getCredential(provider, context) {
+  let credential;
+  try {
+    credential = await provider.getCredential(context);
+  } catch {
+    throw new CliError("API_ERROR", "Credential provider failed to provide a credential");
+  }
+  if (typeof credential !== "string" || !credential.trim() || /[\r\n]/.test(credential)) {
+    throw new CliError("API_ERROR", "Credential provider returned an invalid credential");
+  }
+  return credential.trim();
+}

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -128,6 +128,86 @@ test("API client maps discover, inspect, call, credits, usage, and ledger endpoi
   ]);
 });
 
+test("API client gets async credentials for the configured resource", async () => {
+  const contexts = [];
+  const credentialProvider = {
+    async getCredential(context) {
+      contexts.push(context);
+      return "short-lived-token";
+    },
+  };
+
+  await withMockFetch(
+    (_url, options) => {
+      assert.equal(options.headers.Authorization, "Bearer short-lived-token");
+      return jsonResponse({ ok: true });
+    },
+    () =>
+      discoverTools({
+        credentialProvider,
+        baseUrl: "https://custom.example/api/v1/",
+        query: "weather",
+      }),
+  );
+
+  assert.deepEqual(contexts, [{ resource: "https://custom.example/api/v1", scopes: [] }]);
+});
+
+test("API request timeout starts after the credential resolves", async () => {
+  const credentialProvider = {
+    async getCredential() {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return "short-lived-token";
+    },
+  };
+
+  await withMockFetch(
+    (_url, options) => {
+      assert.equal(options.signal.aborted, false);
+      return jsonResponse({ ok: true });
+    },
+    () =>
+      discoverTools({
+        credentialProvider,
+        query: "weather",
+        timeoutMs: 1,
+      }),
+  );
+});
+
+test("API client rejects ambiguous or invalid provider credentials without exposing values", async () => {
+  await assert.rejects(
+    discoverTools({
+      apiKey: "sk-test",
+      credentialProvider: { getCredential: async () => "short-lived-token" },
+      query: "weather",
+    }),
+    /either apiKey or credentialProvider/,
+  );
+
+  const secret = "secret-token";
+  await assert.rejects(
+    discoverTools({
+      credentialProvider: { getCredential: async () => `${secret}\nforged-header` },
+      query: "weather",
+    }),
+    (err) => err instanceof CliError && /invalid credential/.test(err.message) && !err.message.includes(secret),
+  );
+
+  await assert.rejects(
+    discoverTools({
+      credentialProvider: {
+        async getCredential() {
+          throw new Error(`failed while handling ${secret}`);
+        },
+      },
+      query: "weather",
+    }),
+    (err) =>
+      err instanceof CliError && /failed to provide a credential/.test(err.message) && !err.message.includes(secret),
+  );
+});
+
 test("QVERIS_BASE_URL controls every API call and normalizes trailing slashes", async () => {
   const previous = process.env.QVERIS_BASE_URL;
   const paths = [];

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added an async-capable `CredentialProvider` contract and `ApiKeyCredentialProvider`. Existing `apiKey` configuration remains the default-compatible path, while applications can supply short-lived bearer credentials without changing endpoint selection. ([#226])
+
 ## [0.4.0] - 2026-07-14
 
 ### Changed
@@ -38,6 +42,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.2.0...js-sdk-v0.3.0
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/js-sdk-v0.2.0
 [#204]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/204
+[#226]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/226
 [#211]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/211
 [#161]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/161
 [#143]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/143

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -75,6 +75,11 @@ The provider receives the resolved API `resource` and the requested `scopes`
 (currently empty). Configure either `apiKey` or `credentialProvider`, never
 both. A provider does not select or change the API endpoint.
 
+A credential provider supplies the bearer value that authenticates requests to
+the QVeris API itself. It is unrelated to the data and tool providers in the
+capability catalog: their upstream credentials are managed by the platform and
+never pass through the SDK.
+
 | Method | Billed | Returns | Notes |
 | --- | --- | --- | --- |
 | `discover(query, options?)` | Free | `SearchResponse` | `options`: `limit`, `sessionId`, `timeoutMs`. Results carry `why_recommended`, `expected_cost`, `stats`. |

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -55,7 +55,25 @@ const credits = await qveris.credits();
 ## API reference
 
 Construct with `new Qveris({ apiKey })` or `Qveris.fromEnv(overrides?)` (reads
-`QVERIS_API_KEY` and resolves the API endpoint automatically).
+`QVERIS_API_KEY` and resolves the API endpoint automatically). Applications
+that manage short-lived credentials can instead pass an async-capable provider:
+
+```typescript
+import { Qveris, type CredentialProvider } from '@qverisai/sdk';
+
+const credentialProvider: CredentialProvider = {
+  async getCredential({ resource, scopes }) {
+    // Resolve a bearer credential through your application's credential store.
+    return process.env.QVERIS_API_KEY!;
+  },
+};
+
+const qveris = new Qveris({ credentialProvider });
+```
+
+The provider receives the resolved API `resource` and the requested `scopes`
+(currently empty). Configure either `apiKey` or `credentialProvider`, never
+both. A provider does not select or change the API endpoint.
 
 | Method | Billed | Returns | Notes |
 | --- | --- | --- | --- |
@@ -80,6 +98,7 @@ All types are exported from the package root (`import type { SearchResponse, Exe
 | Option / env var | Description |
 | --- | --- |
 | `apiKey` / `QVERIS_API_KEY` | Required. Create one at [qveris.ai](https://qveris.ai/account?page=api-keys) |
+| `credentialProvider` | Async-capable bearer credential source; mutually exclusive with `apiKey` |
 | `baseUrl` / `QVERIS_BASE_URL` | API endpoint: constructor option > environment variable > built-in default |
 | `timeoutMs` | Default request timeout (30s; `call` defaults to 120s) |
 | `maxRetries` | Retries for rate-limited (429) / transient (503) responses (default 3; `0` disables) |

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Qveris } from './client.js';
+import type { QverisClientOptions } from './client.js';
+import { ApiKeyCredentialProvider } from './credentials.js';
 import { QverisApiError } from './errors.js';
 import type { ToolCategory, ToolCapability } from './types.js';
 
@@ -68,6 +70,90 @@ describe('Qveris client', () => {
 
   it('requires an API key', () => {
     expect(() => new Qveris({ apiKey: '' })).toThrow(/API key is required/);
+  });
+
+  it('does not serialize the static API key provider credential', () => {
+    const provider = new ApiKeyCredentialProvider(API_KEY);
+    expect(JSON.stringify(provider)).not.toContain(API_KEY);
+  });
+
+  it('rejects ambiguous API key and credential provider configuration', () => {
+    const ambiguous = {
+      apiKey: API_KEY,
+      credentialProvider: { getCredential: async () => 'provider-token' },
+    } as unknown as QverisClientOptions;
+    expect(() => new Qveris(ambiguous)).toThrow(/either apiKey or credentialProvider/);
+  });
+
+  it('rejects a null credential provider with a configuration error', () => {
+    const invalid = { credentialProvider: null } as unknown as QverisClientOptions;
+    expect(() => new Qveris(invalid)).toThrow(/credentialProvider must implement getCredential/);
+  });
+
+  it('gets an async credential for the configured API resource', async () => {
+    const fetchMock = mockFetch(SAMPLE_DISCOVER_RESPONSE);
+    globalThis.fetch = fetchMock;
+    const getCredential = vi.fn().mockResolvedValue('short-lived-token');
+
+    await new Qveris({
+      baseUrl: 'https://custom.example/api/v1/',
+      credentialProvider: { getCredential },
+    }).discover('weather');
+
+    expect(getCredential).toHaveBeenCalledWith({
+      resource: 'https://custom.example/api/v1',
+      scopes: [],
+    });
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer short-lived-token');
+  });
+
+  it('rejects an invalid provider credential without exposing it', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    const client = new Qveris({
+      credentialProvider: { getCredential: async () => 'secret-token\nforged-header' },
+    });
+
+    await expect(client.discover('weather')).rejects.toThrow('invalid credential');
+    await expect(client.discover('weather')).rejects.not.toThrow('secret-token');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('normalizes provider failures without exposing their error text', async () => {
+    const client = new Qveris({
+      credentialProvider: {
+        getCredential: async () => {
+          throw new Error('failed while handling secret-token');
+        },
+      },
+    });
+
+    const error = await client.discover('weather').catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(QverisApiError);
+    expect((error as Error).message).toContain('failed to provide a credential');
+    expect((error as Error).message).not.toContain('secret-token');
+  });
+
+  it('starts the request timeout only after the credential resolves', async () => {
+    globalThis.fetch = mockFetch(SAMPLE_DISCOVER_RESPONSE);
+    let releaseCredential!: (credential: string) => void;
+    const credential = new Promise<string>((resolve) => {
+      releaseCredential = resolve;
+    });
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const client = new Qveris({
+      credentialProvider: { getCredential: () => credential },
+      timeoutMs: 1,
+    });
+
+    const request = client.discover('weather');
+    await Promise.resolve();
+    expect(timeoutSpy).not.toHaveBeenCalled();
+
+    releaseCredential('short-lived-token');
+    await request;
+    expect(timeoutSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does not infer the endpoint from the API key or QVERIS_REGION', async () => {
@@ -407,6 +493,23 @@ describe('Qveris client', () => {
       expect(result.search_id).toBe('search-123');
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(client.rateLimitRetryCount).toBe(1);
+    });
+
+    it('resolves a fresh credential for each retry attempt', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(rateLimited('1'))
+        .mockResolvedValueOnce(jsonResponse(SAMPLE_DISCOVER_RESPONSE));
+      globalThis.fetch = fetchMock;
+      const getCredential = vi.fn().mockResolvedValueOnce('token-1').mockResolvedValueOnce('token-2');
+      const client = new Qveris({ credentialProvider: { getCredential } });
+      vi.spyOn(client as unknown as { sleep: () => Promise<void> }, 'sleep').mockResolvedValue(undefined);
+
+      await client.discover('weather');
+
+      expect(getCredential).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer token-1');
+      expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe('Bearer token-2');
     });
 
     it('gives up after maxRetries and throws the final 429', async () => {

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -12,6 +12,8 @@
  */
 
 import { QverisApiError } from './errors.js';
+import { ApiKeyCredentialProvider, resolveCredential } from './credentials.js';
+import type { CredentialProvider } from './credentials.js';
 import {
   computeRetryDelayMs,
   DEFAULT_BASE_DELAY_MS,
@@ -34,6 +36,21 @@ import type {
   UsageEventsResponse,
   UsageHistoryRequest,
 } from './types.js';
+
+/** Configuration accepted by the QVeris REST client. */
+export type QverisClientOptions = Omit<QverisClientConfig, 'apiKey'> &
+  (
+    | {
+        /** API authentication token. Mutually exclusive with credentialProvider. */
+        apiKey: string;
+        credentialProvider?: never;
+      }
+    | {
+        apiKey?: never;
+        /** Async-capable credential source. Mutually exclusive with apiKey. */
+        credentialProvider: CredentialProvider;
+      }
+  );
 
 const DEFAULT_BASE_URL = 'https://qveris.ai/api/v1';
 
@@ -132,17 +149,26 @@ export interface CallOptions {
  * ```
  */
 export class Qveris {
-  private readonly apiKey: string;
+  private readonly credentialProvider: CredentialProvider;
   private readonly baseUrl: string;
   private readonly defaultTimeoutMs: number;
   private readonly maxRetries: number;
   private rateLimitRetries = 0;
 
-  constructor(config: QverisClientConfig) {
-    if (!config.apiKey) {
+  constructor(config: QverisClientOptions) {
+    if (config.apiKey !== undefined && config.credentialProvider !== undefined) {
+      throw new Error('Configure either apiKey or credentialProvider, not both.');
+    }
+    if (config.credentialProvider !== undefined) {
+      if (typeof config.credentialProvider?.getCredential !== 'function') {
+        throw new Error('QVeris credentialProvider must implement getCredential().');
+      }
+      this.credentialProvider = config.credentialProvider;
+    } else if (typeof config.apiKey === 'string' && config.apiKey.trim()) {
+      this.credentialProvider = new ApiKeyCredentialProvider(config.apiKey);
+    } else {
       throw new Error('QVeris API key is required.\n' + 'Create one at https://qveris.ai/account?page=api-keys');
     }
-    this.apiKey = config.apiKey;
     this.baseUrl = resolveBaseUrl(config.baseUrl);
     this.defaultTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.maxRetries = resolveMaxRetries(config.maxRetries);
@@ -167,7 +193,7 @@ export class Qveris {
    * Create a client from the QVERIS_API_KEY environment variable.
    * An explicit baseUrl override takes priority over QVERIS_BASE_URL.
    */
-  static fromEnv(overrides?: Omit<QverisClientConfig, 'apiKey'>): Qveris {
+  static fromEnv(overrides?: Omit<QverisClientOptions, 'apiKey' | 'credentialProvider'>): Qveris {
     const apiKey = process.env.QVERIS_API_KEY;
     if (!apiKey) {
       throw new Error(
@@ -301,6 +327,13 @@ export class Qveris {
     // otherwise exponential backoff with jitter, bounded by maxRetries. Each
     // attempt is a fresh fetch with its own timeout.
     for (let attempt = 0; ; attempt++) {
+      // Credential acquisition is not part of the API request timeout. Resolve
+      // it for every attempt so a retry can refresh a short-lived token, and
+      // let provider failures retain their authentication-specific error.
+      const credential = await resolveCredential(this.credentialProvider, {
+        resource: this.baseUrl,
+        scopes: [],
+      });
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
       // eslint-disable-next-line no-useless-assignment -- TS definite-assignment needs the init across try/finally
@@ -309,7 +342,7 @@ export class Qveris {
         const response = await fetch(url.toString(), {
           method,
           headers: {
-            Authorization: `Bearer ${this.apiKey}`,
+            Authorization: `Bearer ${credential}`,
             'Content-Type': 'application/json',
           },
           body: body ? JSON.stringify(body) : undefined,

--- a/packages/js-sdk/src/credentials.ts
+++ b/packages/js-sdk/src/credentials.ts
@@ -1,0 +1,44 @@
+/** Context supplied whenever the client requests a credential. */
+export interface CredentialContext {
+  /** API resource the credential will be sent to. */
+  resource: string;
+
+  /** Requested authorization scopes. Empty until a public scope contract is available. */
+  scopes: readonly string[];
+}
+
+/** Supplies a bearer credential for an API request. */
+export interface CredentialProvider {
+  getCredential(context: CredentialContext): string | Promise<string>;
+}
+
+/** A credential provider backed by a static QVeris API key. */
+export class ApiKeyCredentialProvider implements CredentialProvider {
+  readonly #apiKey: string;
+
+  constructor(apiKey: string) {
+    const value = apiKey.trim();
+    if (!value || /[\r\n]/.test(value)) {
+      throw new Error('QVeris API key is required.');
+    }
+    this.#apiKey = value;
+  }
+
+  async getCredential(_context: CredentialContext): Promise<string> {
+    return this.#apiKey;
+  }
+}
+
+/** Resolve and validate a provider value without exposing it in errors. */
+export async function resolveCredential(provider: CredentialProvider, context: CredentialContext): Promise<string> {
+  let credential: string;
+  try {
+    credential = await provider.getCredential(context);
+  } catch {
+    throw new Error('QVeris credential provider failed to provide a credential.');
+  }
+  if (typeof credential !== 'string' || !credential.trim() || /[\r\n]/.test(credential)) {
+    throw new Error('QVeris credential provider returned an invalid credential.');
+  }
+  return credential.trim();
+}

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -16,6 +16,8 @@
  */
 
 export { Qveris } from './client.js';
-export type { DiscoverOptions, InspectOptions, CallOptions } from './client.js';
+export type { DiscoverOptions, InspectOptions, CallOptions, QverisClientOptions } from './client.js';
+export { ApiKeyCredentialProvider } from './credentials.js';
+export type { CredentialContext, CredentialProvider } from './credentials.js';
 export { QverisApiError } from './errors.js';
 export * from './types.js';

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added an async `CredentialProvider` protocol and `ApiKeyCredentialProvider`. Existing `QverisConfig.api_key` behavior remains compatible, while applications can supply short-lived bearer credentials without changing endpoint selection. ([#226])
+
 ## [0.3.1] - 2026-07-14
 
 ### Fixed
@@ -51,6 +55,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [0.2.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.2.0...python-sdk-v0.2.1
 [0.2.0]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/python-sdk-v0.2.0
 [#204]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/204
+[#226]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/226
 [#157]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/157
 [#142]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/142
 [#141]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/141

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -52,6 +52,11 @@ The provider receives the resolved API `resource` and requested `scopes`
 (currently empty). Configure either `api_key` or `credential_provider`, never
 both. A provider does not select or change the API endpoint.
 
+A credential provider supplies the bearer value that authenticates requests to
+the QVeris API itself. It is unrelated to the data and tool providers in the
+capability catalog: their upstream credentials are managed by the platform and
+never pass through the SDK.
+
 ## Canonical Workflow
 
 ```python

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -31,6 +31,27 @@ client = QverisClient(QverisConfig(api_key="sk-...", base_url="https://qveris.ai
 
 Endpoint priority is `QverisConfig(base_url=...)` > `QVERIS_BASE_URL` > the built-in default. API keys never select the endpoint. Overrides must be HTTP(S) URLs without credentials, a query string, or a fragment.
 
+Applications that manage short-lived credentials can pass an async provider
+instead of `api_key`:
+
+```python
+import os
+from qveris import CredentialContext, QverisClient, QverisConfig
+
+class EnvironmentCredentialProvider:
+    async def get_credential(self, context: CredentialContext) -> str:
+        return os.environ["QVERIS_API_KEY"]
+
+client = QverisClient(
+    QverisConfig(api_key=None),
+    credential_provider=EnvironmentCredentialProvider(),
+)
+```
+
+The provider receives the resolved API `resource` and requested `scopes`
+(currently empty). Configure either `api_key` or `credential_provider`, never
+both. A provider does not select or change the API endpoint.
+
 ## Canonical Workflow
 
 ```python

--- a/packages/python-sdk/qveris/__init__.py
+++ b/packages/python-sdk/qveris/__init__.py
@@ -2,6 +2,7 @@ from .agent.budget import BudgetTracker
 from .agent.core import Agent
 from .client.api import QverisClient
 from .config import QverisConfig, AgentConfig
+from .credentials import ApiKeyCredentialProvider, CredentialContext, CredentialProvider
 from .types import (
     CompactBillingStatement,
     CreditsLedgerItem,
@@ -24,6 +25,9 @@ __all__ = [
     "BudgetTracker",
     "QverisClient",
     "QverisConfig",
+    "CredentialContext",
+    "CredentialProvider",
+    "ApiKeyCredentialProvider",
     "AgentConfig",
     "Message",
     "StreamEvent",

--- a/packages/python-sdk/qveris/client/__init__.py
+++ b/packages/python-sdk/qveris/client/__init__.py
@@ -1,4 +1,5 @@
 from .api import QverisClient
+from ..credentials import ApiKeyCredentialProvider, CredentialContext, CredentialProvider
 from .tools import (
     CALL_TOOL_DEF,
     DEFAULT_SYSTEM_PROMPT,
@@ -11,6 +12,9 @@ from .tools import (
 
 __all__ = [
     "QverisClient",
+    "CredentialContext",
+    "CredentialProvider",
+    "ApiKeyCredentialProvider",
     "DEFAULT_SYSTEM_PROMPT",
     "DISCOVER_TOOL_DEF",
     "INSPECT_TOOL_DEF",

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -30,6 +30,7 @@ from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 import httpx
 
 from ..config import QverisConfig
+from ..credentials import ApiKeyCredentialProvider, CredentialContext, CredentialProvider, resolve_credential
 from ..observability import (
     ATTR_CREDITS,
     ATTR_ELAPSED_MS,
@@ -59,14 +60,28 @@ def _pre_settlement_credits(response: ToolExecutionResponse) -> Optional[float]:
 class QverisClient:
     """Async client for Qveris API."""
 
-    def __init__(self, config: Optional[QverisConfig] = None, debug_callback: Optional[Callable[[str], None]] = None):
+    def __init__(
+        self,
+        config: Optional[QverisConfig] = None,
+        debug_callback: Optional[Callable[[str], None]] = None,
+        *,
+        credential_provider: Optional[CredentialProvider] = None,
+    ):
         self.config = config or QverisConfig()
         self.debug_callback = debug_callback
+        if credential_provider is not None and self.config.api_key:
+            raise ValueError("Configure either api_key or credential_provider, not both")
+        if credential_provider is not None:
+            if not callable(getattr(credential_provider, "get_credential", None)):
+                raise TypeError("credential_provider must implement get_credential")
+            self.credential_provider = credential_provider
+        elif self.config.api_key:
+            self.credential_provider = ApiKeyCredentialProvider(self.config.api_key)
+        else:
+            raise ValueError("QVeris API key or credential_provider is required")
         self.headers = {
             "Content-Type": "application/json",
         }
-        if self.config.api_key:
-            self.headers["Authorization"] = f"Bearer {self.config.api_key}"
 
         # httpx automatically respects HTTP_PROXY/HTTPS_PROXY env vars (kept by
         # using the default transport). Retries are layered on top at the client
@@ -82,7 +97,18 @@ class QverisClient:
 
     async def _send(self, method: str, endpoint: str, **kwargs: Any) -> httpx.Response:
         """Send a request through the retry policy (429/503 backoff)."""
-        return await self._retry.send(self.client, method, endpoint, **kwargs)
+        request_headers = dict(kwargs.pop("headers", {}))
+
+        async def prepare_attempt() -> Dict[str, Any]:
+            credential = await resolve_credential(
+                self.credential_provider,
+                CredentialContext(resource=self.config.base_url, scopes=()),
+            )
+            headers = dict(request_headers)
+            headers["Authorization"] = f"Bearer {credential}"
+            return {"headers": headers}
+
+        return await self._retry.send(self.client, method, endpoint, prepare_attempt=prepare_attempt, **kwargs)
 
     @property
     def rate_limit_retries(self) -> int:
@@ -116,7 +142,9 @@ class QverisClient:
 
     def _debug_headers(self) -> None:
         """Log request headers with authorization redacted."""
-        headers = {k: v if k != "Authorization" else "Bearer ***" for k, v in self.headers.items()}
+        headers = dict(self.headers)
+        if self.credential_provider is not None:
+            headers["Authorization"] = "Bearer ***"
         self._debug(f"[Qveris API] Headers: {json.dumps(headers, indent=2)}")
 
     def _query_params(self, **kwargs: Any) -> Dict[str, Any]:

--- a/packages/python-sdk/qveris/client/retry.py
+++ b/packages/python-sdk/qveris/client/retry.py
@@ -19,7 +19,7 @@ import asyncio
 import email.utils
 import random
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 import httpx
 
@@ -96,11 +96,22 @@ class RetryPolicy:
         self.retries = 0
         self.total_backoff_seconds = 0.0
 
-    async def send(self, client: httpx.AsyncClient, method: str, url: str, **kwargs: Any) -> httpx.Response:
+    async def send(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        url: str,
+        *,
+        prepare_attempt: Optional[Callable[[], Awaitable[Dict[str, Any]]]] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
         """Send a request through ``client``, retrying 429/503 with backoff."""
         attempt = 0
         while True:
-            response = await client.request(method, url, **kwargs)
+            attempt_kwargs = dict(kwargs)
+            if prepare_attempt is not None:
+                attempt_kwargs.update(await prepare_attempt())
+            response = await client.request(method, url, **attempt_kwargs)
             if response.status_code not in RETRYABLE_STATUS or attempt >= self.max_retries:
                 return response
 

--- a/packages/python-sdk/qveris/config.py
+++ b/packages/python-sdk/qveris/config.py
@@ -72,7 +72,7 @@ class QverisConfig(BaseSettings):
     # Qveris Settings. The env source reads ONLY the ``QVERIS_``-prefixed names;
     # an explicit ``QverisConfig(api_key=...)`` still wins over the env var via
     # the custom init source below (see settings_customise_sources / #136).
-    api_key: Optional[str] = Field(default=None, validation_alias="QVERIS_API_KEY")
+    api_key: Optional[str] = Field(default=None, validation_alias="QVERIS_API_KEY", repr=False)
     base_url: str = Field(default="https://qveris.ai/api/v1", validation_alias="QVERIS_BASE_URL")
 
     # Transport settings. On a 429 (or 503) the client honors Retry-After and

--- a/packages/python-sdk/qveris/credentials.py
+++ b/packages/python-sdk/qveris/credentials.py
@@ -1,0 +1,46 @@
+"""Credential providers for authenticated QVeris API requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Tuple
+
+
+@dataclass(frozen=True)
+class CredentialContext:
+    """Context supplied whenever the client requests a credential."""
+
+    resource: str
+    scopes: Tuple[str, ...] = ()
+
+
+class CredentialProvider(Protocol):
+    """Async source of bearer credentials for QVeris API requests."""
+
+    async def get_credential(self, context: CredentialContext) -> str:
+        """Return a bearer credential for ``context``."""
+        ...
+
+
+class ApiKeyCredentialProvider:
+    """Credential provider backed by a static QVeris API key."""
+
+    def __init__(self, api_key: str) -> None:
+        value = api_key.strip()
+        if not value or "\r" in value or "\n" in value:
+            raise ValueError("QVeris API key is required")
+        self._api_key = value
+
+    async def get_credential(self, context: CredentialContext) -> str:
+        return self._api_key
+
+
+async def resolve_credential(provider: CredentialProvider, context: CredentialContext) -> str:
+    """Resolve a valid credential without including its value in errors."""
+    try:
+        credential = await provider.get_credential(context)
+    except Exception:
+        raise RuntimeError("QVeris credential provider failed to provide a credential") from None
+    if not isinstance(credential, str) or not credential.strip() or "\r" in credential or "\n" in credential:
+        raise ValueError("QVeris credential provider returned an invalid credential")
+    return credential.strip()

--- a/packages/python-sdk/tests/test_client_contracts.py
+++ b/packages/python-sdk/tests/test_client_contracts.py
@@ -6,7 +6,9 @@ import pytest
 
 from qveris.client import CALL_TOOL_DEF, DISCOVER_TOOL_DEF, INSPECT_TOOL_DEF
 from qveris.client.api import QverisClient
+from qveris.client.retry import RetryPolicy
 from qveris.config import QverisConfig
+from qveris.credentials import ApiKeyCredentialProvider, CredentialContext
 
 
 def make_client(handler: Callable[[httpx.Request], httpx.Response]) -> QverisClient:
@@ -20,6 +22,147 @@ def make_client(handler: Callable[[httpx.Request], httpx.Response]) -> QverisCli
     return client
 
 
+@pytest.mark.asyncio
+async def test_api_key_provider_preserves_authorization_without_repr_leak() -> None:
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"search_id": "search-1", "results": []})
+
+    client = make_client(handler)
+    try:
+        await client.discover("weather")
+    finally:
+        await client.close()
+
+    assert requests[0].headers["Authorization"] == "Bearer sk-test"
+    assert "sk-test" not in repr(ApiKeyCredentialProvider("sk-test"))
+
+
+class RecordingCredentialProvider:
+    def __init__(self, credential: str = "short-lived-token") -> None:
+        self.credential = credential
+        self.contexts = []
+
+    async def get_credential(self, context: CredentialContext) -> str:
+        self.contexts.append(context)
+        return self.credential
+
+
+@pytest.mark.asyncio
+async def test_async_credential_provider_receives_api_resource() -> None:
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"search_id": "search-1", "results": []})
+
+    provider = RecordingCredentialProvider()
+    client = QverisClient(
+        QverisConfig(api_key=None, base_url="https://custom.example/api/v1"),
+        credential_provider=provider,
+    )
+    client.client = httpx.AsyncClient(
+        base_url=client.base_url,
+        headers=client.headers,
+        transport=httpx.MockTransport(handler),
+        timeout=60.0,
+    )
+    try:
+        await client.discover("weather")
+    finally:
+        await client.close()
+
+    assert provider.contexts == [CredentialContext(resource="https://custom.example/api/v1", scopes=())]
+    assert requests[0].headers["Authorization"] == "Bearer short-lived-token"
+
+
+def test_rejects_api_key_and_credential_provider_together() -> None:
+    with pytest.raises(ValueError, match="either api_key or credential_provider"):
+        QverisClient(QverisConfig(api_key="sk-test"), credential_provider=RecordingCredentialProvider())
+
+
+def test_requires_api_key_or_credential_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("QVERIS_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="API key or credential_provider is required"):
+        QverisClient(QverisConfig(api_key=None))
+
+
+def test_rejects_credential_provider_without_get_credential() -> None:
+    with pytest.raises(TypeError, match="credential_provider must implement get_credential"):
+        QverisClient(QverisConfig(api_key=None), credential_provider=object())
+
+
+@pytest.mark.asyncio
+async def test_resolves_a_fresh_credential_for_each_retry_attempt() -> None:
+    authorizations = []
+
+    class RotatingCredentialProvider:
+        def __init__(self) -> None:
+            self.contexts = []
+
+        async def get_credential(self, context: CredentialContext) -> str:
+            self.contexts.append(context)
+            return f"token-{len(self.contexts)}"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        authorizations.append(request.headers["Authorization"])
+        if len(authorizations) == 1:
+            return httpx.Response(429, json={"error": "rate limited"})
+        return httpx.Response(200, json={"search_id": "search-1", "results": []})
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    provider = RotatingCredentialProvider()
+    client = QverisClient(QverisConfig(api_key=None), credential_provider=provider)
+    client._retry = RetryPolicy(sleep=no_sleep, rng=lambda: 0.0)
+    client.client = httpx.AsyncClient(
+        base_url=client.base_url,
+        headers=client.headers,
+        transport=httpx.MockTransport(handler),
+        timeout=60.0,
+    )
+    try:
+        await client.discover("weather")
+    finally:
+        await client.close()
+
+    expected_context = CredentialContext(resource="https://qveris.ai/api/v1", scopes=())
+    assert provider.contexts == [expected_context, expected_context]
+    assert authorizations == ["Bearer token-1", "Bearer token-2"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_provider_credential_is_not_exposed() -> None:
+    provider = RecordingCredentialProvider("secret-token\nforged-header")
+    client = QverisClient(QverisConfig(api_key=None), credential_provider=provider)
+    try:
+        with pytest.raises(ValueError, match="invalid credential") as exc_info:
+            await client.discover("weather")
+    finally:
+        await client.close()
+
+    assert "secret-token" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_text_is_not_exposed() -> None:
+    class FailingCredentialProvider:
+        async def get_credential(self, context: CredentialContext) -> str:
+            raise RuntimeError("failed while handling secret-token")
+
+    client = QverisClient(QverisConfig(api_key=None), credential_provider=FailingCredentialProvider())
+    try:
+        with pytest.raises(RuntimeError, match="failed to provide a credential") as exc_info:
+            await client.discover("weather")
+    finally:
+        await client.close()
+
+    assert "secret-token" not in str(exc_info.value)
+
+
 def test_qveris_config_constructor_values_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("QVERIS_API_KEY", "sk-env")
     monkeypatch.setenv("QVERIS_BASE_URL", "https://env.example/api/v1")
@@ -28,6 +171,7 @@ def test_qveris_config_constructor_values_override_env(monkeypatch: pytest.Monke
 
     assert config.api_key == "sk-test"
     assert config.base_url == "https://qveris.ai/api/v1"
+    assert "sk-test" not in repr(config)
 
 
 def test_qveris_config_reads_env_when_no_init_value(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/python-sdk/tests/test_public_exports.py
+++ b/packages/python-sdk/tests/test_public_exports.py
@@ -1,4 +1,13 @@
-from qveris import Agent, Message, QverisClient, SearchResponse, ToolExecutionResponse
+from qveris import (
+    Agent,
+    ApiKeyCredentialProvider,
+    CredentialContext,
+    CredentialProvider,
+    Message,
+    QverisClient,
+    SearchResponse,
+    ToolExecutionResponse,
+)
 from qveris.client import (
     CALL_TOOL_DEF,
     DEFAULT_SYSTEM_PROMPT,
@@ -14,6 +23,9 @@ from qveris.types import ToolInfo, ToolParameter
 def test_public_sdk_exports_cover_core_classes_and_models() -> None:
     assert Agent.__name__ == "Agent"
     assert QverisClient.__name__ == "QverisClient"
+    assert ApiKeyCredentialProvider.__name__ == "ApiKeyCredentialProvider"
+    assert CredentialContext(resource="https://qveris.ai/api/v1").scopes == ()
+    assert CredentialProvider.__name__ == "CredentialProvider"
     assert Message(role="user", content="hello").role == "user"
     assert SearchResponse(results=[{"tool_id": "tool-1"}]).results[0].tool_id == "tool-1"
     assert ToolExecutionResponse(execution_id="exec-1", success=True).success is True


### PR DESCRIPTION
## Summary

- introduce an API-key-compatible credential-provider boundary in the CLI request layer
- add public async-capable credential providers to the JavaScript and Python SDKs
- preserve all existing API-key and endpoint-resolution behavior
- reject ambiguous API key/provider configuration and invalid credential values before network access
- prevent provider failure text, API keys, and returned credentials from appearing in normal errors or representations

## Public contract

- JavaScript exports `CredentialProvider`, `CredentialContext`, `ApiKeyCredentialProvider`, and `QverisClientOptions`
- Python exports `CredentialProvider`, `CredentialContext`, and `ApiKeyCredentialProvider`
- providers receive the normalized API resource and an empty scope list; no protocol endpoint or scope is invented by this phase
- providers never select or rewrite the API endpoint
- existing `apiKey`, `QVERIS_API_KEY`, and `QverisConfig.api_key` paths remain compatible

## Verification

- CLI: 87 tests passed; lint and coverage passed
- JavaScript SDK: 55 tests passed; typecheck, lint, type drift, and coverage passed
- Python SDK: 102 tests passed, 1 skipped; Ruff check/format and coverage passed
- public documentation boundary scans passed; only historical changelog entries describing old releases remain

## Out of scope

Device Flow, refresh rotation, revoke, token exchange, and delegation remain blocked on public protocol contracts and are tracked separately under #200.

Closes #226
