### PR TITLE
docs: align hosted MCP endpoint guidance

### DIFF
--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -122,14 +122,37 @@ qveris mcp validate --target cursor --probe
 
 ## Hosted MCP
 
-Hosted MCP 已列入规划，但当前接入路径不依赖托管端点。在正式发布托管端点前，请使用上文的 stdio server：`npx -y @qverisai/mcp`。
+QVeris 提供远程 Streamable HTTP MCP 托管服务，无需安装本地软件包或运行后台进程。如果端点暂时不可用，请在托管服务发布完成前继续使用上文的本地 stdio 软件包。
 
-托管 MCP 端点可用后，接入流程会是：
+```text
+https://mcp.qveris.cn/mcp
+```
 
-1. 创建或选择一个 QVeris API key。
-2. 从 QVeris 控制台或文档复制 hosted MCP URL。
-3. 按 MCP 客户端的远程 MCP 配置流程添加该 hosted URL。
-4. 运行 `qveris mcp validate --target <client>` 或使用客户端内置工具列表，确认 `discover`、`inspect`、`call` 可见。
+在支持远程 MCP 的客户端中添加服务地址，并在每次请求中发送 QVeris API 密钥：
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_QVERIS_API_KEY"
+      }
+    }
+  }
+}
+```
+
+接入步骤：
+
+1. 在[控制台/API 密钥](/account?page=api-keys)创建密钥。
+2. 将服务地址和 Bearer 请求头添加到客户端。客户端支持时，请用密钥管理或环境变量保存 API 密钥，切勿提交到源代码仓库。
+3. 重新连接客户端，确认 `discover`、`inspect`、`call` 可见。
+
+服务会在会话启动时验证并绑定密钥。`401` 表示密钥缺失或无效；`503` 表示验证服务暂时不可用。更换密钥后请新建 MCP 会话。可前往[托管 MCP 页面](/hosted-mcp)复制配置。
+
+不支持远程 Streamable HTTP MCP 的客户端仍可使用本地 stdio 软件包。
 
 ---
 

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -141,14 +141,43 @@ For environment-specific setup guides, see:
 
 ## Hosted MCP
 
-Hosted MCP is planned but not required for the current onboarding path. Until a hosted endpoint is published, use the stdio server shown above with `npx -y @qverisai/mcp`.
+QVeris provides a remote Streamable HTTP MCP service. It requires no local package or background process. If the endpoint is not yet available, continue using the local stdio package shown above while the hosted service rollout completes.
 
-When a hosted MCP endpoint becomes available, the onboarding flow will be:
+```text
+https://mcp.qveris.ai/mcp
+```
 
-1. Create or select a QVeris API key.
-2. Copy the hosted MCP URL from the QVeris dashboard or docs.
-3. Add the hosted URL to your MCP client using its remote MCP configuration flow.
-4. Run `qveris mcp validate --target <client>` or the client's built-in tool list view and confirm `discover`, `inspect`, and `call` are visible.
+Add the endpoint to a remote-MCP-compatible client and send your QVeris API key on every request:
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_QVERIS_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Claude Code can add it from the command line:
+
+```bash
+claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --header "Authorization: Bearer YOUR_QVERIS_API_KEY"
+```
+
+Setup flow:
+
+1. Create a key on [Dashboard / API Keys](/account?page=api-keys).
+2. Add the endpoint and Bearer header to your client. Store the key in a secret or environment variable when supported; never commit it.
+3. Reconnect the client and confirm `discover`, `inspect`, and `call` are visible.
+
+The server validates the key when a session starts and binds that session to the credential. A `401` means the key is missing or invalid; a `503` means validation is temporarily unavailable. Start a new MCP session after changing the key. See the [Hosted MCP page](/hosted-mcp) for a copy-ready setup.
+
+The local stdio package remains available for clients that do not support remote Streamable HTTP MCP.
 
 ---
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -141,14 +141,43 @@ qveris mcp validate --target cursor --probe
 
 ## Hosted MCP
 
-Hosted MCP 已列入规划，但当前接入路径不依赖托管端点。在正式发布托管端点前，请使用上文的 stdio server：`npx -y @qverisai/mcp`。
+QVeris 提供远程 Streamable HTTP MCP 托管服务，无需安装本地软件包或运行后台进程。如果端点暂时不可用，请在托管服务发布完成前继续使用上文的本地 stdio 软件包。
 
-托管 MCP 端点可用后，接入流程会是：
+```text
+https://mcp.qveris.ai/mcp
+```
 
-1. 创建或选择一个 QVeris API key。
-2. 从 QVeris 控制台或文档复制 hosted MCP URL。
-3. 按 MCP 客户端的远程 MCP 配置流程添加该 hosted URL。
-4. 运行 `qveris mcp validate --target <client>` 或使用客户端内置工具列表，确认 `discover`、`inspect`、`call` 可见。
+在支持远程 MCP 的客户端中添加服务地址，并在每次请求中发送 QVeris API 密钥：
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_QVERIS_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Claude Code 可直接通过命令行添加：
+
+```bash
+claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --header "Authorization: Bearer YOUR_QVERIS_API_KEY"
+```
+
+接入步骤：
+
+1. 在[控制台/API 密钥](/account?page=api-keys)创建密钥。
+2. 将服务地址和 Bearer 请求头添加到客户端。客户端支持时，请用密钥管理或环境变量保存 API 密钥，切勿提交到源代码仓库。
+3. 重新连接客户端，确认 `discover`、`inspect`、`call` 可见。
+
+服务会在会话启动时验证并绑定密钥。`401` 表示密钥缺失或无效；`503` 表示验证服务暂时不可用。更换密钥后请新建 MCP 会话。可前往[托管 MCP 页面](/hosted-mcp)复制配置。
+
+不支持远程 Streamable HTTP MCP 的客户端仍可使用本地 stdio 软件包。
 
 ---
 


### PR DESCRIPTION
## Summary

- document the hosted Streamable HTTP MCP endpoints for the global and China-facing guides
- keep the local stdio package as an explicit fallback while the hosted rollout completes
- preserve public-site boundaries and omit unsupported assistant-specific instructions from the China-facing guide

## Root cause

The toolkit-owned MCP guides still described hosted MCP as a future-only capability, while the downstream documentation had already moved to the target endpoint guidance. A source sync would therefore regress the published content.

## Impact

The toolkit becomes authoritative for the intended hosted MCP setup without hiding the temporary stdio fallback. Future documentation syncs retain the correct endpoint and audience-specific copy.

## Validation

- `node scripts/check-doc-locales.mjs`
- `git diff --check`
- public documentation region-boundary scans from `AGENTS.md`
- downstream sync dry run and local sync comparison