### PR TITLE
feat(cli): add OAuth Device Flow authentication

### DIFF
--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -264,7 +264,22 @@ qveris mcp validate --target cursor --probe
 
 ---
 
-### `qveris login`
+### `qveris auth login/status/logout`
+
+设置本站 API 地址后，可在本地或无头终端通过 OAuth Device Flow 登录，无需复制 API 密钥。CLI 从当前站点的 Discovery 获取全部 OAuth 端点，打开验证页面，并严格按服务端返回的轮询间隔等待授权。
+
+```bash
+export QVERIS_BASE_URL="https://qveris.cn/api/v1"
+qveris auth login
+qveris auth status
+qveris auth logout
+```
+
+Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 会明确降级为仅当前进程有效的凭证。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
+
+无头主机可使用 `--no-browser`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
+
+### `qveris login`（API Key）
 
 使用 QVeris API 密钥认证。打开浏览器进入 API 密钥页面并掩码输入。
 

--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -275,9 +275,9 @@ qveris auth status
 qveris auth logout
 ```
 
-Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 会明确降级为仅当前进程有效的凭证。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
+Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 默认仅在当前进程保留凭证。在可信的无头主机上，可显式添加 `--allow-unencrypted-storage`，将 token 持久化到权限为 `0600` 的用户配置文件中。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
 
-无头主机可使用 `--no-browser`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
+在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
 
 ### `qveris login`（API Key）
 

--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -277,6 +277,8 @@ qveris auth logout
 
 Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 默认仅在当前进程保留凭证。在可信的无头主机上，可显式添加 `--allow-unencrypted-storage`，将 token 持久化到权限为 `0600` 的用户配置文件中。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
 
+持久化的 OAuth 会话还会记住本站 API 地址，供后续 CLI 进程自动恢复。显式传入的 `--base-url` 或 `QVERIS_BASE_URL` 仍具有更高优先级，且必须与会话 issuer 匹配。
+
 在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约，且自定义 scope 必须保留 `offline_access`，以便安全刷新会话。
 
 ### `qveris login`（API Key）
@@ -377,7 +379,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-面向首次调用的自检诊断：依次检查 Node.js 版本、API 密钥、API 地址，再用一次免费的 `discover` 探测覆盖连通性、密钥有效性、剩余积分，以及响应结构是否符合 CLI 合同。每项失败都会给出可执行的修复建议。诊断不消耗积分（discover 免费）。加 `--json` 输出机器可读结果。
+面向首次调用的自检诊断：依次检查 Node.js 版本、当前 API Key 或 OAuth 会话、API 地址，再用一次免费的 `discover` 探测覆盖连通性、凭证有效性、剩余积分，以及响应结构是否符合 CLI 合同。每项失败都会给出可执行的修复建议。诊断不消耗积分（discover 免费）。加 `--json` 输出机器可读结果。
 
 ### `qveris config`
 
@@ -457,7 +459,7 @@ qveris history [--clear]
 
 **优先级：**`--flag` > 环境变量 > 配置文件 > 默认值
 
-API 地址单独遵循 `--base-url` > `QVERIS_BASE_URL` > 内置默认值。使用本站服务时，请设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1`。API 密钥不会选择或替换地址；覆盖值必须是完整的 HTTP(S) URL，且不能包含凭据、查询参数或片段。
+API 地址单独遵循 `--base-url` > `QVERIS_BASE_URL` > 已存储的 OAuth 会话地址（OAuth 生效时）> 内置默认值。首次使用本站服务时，请设置 `QVERIS_BASE_URL=https://qveris.cn/api/v1`；完成 OAuth 登录后，CLI 会自动恢复该地址。API 密钥不会选择或替换地址；覆盖值必须是完整的 HTTP(S) URL，且不能包含凭据、查询参数或片段。
 
 ---
 

--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -277,7 +277,7 @@ qveris auth logout
 
 Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 默认仅在当前进程保留凭证。在可信的无头主机上，可显式添加 `--allow-unencrypted-storage`，将 token 持久化到权限为 `0600` 的用户配置文件中。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
 
-在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
+在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约，且自定义 scope 必须保留 `offline_access`，以便安全刷新会话。
 
 ### `qveris login`（API Key）
 

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -276,9 +276,9 @@ qveris auth status
 qveris auth logout
 ```
 
-Refresh credentials are rotated automatically and stored in the operating-system credential store. If no credential store is available, the CLI explicitly limits the credential to the current process. `auth logout` attempts remote revocation before clearing local credentials. An explicitly configured API key keeps its existing priority and behavior.
+Refresh credentials are rotated automatically and stored in the operating-system credential store. If no credential store is available, the CLI limits the credential to the current process by default. On a trusted headless host, add `--allow-unencrypted-storage` to explicitly persist the tokens in the user-only config file (`0600` permissions). `auth logout` attempts remote revocation before clearing local credentials. An explicitly configured API key keeps its existing priority and behavior.
 
-Use `--no-browser` on a headless host. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract.
+Use `--no-browser --allow-unencrypted-storage` on a trusted headless host that has no operating-system keyring. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract.
 
 ### `qveris login` (API key)
 

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -266,7 +266,21 @@ qveris mcp validate --target cursor --probe
 
 ---
 
-### `qveris login`
+### `qveris auth login/status/logout`
+
+Use OAuth Device Flow on a local or headless terminal without copying an API key. The CLI discovers all OAuth endpoints from the selected API origin, opens the verification page, and polls at the server-provided interval.
+
+```bash
+qveris auth login
+qveris auth status
+qveris auth logout
+```
+
+Refresh credentials are rotated automatically and stored in the operating-system credential store. If no credential store is available, the CLI explicitly limits the credential to the current process. `auth logout` attempts remote revocation before clearing local credentials. An explicitly configured API key keeps its existing priority and behavior.
+
+Use `--no-browser` on a headless host. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract.
+
+### `qveris login` (API key)
 
 Authenticate with your QVeris API key. Opens the browser to the API key page and prompts for masked input.
 

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -278,7 +278,7 @@ qveris auth logout
 
 Refresh credentials are rotated automatically and stored in the operating-system credential store. If no credential store is available, the CLI limits the credential to the current process by default. On a trusted headless host, add `--allow-unencrypted-storage` to explicitly persist the tokens in the user-only config file (`0600` permissions). `auth logout` attempts remote revocation before clearing local credentials. An explicitly configured API key keeps its existing priority and behavior.
 
-Use `--no-browser --allow-unencrypted-storage` on a trusted headless host that has no operating-system keyring. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract.
+Use `--no-browser --allow-unencrypted-storage` on a trusted headless host that has no operating-system keyring. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract, and a custom scope must retain `offline_access` so the session can refresh safely.
 
 ### `qveris login` (API key)
 

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -278,6 +278,8 @@ qveris auth logout
 
 Refresh credentials are rotated automatically and stored in the operating-system credential store. If no credential store is available, the CLI limits the credential to the current process by default. On a trusted headless host, add `--allow-unencrypted-storage` to explicitly persist the tokens in the user-only config file (`0600` permissions). `auth logout` attempts remote revocation before clearing local credentials. An explicitly configured API key keeps its existing priority and behavior.
 
+The persisted OAuth session also remembers its API endpoint for later CLI processes. An explicit `--base-url` or `QVERIS_BASE_URL` still takes precedence and must match the session issuer.
+
 Use `--no-browser --allow-unencrypted-storage` on a trusted headless host that has no operating-system keyring. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract, and a custom scope must retain `offline_access` so the session can refresh safely.
 
 ### `qveris login` (API key)
@@ -425,7 +427,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-Self-check diagnostics for a working first call. Checks Node.js version, API key, API endpoint, then a free `discover` probe covering connectivity, key validity, remaining credits, and response-shape conformance to the CLI contract. Each failure prints an actionable fix. Diagnostics consume no credits (discover is free). Add `--json` for machine-readable output.
+Self-check diagnostics for a working first call. Checks Node.js version, the active API key or OAuth session, the API endpoint, then a free `discover` probe covering connectivity, credential validity, remaining credits, and response-shape conformance to the CLI contract. Each failure prints an actionable fix. Diagnostics consume no credits (discover is free). Add `--json` for machine-readable output.
 
 ```bash
 qveris doctor
@@ -510,7 +512,7 @@ Use `--` to end option parsing: `qveris discover -- --literal-query`.
 
 **Priority:** `--flag` > environment variable > config file > default
 
-For the API endpoint specifically, resolution is `--base-url` > `QVERIS_BASE_URL` > built-in default. API keys never select or replace the endpoint. Override values must be complete HTTP(S) URLs without credentials, query parameters, or fragments.
+For the API endpoint specifically, resolution is `--base-url` > `QVERIS_BASE_URL` > stored OAuth session endpoint (when OAuth is active) > built-in default. API keys never select or replace the endpoint. Override values must be complete HTTP(S) URLs without credentials, query parameters, or fragments.
 
 ---
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -276,9 +276,9 @@ qveris auth status
 qveris auth logout
 ```
 
-Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 会明确降级为仅当前进程有效的凭证。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
+Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 默认仅在当前进程保留凭证。在可信的无头主机上，可显式添加 `--allow-unencrypted-storage`，将 token 持久化到权限为 `0600` 的用户配置文件中。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
 
-无头主机可使用 `--no-browser`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
+在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
 
 ### `qveris login`（API Key）
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -266,7 +266,21 @@ qveris mcp validate --target cursor --probe
 
 ---
 
-### `qveris login`
+### `qveris auth login/status/logout`
+
+在本地或无头终端通过 OAuth Device Flow 登录，无需复制 API 密钥。CLI 从当前 API 站点的 Discovery 获取全部 OAuth 端点，打开验证页面，并严格按服务端返回的轮询间隔等待授权。
+
+```bash
+qveris auth login
+qveris auth status
+qveris auth logout
+```
+
+Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 会明确降级为仅当前进程有效的凭证。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
+
+无头主机可使用 `--no-browser`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
+
+### `qveris login`（API Key）
 
 使用 QVeris API 密钥认证。打开浏览器进入 API 密钥页面并掩码输入。
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -278,6 +278,8 @@ qveris auth logout
 
 Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 默认仅在当前进程保留凭证。在可信的无头主机上，可显式添加 `--allow-unencrypted-storage`，将 token 持久化到权限为 `0600` 的用户配置文件中。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
 
+持久化的 OAuth 会话还会记住其 API 地址，供后续 CLI 进程自动恢复。显式传入的 `--base-url` 或 `QVERIS_BASE_URL` 仍具有更高优先级，且必须与会话 issuer 匹配。
+
 在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约，且自定义 scope 必须保留 `offline_access`，以便安全刷新会话。
 
 ### `qveris login`（API Key）
@@ -378,7 +380,7 @@ qveris> exit
 
 ### `qveris doctor`
 
-面向首次调用的自检诊断：依次检查 Node.js 版本、API 密钥、API 地址，再用一次免费的 `discover` 探测覆盖连通性、密钥有效性、剩余积分，以及响应结构是否符合 CLI 合同。每项失败都会给出可执行的修复建议。诊断不消耗积分（discover 免费）。加 `--json` 输出机器可读结果。
+面向首次调用的自检诊断：依次检查 Node.js 版本、当前 API Key 或 OAuth 会话、API 地址，再用一次免费的 `discover` 探测覆盖连通性、凭证有效性、剩余积分，以及响应结构是否符合 CLI 合同。每项失败都会给出可执行的修复建议。诊断不消耗积分（discover 免费）。加 `--json` 输出机器可读结果。
 
 ### `qveris config`
 
@@ -458,7 +460,7 @@ qveris history [--clear]
 
 **优先级：** `--flag` > 环境变量 > 配置文件 > 默认值
 
-API 地址单独遵循 `--base-url` > `QVERIS_BASE_URL` > 内置默认值。API 密钥不会选择或替换地址。覆盖值必须是完整的 HTTP(S) URL，且不能包含凭据、查询参数或片段。
+API 地址单独遵循 `--base-url` > `QVERIS_BASE_URL` > 已存储的 OAuth 会话地址（OAuth 生效时）> 内置默认值。API 密钥不会选择或替换地址。覆盖值必须是完整的 HTTP(S) URL，且不能包含凭据、查询参数或片段。
 
 ---
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -278,7 +278,7 @@ qveris auth logout
 
 Refresh Token 会自动轮换并保存在操作系统凭证库中。系统凭证库不可用时，CLI 默认仅在当前进程保留凭证。在可信的无头主机上，可显式添加 `--allow-unencrypted-storage`，将 token 持久化到权限为 `0600` 的用户配置文件中。`auth logout` 会先尝试远程撤销，再清理本地凭证。显式配置的 API Key 继续保持原有优先级和行为。
 
-在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约。
+在没有操作系统凭证库的可信无头主机上，可使用 `--no-browser --allow-unencrypted-storage`。高级集成可通过 `--scope <scopes>` 和 `--resource <url>` 收窄授权请求；两者都必须符合服务端公开契约，且自定义 scope 必须保留 `offline_access`，以便安全刷新会话。
 
 ### `qveris login`（API Key）
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added `qveris auth login/status/logout` using OAuth Device Authorization Grant, refresh-token rotation, revocation, and operating-system credential storage. API key authentication remains fully compatible and takes precedence when configured.
+
 ## [0.8.2] - 2026-07-18
 
 ### Changed

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,7 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
-- Added `qveris auth login/status/logout` using OAuth Device Authorization Grant, refresh-token rotation, revocation, and operating-system credential storage. API key authentication remains fully compatible and takes precedence when configured.
+- Added `qveris auth login/status/logout` using OAuth Device Authorization Grant, refresh-token rotation, revocation, and operating-system credential storage. Trusted headless hosts can explicitly opt into a user-only unencrypted config fallback. API key authentication remains fully compatible and takes precedence when configured.
 
 ## [0.8.2] - 2026-07-18
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -156,7 +156,7 @@ qveris call 1 --params '{"set":"land","first":"sct","timeOfDay":"day"}'
 | Command | Description |
 |---------|-------------|
 | `qveris interactive` | Launch REPL mode (discover/inspect/call/codegen in one session) |
-| `qveris doctor` | Self-check: Node.js version, API key, API endpoint, connectivity |
+| `qveris doctor` | Self-check: Node.js version, active credential, API endpoint, connectivity |
 | `qveris config <subcommand>` | Manage CLI settings (set, get, list, reset, path) |
 | `qveris mcp configure` | Generate MCP client config for Cursor, Claude Desktop, OpenCode, OpenClaw, or generic stdio; generate a `claude mcp add` command for Claude Code |
 | `qveris mcp validate` | Validate an MCP config file, with optional live stdio tool probing |
@@ -387,7 +387,7 @@ The CLI uses a built-in API endpoint by default. When an explicit endpoint is re
 qveris discover "weather" --base-url "$QVERIS_BASE_URL"
 ```
 
-Resolution order: `--base-url` > `QVERIS_BASE_URL` > built-in default. API keys never change the selected endpoint. Values must be complete HTTP(S) URLs without credentials, query parameters, or fragments; trailing slashes are normalized automatically.
+Resolution order: `--base-url` > `QVERIS_BASE_URL` > stored OAuth session endpoint (when OAuth is active) > built-in default. API keys never change the selected endpoint. Values must be complete HTTP(S) URLs without credentials, query parameters, or fragments; trailing slashes are normalized automatically.
 
 ### Rate limiting & retries
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -141,6 +141,9 @@ qveris call 1 --params '{"set":"land","first":"sct","timeOfDay":"day"}'
 
 | Command | Description |
 |---------|-------------|
+| `qveris auth login` | Authenticate through OAuth Device Flow without copying an API key |
+| `qveris auth status` | Validate the stored OAuth session |
+| `qveris auth logout` | Revoke and remove the stored OAuth session |
 | `qveris login` | Authenticate with an API key (opens the account page, or accepts `--token` for direct input) |
 | `qveris logout` | Remove stored key |
 | `qveris whoami` | Show current auth status, key source, and API endpoint |

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -20,6 +20,9 @@
       },
       "engines": {
         "node": ">=18.2.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring": "^1.3.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -262,6 +265,226 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@types/esrecurse": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "optionalDependencies": {
+    "@napi-rs/keyring": "^1.3.0"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "c8": "^11.0.0",

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -279,8 +279,15 @@ export async function pollDeviceToken(
 }
 
 function validateTokenResponse(payload, { requireRefreshToken = false } = {}) {
-  const validToken = (value) =>
-    typeof value === "string" && value.trim() && value.length <= MAX_OAUTH_TOKEN_LENGTH && !/[\r\n]/.test(value);
+  const validToken = (value, { allowInternalSpaces = false } = {}) =>
+    typeof value === "string" &&
+    value.length > 0 &&
+    value === value.trim() &&
+    value.length <= MAX_OAUTH_TOKEN_LENGTH &&
+    Array.from(value).every((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint >= (allowInternalSpaces ? 0x20 : 0x21) && codePoint <= 0x7e;
+    });
   if (
     typeof payload.token_type !== "string" ||
     payload.token_type.toLowerCase() !== "bearer" ||
@@ -288,8 +295,11 @@ function validateTokenResponse(payload, { requireRefreshToken = false } = {}) {
   ) {
     throw new CliError("API_ERROR", "Token endpoint returned an invalid access token response");
   }
-  if (requireRefreshToken && !validToken(payload.refresh_token)) {
+  if (payload.refresh_token === undefined && requireRefreshToken) {
     throw new CliError("API_ERROR", "Token endpoint did not return the required refresh token");
+  }
+  if (payload.refresh_token !== undefined && !validToken(payload.refresh_token, { allowInternalSpaces: true })) {
+    throw new CliError("API_ERROR", "Token endpoint returned an invalid refresh token");
   }
   if (
     payload.scope !== undefined &&

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -10,6 +10,15 @@ const MAX_DEVICE_TIMER_SECONDS = Math.floor(0x7fffffff / 1000);
 const MAX_TOKEN_LIFETIME_SECONDS = Math.floor((Number.MAX_SAFE_INTEGER - Date.now()) / 1000);
 let sharedRefreshPromise = null;
 
+function isSameOAuthSession(left, right) {
+  return (
+    left?.issuer === right?.issuer &&
+    left?.api_base_url === right?.api_base_url &&
+    left?.token_endpoint === right?.token_endpoint &&
+    left?.revocation_endpoint === right?.revocation_endpoint
+  );
+}
+
 function oauthError(code) {
   const messages = {
     access_denied: "Device authorization was denied",
@@ -81,9 +90,9 @@ function positiveNumber(value, label, defaultValue, maximum = Number.MAX_SAFE_IN
   return normalized;
 }
 
-async function timedFetch(fetchImpl, url, options = {}) {
+async function timedFetch(fetchImpl, url, options = {}, timeoutMs = OAUTH_REQUEST_TIMEOUT_MS) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), OAUTH_REQUEST_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     return await fetchImpl(url, { ...options, signal: controller.signal });
   } catch (error) {
@@ -130,13 +139,18 @@ export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
   return result;
 }
 
-async function postForm(url, form, fetchImpl = fetch) {
-  const response = await timedFetch(fetchImpl, url, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
-    body: new URLSearchParams(form),
-    redirect: "error",
-  });
+async function postForm(url, form, fetchImpl = fetch, timeoutMs = OAUTH_REQUEST_TIMEOUT_MS) {
+  const response = await timedFetch(
+    fetchImpl,
+    url,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body: new URLSearchParams(form),
+      redirect: "error",
+    },
+    timeoutMs,
+  );
   return { response, payload: await jsonResponse(response, "OAuth endpoint") };
 }
 
@@ -178,15 +192,23 @@ export async function pollDeviceToken(
   while (now() < deadline) {
     await sleep(Math.min(intervalMs, deadline - now()));
     if (now() >= deadline) break;
-    const { response, payload } = await postForm(
-      metadata.token_endpoint,
-      {
-        grant_type: DEVICE_CODE_GRANT,
-        client_id: OAUTH_CLIENT_ID,
-        device_code: authorization.device_code,
-      },
-      fetchImpl,
-    );
+    let tokenResult;
+    try {
+      tokenResult = await postForm(
+        metadata.token_endpoint,
+        {
+          grant_type: DEVICE_CODE_GRANT,
+          client_id: OAUTH_CLIENT_ID,
+          device_code: authorization.device_code,
+        },
+        fetchImpl,
+        Math.max(1, Math.min(OAUTH_REQUEST_TIMEOUT_MS, deadline - now())),
+      );
+    } catch (error) {
+      if (error?.code === "NET_TIMEOUT" && now() >= deadline) break;
+      throw error;
+    }
+    const { response, payload } = tokenResult;
     onPoll?.(payload.error || "approved");
     if (response.ok) return validateTokenResponse(payload, { requireRefreshToken: true });
     if (payload.error === "authorization_pending") continue;
@@ -254,7 +276,17 @@ export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
     ...metadata,
     expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
   };
-  const persisted = await saveOAuthSession(updated, replacement);
+  let persisted;
+  try {
+    persisted = await saveOAuthSession(updated, replacement);
+  } catch (error) {
+    try {
+      await revokeOAuthSession(updated, replacement, fetchImpl);
+    } catch {
+      // Preserve the local persistence error as the actionable failure.
+    }
+    throw error;
+  }
   if (["keyring", "config"].includes(metadata.storage) && !persisted) {
     throw new CliError("API_ERROR", "Rotated OAuth credentials could not be persisted; run qveris auth login again");
   }
@@ -308,6 +340,12 @@ export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) 
           if (!metadata || !secret) {
             throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
           }
+          if (!isSameOAuthSession(metadata, initialMetadata)) {
+            throw new CliError(
+              "API_ERROR",
+              "OAuth session changed while credentials were being refreshed; retry the command",
+            );
+          }
           if (
             secret.access_token !== initialSecret.access_token ||
             secret.refresh_token !== initialSecret.refresh_token
@@ -334,7 +372,14 @@ export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) 
         throw new CliError("API_ERROR", "OAuth session does not match the selected API endpoint");
       }
       if (Date.now() >= Number(metadata.expires_at || 0) - 60000) {
-        ({ secret } = await refresh());
+        const refreshed = await refresh();
+        if (!isSameOAuthSession(refreshed.metadata, metadata)) {
+          throw new CliError(
+            "API_ERROR",
+            "OAuth session changed while credentials were being refreshed; retry the command",
+          );
+        }
+        ({ secret } = refreshed);
       }
       return secret.access_token;
     },

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -5,6 +5,7 @@ import { getOAuthSessionMetadata, loadOAuthSessionSecret, saveOAuthSession } fro
 export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 export const OAUTH_CLIENT_ID = "qveris-cli";
 export const DEFAULT_OAUTH_SCOPES = "openid offline_access tools.search tools.inspect tools.execute";
+const OAUTH_REQUEST_TIMEOUT_MS = 30000;
 let sharedRefreshPromise = null;
 
 function oauthError(code) {
@@ -39,13 +40,26 @@ function validateEndpoint(value, label) {
   } catch {
     throw new CliError("API_ERROR", `OAuth discovery has an invalid ${label}`);
   }
-  if (url.protocol !== "https:" && url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
+  const isLoopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopback)) {
     throw new CliError("API_ERROR", `OAuth ${label} must use HTTPS`);
   }
   if (url.username || url.password || url.hash) {
     throw new CliError("API_ERROR", `OAuth discovery has an unsafe ${label}`);
   }
   return url.toString();
+}
+
+export function validateOAuthScopes(metadata, scope) {
+  const requestedScopes = scope.split(/\s+/).filter(Boolean);
+  if (!requestedScopes.includes("offline_access")) {
+    throw new CliError("API_ERROR", "OAuth scopes must include offline_access for a persistent CLI session");
+  }
+  const unsupported = requestedScopes.filter((item) => !metadata.scopes_supported.includes(item));
+  if (unsupported.length) {
+    throw new CliError("API_ERROR", `OAuth scopes are not supported: ${unsupported.join(", ")}`);
+  }
+  return requestedScopes;
 }
 
 function validateIssuerEndpoint(metadata, key) {
@@ -56,9 +70,31 @@ function validateIssuerEndpoint(metadata, key) {
   return endpoint;
 }
 
+function positiveNumber(value, label, defaultValue) {
+  if (value === undefined && defaultValue !== undefined) return defaultValue;
+  const normalized = Number(value);
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    throw new CliError("API_ERROR", `OAuth response has an invalid ${label}`);
+  }
+  return normalized;
+}
+
+async function timedFetch(fetchImpl, url, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OAUTH_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetchImpl(url, { ...options, signal: controller.signal });
+  } catch (error) {
+    if (error?.name === "AbortError") throw new CliError("NET_TIMEOUT", "OAuth request timed out");
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
   const normalizedIssuer = new URL(issuer).origin;
-  const response = await fetchImpl(`${normalizedIssuer}/.well-known/oauth-authorization-server`, {
+  const response = await timedFetch(fetchImpl, `${normalizedIssuer}/.well-known/oauth-authorization-server`, {
     headers: { Accept: "application/json" },
   });
   const metadata = await jsonResponse(response, "OAuth discovery");
@@ -72,7 +108,7 @@ export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
   if (!metadata.token_endpoint_auth_methods_supported?.includes("none")) {
     throw new CliError("API_ERROR", "This endpoint does not support the public QVeris CLI client");
   }
-  return {
+  const result = {
     issuer: normalizedIssuer,
     device_authorization_endpoint: validateEndpoint(
       metadata.device_authorization_endpoint,
@@ -82,10 +118,14 @@ export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
     revocation_endpoint: validateEndpoint(metadata.revocation_endpoint, "revocation_endpoint"),
     scopes_supported: Array.isArray(metadata.scopes_supported) ? metadata.scopes_supported : [],
   };
+  for (const key of ["device_authorization_endpoint", "token_endpoint", "revocation_endpoint"]) {
+    validateIssuerEndpoint(result, key);
+  }
+  return result;
 }
 
 async function postForm(url, form, fetchImpl = fetch) {
-  const response = await fetchImpl(url, {
+  const response = await timedFetch(fetchImpl, url, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
     body: new URLSearchParams(form),
@@ -113,8 +153,8 @@ export async function startDeviceAuthorization(metadata, { scope, resource }, fe
     ...payload,
     verification_uri: verificationUri,
     ...(verificationUriComplete ? { verification_uri_complete: verificationUriComplete } : {}),
-    expires_in: Number.isFinite(Number(payload.expires_in)) ? Number(payload.expires_in) : 600,
-    interval: Number.isFinite(Number(payload.interval)) ? Math.max(1, Number(payload.interval)) : 5,
+    expires_in: positiveNumber(payload.expires_in, "expires_in"),
+    interval: positiveNumber(payload.interval, "interval", 5),
   };
 }
 
@@ -126,7 +166,8 @@ export async function pollDeviceToken(
   const deadline = now() + authorization.expires_in * 1000;
   let intervalMs = authorization.interval * 1000;
   while (now() < deadline) {
-    await sleep(intervalMs);
+    await sleep(Math.min(intervalMs, deadline - now()));
+    if (now() >= deadline) break;
     const { response, payload } = await postForm(
       metadata.token_endpoint,
       {
@@ -137,7 +178,7 @@ export async function pollDeviceToken(
       fetchImpl,
     );
     onPoll?.(payload.error || "approved");
-    if (response.ok) return validateTokenResponse(payload);
+    if (response.ok) return validateTokenResponse(payload, { requireRefreshToken: true });
     if (payload.error === "authorization_pending") continue;
     if (payload.error === "slow_down") {
       intervalMs += 5000;
@@ -151,11 +192,19 @@ export async function pollDeviceToken(
   throw oauthError("expired_token", "Device authorization expired before it was approved");
 }
 
-function validateTokenResponse(payload) {
-  if (payload.token_type?.toLowerCase() !== "bearer" || typeof payload.access_token !== "string") {
+function validateTokenResponse(payload, { requireRefreshToken = false } = {}) {
+  if (
+    typeof payload.token_type !== "string" ||
+    payload.token_type.toLowerCase() !== "bearer" ||
+    typeof payload.access_token !== "string" ||
+    !payload.access_token.trim()
+  ) {
     throw new CliError("API_ERROR", "Token endpoint returned an invalid access token response");
   }
-  return payload;
+  if (requireRefreshToken && (typeof payload.refresh_token !== "string" || !payload.refresh_token.trim())) {
+    throw new CliError("API_ERROR", "Token endpoint did not return the required refresh token");
+  }
+  return { ...payload, expires_in: positiveNumber(payload.expires_in, "expires_in") };
 }
 
 export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
@@ -172,7 +221,11 @@ export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
   const tokens = validateTokenResponse(payload);
   // QVeris advertises refresh-token rotation as part of its public OAuth contract.
   // Rejecting a non-rotating response prevents reuse of a superseded credential.
-  if (typeof tokens.refresh_token !== "string" || !tokens.refresh_token) {
+  if (
+    typeof tokens.refresh_token !== "string" ||
+    !tokens.refresh_token.trim() ||
+    tokens.refresh_token === secret.refresh_token
+  ) {
     throw new CliError("API_ERROR", "Token endpoint did not rotate the refresh token");
   }
   const replacement = {
@@ -183,14 +236,17 @@ export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
     ...metadata,
     expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
   };
-  await saveOAuthSession(updated, replacement);
+  const persisted = await saveOAuthSession(updated, replacement);
+  if (["keyring", "config"].includes(metadata.storage) && !persisted) {
+    throw new CliError("API_ERROR", "Rotated OAuth credentials could not be persisted; run qveris auth login again");
+  }
   return { metadata: updated, secret: replacement };
 }
 
 export async function revokeOAuthToken(metadata, token, hint, fetchImpl = fetch) {
   if (!token) return;
   const revocationEndpoint = validateIssuerEndpoint(metadata, "revocation_endpoint");
-  const response = await fetchImpl(revocationEndpoint, {
+  const response = await timedFetch(fetchImpl, revocationEndpoint, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
     body: new URLSearchParams({ client_id: OAUTH_CLIENT_ID, token, token_type_hint: hint }),
@@ -232,6 +288,7 @@ export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) 
     return sharedRefreshPromise;
   }
   return {
+    authType: "oauth",
     async getCredential(context) {
       const metadata = getOAuthSessionMetadata();
       let secret = await loadOAuthSessionSecret(metadata);

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -1,0 +1,231 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { CliError } from "../errors/handler.mjs";
+import { getOAuthSessionMetadata, loadOAuthSessionSecret, saveOAuthSession } from "./storage.mjs";
+
+export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+export const OAUTH_CLIENT_ID = "qveris-cli";
+export const DEFAULT_OAUTH_SCOPES = "openid offline_access tools.search tools.inspect tools.execute";
+let sharedRefreshPromise = null;
+
+function oauthError(code) {
+  const messages = {
+    access_denied: "Device authorization was denied",
+    expired_token: "Device authorization or OAuth session expired",
+    invalid_grant: "OAuth session is invalid or no longer active",
+    invalid_client: "The public QVeris CLI client is unavailable",
+  };
+  const err = new CliError("AUTH_OAUTH_FAILED", messages[code] || `OAuth request failed (${code})`);
+  err.oauthCode = code;
+  return err;
+}
+
+async function jsonResponse(response, label) {
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new CliError("API_ERROR", `${label} returned invalid JSON`);
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new CliError("API_ERROR", `${label} returned an invalid response`);
+  }
+  return payload;
+}
+
+function validateEndpoint(value, label) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CliError("API_ERROR", `OAuth discovery has an invalid ${label}`);
+  }
+  if (url.protocol !== "https:" && url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
+    throw new CliError("API_ERROR", `OAuth ${label} must use HTTPS`);
+  }
+  if (url.username || url.password || url.hash) {
+    throw new CliError("API_ERROR", `OAuth discovery has an unsafe ${label}`);
+  }
+  return url.toString();
+}
+
+function validateIssuerEndpoint(metadata, key) {
+  const endpoint = validateEndpoint(metadata[key], key);
+  if (new URL(endpoint).origin !== metadata.issuer) {
+    throw new CliError("API_ERROR", `OAuth ${key} does not match the stored issuer`);
+  }
+  return endpoint;
+}
+
+export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
+  const normalizedIssuer = new URL(issuer).origin;
+  const response = await fetchImpl(`${normalizedIssuer}/.well-known/oauth-authorization-server`, {
+    headers: { Accept: "application/json" },
+  });
+  const metadata = await jsonResponse(response, "OAuth discovery");
+  if (!response.ok) throw oauthError(metadata.error || "discovery_failed", metadata.error_description);
+  if (metadata.issuer !== normalizedIssuer) {
+    throw new CliError("API_ERROR", "OAuth discovery issuer does not match the requested endpoint");
+  }
+  if (!metadata.grant_types_supported?.includes(DEVICE_CODE_GRANT)) {
+    throw new CliError("API_ERROR", "This endpoint does not advertise Device Authorization Grant");
+  }
+  if (!metadata.token_endpoint_auth_methods_supported?.includes("none")) {
+    throw new CliError("API_ERROR", "This endpoint does not support the public QVeris CLI client");
+  }
+  return {
+    issuer: normalizedIssuer,
+    device_authorization_endpoint: validateEndpoint(
+      metadata.device_authorization_endpoint,
+      "device_authorization_endpoint",
+    ),
+    token_endpoint: validateEndpoint(metadata.token_endpoint, "token_endpoint"),
+    revocation_endpoint: validateEndpoint(metadata.revocation_endpoint, "revocation_endpoint"),
+    scopes_supported: Array.isArray(metadata.scopes_supported) ? metadata.scopes_supported : [],
+  };
+}
+
+async function postForm(url, form, fetchImpl = fetch) {
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body: new URLSearchParams(form),
+  });
+  return { response, payload: await jsonResponse(response, "OAuth endpoint") };
+}
+
+export async function startDeviceAuthorization(metadata, { scope, resource }, fetchImpl = fetch) {
+  const { response, payload } = await postForm(
+    metadata.device_authorization_endpoint,
+    { client_id: OAUTH_CLIENT_ID, scope, resource },
+    fetchImpl,
+  );
+  if (!response.ok) throw oauthError(payload.error || "authorization_failed", payload.error_description);
+  for (const field of ["device_code", "user_code", "verification_uri"]) {
+    if (typeof payload[field] !== "string" || !payload[field]) {
+      throw new CliError("API_ERROR", `Device Authorization response is missing ${field}`);
+    }
+  }
+  return {
+    ...payload,
+    expires_in: Number.isFinite(Number(payload.expires_in)) ? Number(payload.expires_in) : 600,
+    interval: Number.isFinite(Number(payload.interval)) ? Math.max(1, Number(payload.interval)) : 5,
+  };
+}
+
+export async function pollDeviceToken(
+  metadata,
+  authorization,
+  { fetchImpl = fetch, sleep = (ms) => delay(ms), now = () => Date.now(), onPoll } = {},
+) {
+  const deadline = now() + authorization.expires_in * 1000;
+  let intervalMs = authorization.interval * 1000;
+  while (now() < deadline) {
+    await sleep(intervalMs);
+    const { response, payload } = await postForm(
+      metadata.token_endpoint,
+      {
+        grant_type: DEVICE_CODE_GRANT,
+        client_id: OAUTH_CLIENT_ID,
+        device_code: authorization.device_code,
+      },
+      fetchImpl,
+    );
+    onPoll?.(payload.error || "approved");
+    if (response.ok) return validateTokenResponse(payload);
+    if (payload.error === "authorization_pending") continue;
+    if (payload.error === "slow_down") {
+      intervalMs += 5000;
+      continue;
+    }
+    if (["access_denied", "expired_token", "invalid_grant"].includes(payload.error)) {
+      throw oauthError(payload.error, payload.error_description);
+    }
+    throw oauthError(payload.error || "token_error", payload.error_description);
+  }
+  throw oauthError("expired_token", "Device authorization expired before it was approved");
+}
+
+function validateTokenResponse(payload) {
+  if (payload.token_type?.toLowerCase() !== "bearer" || typeof payload.access_token !== "string") {
+    throw new CliError("API_ERROR", "Token endpoint returned an invalid access token response");
+  }
+  return payload;
+}
+
+export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
+  if (typeof secret.refresh_token !== "string" || !secret.refresh_token) {
+    throw oauthError("invalid_grant", "OAuth session cannot be refreshed; run qveris auth login again");
+  }
+  const tokenEndpoint = validateIssuerEndpoint(metadata, "token_endpoint");
+  const { response, payload } = await postForm(
+    tokenEndpoint,
+    { grant_type: "refresh_token", client_id: OAUTH_CLIENT_ID, refresh_token: secret.refresh_token },
+    fetchImpl,
+  );
+  if (!response.ok) throw oauthError(payload.error || "refresh_failed", payload.error_description);
+  const tokens = validateTokenResponse(payload);
+  if (typeof tokens.refresh_token !== "string" || !tokens.refresh_token) {
+    throw new CliError("API_ERROR", "Token endpoint did not rotate the refresh token");
+  }
+  const replacement = {
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+  };
+  const updated = {
+    ...metadata,
+    expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
+  };
+  await saveOAuthSession(updated, replacement);
+  return { metadata: updated, secret: replacement };
+}
+
+export async function revokeOAuthToken(metadata, token, hint, fetchImpl = fetch) {
+  if (!token) return;
+  const revocationEndpoint = validateIssuerEndpoint(metadata, "revocation_endpoint");
+  const response = await fetchImpl(revocationEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body: new URLSearchParams({ client_id: OAUTH_CLIENT_ID, token, token_type_hint: hint }),
+  });
+  if (response.ok) return;
+  const payload = await jsonResponse(response, "OAuth revocation endpoint");
+  throw oauthError(payload.error || "revoke_failed", payload.error_description);
+}
+
+export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) {
+  async function refresh() {
+    if (!sharedRefreshPromise) {
+      sharedRefreshPromise = (async () => {
+        const metadata = getOAuthSessionMetadata();
+        const secret = await loadOAuthSessionSecret(metadata);
+        if (!metadata || !secret) {
+          throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
+        }
+        return refreshOAuthSession(metadata, secret, fetchImpl);
+      })().finally(() => {
+        sharedRefreshPromise = null;
+      });
+    }
+    return sharedRefreshPromise;
+  }
+  return {
+    async getCredential(context) {
+      const metadata = getOAuthSessionMetadata();
+      let secret = await loadOAuthSessionSecret(metadata);
+      if (!metadata || !secret) {
+        throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
+      }
+      if (new URL(context.resource).origin !== metadata.issuer) {
+        throw new CliError("API_ERROR", "OAuth session does not match the selected API endpoint");
+      }
+      if (Date.now() >= Number(metadata.expires_at || 0) - 60000) {
+        ({ secret } = await refresh());
+      }
+      return secret.access_token;
+    },
+    async refreshCredential() {
+      const result = await refresh();
+      return result.secret.access_token;
+    },
+  };
+}

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -6,6 +6,8 @@ export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 export const OAUTH_CLIENT_ID = "qveris-cli";
 export const DEFAULT_OAUTH_SCOPES = "openid offline_access tools.search tools.inspect tools.execute";
 const OAUTH_REQUEST_TIMEOUT_MS = 30000;
+const MAX_OAUTH_RESPONSE_BYTES = 1024 * 1024;
+const MAX_OAUTH_TOKEN_LENGTH = 16384;
 const MAX_DEVICE_TIMER_SECONDS = Math.floor(0x7fffffff / 1000);
 const MAX_TOKEN_LIFETIME_SECONDS = Math.floor((Number.MAX_SAFE_INTEGER - Date.now()) / 1000);
 let sharedRefreshPromise = null;
@@ -31,10 +33,44 @@ function oauthError(code) {
   return err;
 }
 
+function hasControlCharacters(value) {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+}
+
 async function jsonResponse(response, label) {
+  let raw = "";
+  try {
+    if (response.body) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let totalBytes = 0;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          totalBytes += value.byteLength;
+          if (totalBytes > MAX_OAUTH_RESPONSE_BYTES) {
+            await reader.cancel();
+            throw new CliError("API_ERROR", `${label} exceeded the maximum response size`);
+          }
+          raw += decoder.decode(value, { stream: true });
+        }
+        raw += decoder.decode();
+      } finally {
+        reader.releaseLock();
+      }
+    }
+  } catch (error) {
+    if (error instanceof CliError) throw error;
+    if (error?.name === "AbortError") throw error;
+    throw new CliError("API_ERROR", `${label} could not be read`);
+  }
   let payload;
   try {
-    payload = await response.json();
+    payload = JSON.parse(raw);
   } catch {
     throw new CliError("API_ERROR", `${label} returned invalid JSON`);
   }
@@ -90,11 +126,18 @@ function positiveNumber(value, label, defaultValue, maximum = Number.MAX_SAFE_IN
   return normalized;
 }
 
-async function timedFetch(fetchImpl, url, options = {}, timeoutMs = OAUTH_REQUEST_TIMEOUT_MS) {
+async function timedFetch(
+  fetchImpl,
+  url,
+  options = {},
+  timeoutMs = OAUTH_REQUEST_TIMEOUT_MS,
+  consumeResponse = (response) => response,
+) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetchImpl(url, { ...options, signal: controller.signal });
+    const response = await fetchImpl(url, { ...options, signal: controller.signal });
+    return await consumeResponse(response);
   } catch (error) {
     if (error?.name === "AbortError") throw new CliError("NET_TIMEOUT", "OAuth request timed out");
     throw error;
@@ -104,12 +147,17 @@ async function timedFetch(fetchImpl, url, options = {}, timeoutMs = OAUTH_REQUES
 }
 
 export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
-  const normalizedIssuer = new URL(issuer).origin;
-  const response = await timedFetch(fetchImpl, `${normalizedIssuer}/.well-known/oauth-authorization-server`, {
-    headers: { Accept: "application/json" },
-    redirect: "error",
-  });
-  const metadata = await jsonResponse(response, "OAuth discovery");
+  const normalizedIssuer = new URL(validateEndpoint(issuer, "issuer")).origin;
+  const { response, payload: metadata } = await timedFetch(
+    fetchImpl,
+    `${normalizedIssuer}/.well-known/oauth-authorization-server`,
+    {
+      headers: { Accept: "application/json" },
+      redirect: "error",
+    },
+    OAUTH_REQUEST_TIMEOUT_MS,
+    async (response) => ({ response, payload: await jsonResponse(response, "OAuth discovery") }),
+  );
   if (!response.ok) throw oauthError(metadata.error || "discovery_failed", metadata.error_description);
   if (metadata.issuer !== normalizedIssuer) {
     throw new CliError("API_ERROR", "OAuth discovery issuer does not match the requested endpoint");
@@ -140,7 +188,7 @@ export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
 }
 
 async function postForm(url, form, fetchImpl = fetch, timeoutMs = OAUTH_REQUEST_TIMEOUT_MS) {
-  const response = await timedFetch(
+  return timedFetch(
     fetchImpl,
     url,
     {
@@ -150,14 +198,15 @@ async function postForm(url, form, fetchImpl = fetch, timeoutMs = OAUTH_REQUEST_
       redirect: "error",
     },
     timeoutMs,
+    async (response) => ({ response, payload: await jsonResponse(response, "OAuth endpoint") }),
   );
-  return { response, payload: await jsonResponse(response, "OAuth endpoint") };
 }
 
 export async function startDeviceAuthorization(metadata, { scope, resource }, fetchImpl = fetch) {
+  const normalizedResource = validateEndpoint(resource, "resource");
   const { response, payload } = await postForm(
     metadata.device_authorization_endpoint,
-    { client_id: OAUTH_CLIENT_ID, scope, resource },
+    { client_id: OAUTH_CLIENT_ID, scope, resource: normalizedResource },
     fetchImpl,
   );
   if (!response.ok) throw oauthError(payload.error || "authorization_failed", payload.error_description);
@@ -165,6 +214,9 @@ export async function startDeviceAuthorization(metadata, { scope, resource }, fe
     if (typeof payload[field] !== "string" || !payload[field]) {
       throw new CliError("API_ERROR", `Device Authorization response is missing ${field}`);
     }
+  }
+  if (payload.user_code.length > 256 || hasControlCharacters(payload.user_code)) {
+    throw new CliError("API_ERROR", "Device Authorization response has an invalid user_code");
   }
   const verificationUri = validateEndpoint(payload.verification_uri, "verification_uri");
   const verificationUriComplete = payload.verification_uri_complete
@@ -193,6 +245,8 @@ export async function pollDeviceToken(
     await sleep(Math.min(intervalMs, deadline - now()));
     if (now() >= deadline) break;
     let tokenResult;
+    const remainingMs = deadline - now();
+    const boundedByAuthorizationDeadline = remainingMs <= OAUTH_REQUEST_TIMEOUT_MS;
     try {
       tokenResult = await postForm(
         metadata.token_endpoint,
@@ -202,10 +256,10 @@ export async function pollDeviceToken(
           device_code: authorization.device_code,
         },
         fetchImpl,
-        Math.max(1, Math.min(OAUTH_REQUEST_TIMEOUT_MS, deadline - now())),
+        Math.max(1, Math.min(OAUTH_REQUEST_TIMEOUT_MS, remainingMs)),
       );
     } catch (error) {
-      if (error?.code === "NET_TIMEOUT" && now() >= deadline) break;
+      if (error?.code === "NET_TIMEOUT" && boundedByAuthorizationDeadline) break;
       throw error;
     }
     const { response, payload } = tokenResult;
@@ -225,7 +279,8 @@ export async function pollDeviceToken(
 }
 
 function validateTokenResponse(payload, { requireRefreshToken = false } = {}) {
-  const validToken = (value) => typeof value === "string" && value.trim() && !/[\r\n]/.test(value);
+  const validToken = (value) =>
+    typeof value === "string" && value.trim() && value.length <= MAX_OAUTH_TOKEN_LENGTH && !/[\r\n]/.test(value);
   if (
     typeof payload.token_type !== "string" ||
     payload.token_type.toLowerCase() !== "bearer" ||
@@ -236,13 +291,17 @@ function validateTokenResponse(payload, { requireRefreshToken = false } = {}) {
   if (requireRefreshToken && !validToken(payload.refresh_token)) {
     throw new CliError("API_ERROR", "Token endpoint did not return the required refresh token");
   }
-  for (const field of ["scope", "resource"]) {
-    if (payload[field] !== undefined && (typeof payload[field] !== "string" || !payload[field].trim())) {
-      throw new CliError("API_ERROR", `Token endpoint returned an invalid ${field}`);
-    }
+  if (
+    payload.scope !== undefined &&
+    (typeof payload.scope !== "string" || !payload.scope.trim() || hasControlCharacters(payload.scope))
+  ) {
+    throw new CliError("API_ERROR", "Token endpoint returned an invalid scope");
   }
+  const normalizedResource =
+    payload.resource === undefined ? undefined : validateEndpoint(payload.resource, "resource");
   return {
     ...payload,
+    ...(normalizedResource ? { resource: normalizedResource } : {}),
     expires_in: positiveNumber(payload.expires_in, "expires_in", undefined, MAX_TOKEN_LIFETIME_SECONDS),
   };
 }
@@ -296,30 +355,32 @@ export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
 export async function revokeOAuthToken(metadata, token, hint, fetchImpl = fetch) {
   if (!token) return;
   const revocationEndpoint = validateIssuerEndpoint(metadata, "revocation_endpoint");
-  const response = await timedFetch(fetchImpl, revocationEndpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
-    body: new URLSearchParams({ client_id: OAUTH_CLIENT_ID, token, token_type_hint: hint }),
-    redirect: "error",
-  });
+  const { response, payload } = await timedFetch(
+    fetchImpl,
+    revocationEndpoint,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body: new URLSearchParams({ client_id: OAUTH_CLIENT_ID, token, token_type_hint: hint }),
+      redirect: "error",
+    },
+    OAUTH_REQUEST_TIMEOUT_MS,
+    async (response) => ({
+      response,
+      payload: response.ok ? null : await jsonResponse(response, "OAuth revocation endpoint"),
+    }),
+  );
   if (response.ok) return;
-  const payload = await jsonResponse(response, "OAuth revocation endpoint");
   throw oauthError(payload.error || "revoke_failed", payload.error_description);
 }
 
 export async function revokeOAuthSession(metadata, secret, fetchImpl = fetch) {
-  let firstError = null;
-  for (const [token, hint] of [
-    [secret.refresh_token, "refresh_token"],
-    [secret.access_token, "access_token"],
-  ]) {
-    try {
-      await revokeOAuthToken(metadata, token, hint, fetchImpl);
-    } catch (error) {
-      firstError ||= error;
-    }
-  }
-  if (firstError) throw firstError;
+  const results = await Promise.allSettled([
+    revokeOAuthToken(metadata, secret.refresh_token, "refresh_token", fetchImpl),
+    revokeOAuthToken(metadata, secret.access_token, "access_token", fetchImpl),
+  ]);
+  const failure = results.find((result) => result.status === "rejected");
+  if (failure) throw failure.reason;
 }
 
 export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) {

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -105,8 +105,14 @@ export async function startDeviceAuthorization(metadata, { scope, resource }, fe
       throw new CliError("API_ERROR", `Device Authorization response is missing ${field}`);
     }
   }
+  const verificationUri = validateEndpoint(payload.verification_uri, "verification_uri");
+  const verificationUriComplete = payload.verification_uri_complete
+    ? validateEndpoint(payload.verification_uri_complete, "verification_uri_complete")
+    : undefined;
   return {
     ...payload,
+    verification_uri: verificationUri,
+    ...(verificationUriComplete ? { verification_uri_complete: verificationUriComplete } : {}),
     expires_in: Number.isFinite(Number(payload.expires_in)) ? Number(payload.expires_in) : 600,
     interval: Number.isFinite(Number(payload.interval)) ? Math.max(1, Number(payload.interval)) : 5,
   };
@@ -164,6 +170,8 @@ export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
   );
   if (!response.ok) throw oauthError(payload.error || "refresh_failed", payload.error_description);
   const tokens = validateTokenResponse(payload);
+  // QVeris advertises refresh-token rotation as part of its public OAuth contract.
+  // Rejecting a non-rotating response prevents reuse of a superseded credential.
   if (typeof tokens.refresh_token !== "string" || !tokens.refresh_token) {
     throw new CliError("API_ERROR", "Token endpoint did not rotate the refresh token");
   }
@@ -190,6 +198,21 @@ export async function revokeOAuthToken(metadata, token, hint, fetchImpl = fetch)
   if (response.ok) return;
   const payload = await jsonResponse(response, "OAuth revocation endpoint");
   throw oauthError(payload.error || "revoke_failed", payload.error_description);
+}
+
+export async function revokeOAuthSession(metadata, secret, fetchImpl = fetch) {
+  let firstError = null;
+  for (const [token, hint] of [
+    [secret.refresh_token, "refresh_token"],
+    [secret.access_token, "access_token"],
+  ]) {
+    try {
+      await revokeOAuthToken(metadata, token, hint, fetchImpl);
+    } catch (error) {
+      firstError ||= error;
+    }
+  }
+  if (firstError) throw firstError;
 }
 
 export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) {

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -1,11 +1,13 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { CliError } from "../errors/handler.mjs";
-import { getOAuthSessionMetadata, loadOAuthSessionSecret, saveOAuthSession } from "./storage.mjs";
+import { getOAuthSessionMetadata, loadOAuthSessionSecret, saveOAuthSession, withOAuthRefreshLock } from "./storage.mjs";
 
 export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 export const OAUTH_CLIENT_ID = "qveris-cli";
 export const DEFAULT_OAUTH_SCOPES = "openid offline_access tools.search tools.inspect tools.execute";
 const OAUTH_REQUEST_TIMEOUT_MS = 30000;
+const MAX_DEVICE_TIMER_SECONDS = Math.floor(0x7fffffff / 1000);
+const MAX_TOKEN_LIFETIME_SECONDS = Math.floor((Number.MAX_SAFE_INTEGER - Date.now()) / 1000);
 let sharedRefreshPromise = null;
 
 function oauthError(code) {
@@ -70,10 +72,10 @@ function validateIssuerEndpoint(metadata, key) {
   return endpoint;
 }
 
-function positiveNumber(value, label, defaultValue) {
+function positiveNumber(value, label, defaultValue, maximum = Number.MAX_SAFE_INTEGER) {
   if (value === undefined && defaultValue !== undefined) return defaultValue;
   const normalized = Number(value);
-  if (!Number.isFinite(normalized) || normalized <= 0) {
+  if (!Number.isFinite(normalized) || normalized <= 0 || normalized > maximum) {
     throw new CliError("API_ERROR", `OAuth response has an invalid ${label}`);
   }
   return normalized;
@@ -96,6 +98,7 @@ export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
   const normalizedIssuer = new URL(issuer).origin;
   const response = await timedFetch(fetchImpl, `${normalizedIssuer}/.well-known/oauth-authorization-server`, {
     headers: { Accept: "application/json" },
+    redirect: "error",
   });
   const metadata = await jsonResponse(response, "OAuth discovery");
   if (!response.ok) throw oauthError(metadata.error || "discovery_failed", metadata.error_description);
@@ -104,6 +107,9 @@ export async function discoverAuthorizationServer(issuer, fetchImpl = fetch) {
   }
   if (!metadata.grant_types_supported?.includes(DEVICE_CODE_GRANT)) {
     throw new CliError("API_ERROR", "This endpoint does not advertise Device Authorization Grant");
+  }
+  if (!metadata.grant_types_supported.includes("refresh_token")) {
+    throw new CliError("API_ERROR", "This endpoint does not advertise Refresh Token Grant");
   }
   if (!metadata.token_endpoint_auth_methods_supported?.includes("none")) {
     throw new CliError("API_ERROR", "This endpoint does not support the public QVeris CLI client");
@@ -129,6 +135,7 @@ async function postForm(url, form, fetchImpl = fetch) {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
     body: new URLSearchParams(form),
+    redirect: "error",
   });
   return { response, payload: await jsonResponse(response, "OAuth endpoint") };
 }
@@ -149,12 +156,15 @@ export async function startDeviceAuthorization(metadata, { scope, resource }, fe
   const verificationUriComplete = payload.verification_uri_complete
     ? validateEndpoint(payload.verification_uri_complete, "verification_uri_complete")
     : undefined;
+  if (verificationUriComplete && new URL(verificationUriComplete).origin !== new URL(verificationUri).origin) {
+    throw new CliError("API_ERROR", "OAuth verification_uri_complete does not match verification_uri");
+  }
   return {
     ...payload,
     verification_uri: verificationUri,
     ...(verificationUriComplete ? { verification_uri_complete: verificationUriComplete } : {}),
-    expires_in: positiveNumber(payload.expires_in, "expires_in"),
-    interval: positiveNumber(payload.interval, "interval", 5),
+    expires_in: positiveNumber(payload.expires_in, "expires_in", undefined, MAX_DEVICE_TIMER_SECONDS),
+    interval: positiveNumber(payload.interval, "interval", 5, MAX_DEVICE_TIMER_SECONDS),
   };
 }
 
@@ -193,18 +203,26 @@ export async function pollDeviceToken(
 }
 
 function validateTokenResponse(payload, { requireRefreshToken = false } = {}) {
+  const validToken = (value) => typeof value === "string" && value.trim() && !/[\r\n]/.test(value);
   if (
     typeof payload.token_type !== "string" ||
     payload.token_type.toLowerCase() !== "bearer" ||
-    typeof payload.access_token !== "string" ||
-    !payload.access_token.trim()
+    !validToken(payload.access_token)
   ) {
     throw new CliError("API_ERROR", "Token endpoint returned an invalid access token response");
   }
-  if (requireRefreshToken && (typeof payload.refresh_token !== "string" || !payload.refresh_token.trim())) {
+  if (requireRefreshToken && !validToken(payload.refresh_token)) {
     throw new CliError("API_ERROR", "Token endpoint did not return the required refresh token");
   }
-  return { ...payload, expires_in: positiveNumber(payload.expires_in, "expires_in") };
+  for (const field of ["scope", "resource"]) {
+    if (payload[field] !== undefined && (typeof payload[field] !== "string" || !payload[field].trim())) {
+      throw new CliError("API_ERROR", `Token endpoint returned an invalid ${field}`);
+    }
+  }
+  return {
+    ...payload,
+    expires_in: positiveNumber(payload.expires_in, "expires_in", undefined, MAX_TOKEN_LIFETIME_SECONDS),
+  };
 }
 
 export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
@@ -250,6 +268,7 @@ export async function revokeOAuthToken(metadata, token, hint, fetchImpl = fetch)
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
     body: new URLSearchParams({ client_id: OAUTH_CLIENT_ID, token, token_type_hint: hint }),
+    redirect: "error",
   });
   if (response.ok) return;
   const payload = await jsonResponse(response, "OAuth revocation endpoint");
@@ -275,12 +294,28 @@ export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) 
   async function refresh() {
     if (!sharedRefreshPromise) {
       sharedRefreshPromise = (async () => {
-        const metadata = getOAuthSessionMetadata();
-        const secret = await loadOAuthSessionSecret(metadata);
-        if (!metadata || !secret) {
+        const initialMetadata = getOAuthSessionMetadata();
+        const initialSecret = await loadOAuthSessionSecret(initialMetadata);
+        if (!initialMetadata || !initialSecret) {
           throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
         }
-        return refreshOAuthSession(metadata, secret, fetchImpl);
+        if (initialMetadata.storage === "session") {
+          return refreshOAuthSession(initialMetadata, initialSecret, fetchImpl);
+        }
+        return withOAuthRefreshLock(async () => {
+          const metadata = getOAuthSessionMetadata({ fresh: true });
+          const secret = await loadOAuthSessionSecret(metadata, { fresh: true });
+          if (!metadata || !secret) {
+            throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
+          }
+          if (
+            secret.access_token !== initialSecret.access_token ||
+            secret.refresh_token !== initialSecret.refresh_token
+          ) {
+            return { metadata, secret };
+          }
+          return refreshOAuthSession(metadata, secret, fetchImpl);
+        });
       })().finally(() => {
         sharedRefreshPromise = null;
       });

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -306,6 +306,25 @@ function validateTokenResponse(payload, { requireRefreshToken = false } = {}) {
   };
 }
 
+export function validateOAuthTokenBinding(tokens, { resource, scope }) {
+  const expectedResource = validateEndpoint(resource, "resource");
+  if (tokens.resource && tokens.resource !== expectedResource) {
+    throw new CliError("API_ERROR", "Token endpoint returned credentials for an unexpected resource");
+  }
+  const requestedScopes = String(scope || "")
+    .split(/\s+/)
+    .filter(Boolean);
+  const grantedScopes = tokens.scope ? tokens.scope.split(/\s+/).filter(Boolean) : requestedScopes;
+  const requested = new Set(requestedScopes);
+  if (grantedScopes.some((item) => !requested.has(item))) {
+    throw new CliError("API_ERROR", "Token endpoint returned credentials with an unexpected scope");
+  }
+  return {
+    resource: tokens.resource || expectedResource,
+    scope: grantedScopes.join(" "),
+  };
+}
+
 export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
   if (typeof secret.refresh_token !== "string" || !secret.refresh_token) {
     throw oauthError("invalid_grant", "OAuth session cannot be refreshed; run qveris auth login again");
@@ -331,8 +350,20 @@ export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
     access_token: tokens.access_token,
     refresh_token: tokens.refresh_token,
   };
+  let binding;
+  try {
+    binding = validateOAuthTokenBinding(tokens, metadata);
+  } catch (error) {
+    try {
+      await revokeOAuthSession(metadata, replacement, fetchImpl);
+    } catch {
+      // Preserve the binding error as the actionable failure.
+    }
+    throw error;
+  }
   const updated = {
     ...metadata,
+    ...binding,
     expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
   };
   let persisted;

--- a/packages/cli/src/auth/storage.mjs
+++ b/packages/cli/src/auth/storage.mjs
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   closeSync,
   futimesSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -172,45 +173,73 @@ export async function withOAuthRefreshLock(
   const lockPath = `${getConfigPath()}.oauth-refresh.lock`;
   const ownerToken = randomUUID();
   const ownerRecord = JSON.stringify({ ownerToken, pid: process.pid });
+  const ownerPath = `${lockPath}.${ownerToken}.owner`;
   mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  writeFileSync(ownerPath, ownerRecord, { encoding: "utf8", flag: "wx", mode: 0o600 });
   const deadline = now() + REFRESH_LOCK_TIMEOUT_MS;
   let descriptor;
-  while (descriptor === undefined) {
-    try {
-      descriptor = openSync(lockPath, "wx", 0o600);
-    } catch (error) {
-      if (error?.code !== "EEXIST") throw error;
+  try {
+    while (descriptor === undefined) {
+      let published = false;
       try {
-        if (now() - statSync(lockPath).mtimeMs >= REFRESH_LOCK_STALE_MS) {
-          let ownerIsAlive = false;
+        // A hard link publishes the fully written owner record atomically. Other
+        // contenders can never observe the empty/partial lock created by open+write.
+        linkSync(ownerPath, lockPath);
+        published = true;
+        descriptor = openSync(lockPath, "r+");
+      } catch (error) {
+        if (published) {
           try {
-            ownerIsAlive = isProcessAlive(JSON.parse(readFileSync(lockPath, "utf8")).pid);
+            if (readFileSync(lockPath, "utf8") === ownerRecord) unlinkSync(lockPath);
           } catch {
-            // Invalid records from a terminated writer are safe to reclaim once stale.
-          }
-          if (!ownerIsAlive) {
-            unlinkSync(lockPath);
-            continue;
+            // Preserve the descriptor-open failure.
           }
         }
-      } catch (statError) {
-        if (statError?.code === "ENOENT") continue;
-        throw statError;
+        if (error?.code !== "EEXIST") throw error;
+        try {
+          const firstStat = statSync(lockPath);
+          if (now() - firstStat.mtimeMs >= REFRESH_LOCK_STALE_MS) {
+            let record;
+            try {
+              record = JSON.parse(readFileSync(lockPath, "utf8"));
+            } catch {
+              // An invalid record is not safe to unlink: it may belong to a
+              // replacement owner that is still being observed by this process.
+            }
+            const secondStat = statSync(lockPath);
+            const recordIsStable =
+              firstStat.dev === secondStat.dev &&
+              firstStat.ino === secondStat.ino &&
+              firstStat.size === secondStat.size &&
+              firstStat.mtimeMs === secondStat.mtimeMs;
+            if (recordIsStable && record?.ownerToken && !isProcessAlive(record.pid)) {
+              unlinkSync(lockPath);
+              continue;
+            }
+          }
+        } catch (statError) {
+          if (statError?.code === "ENOENT") continue;
+          throw statError;
+        }
+        if (now() >= deadline) {
+          throw new CliError(
+            "NET_TIMEOUT",
+            "Timed out waiting for another QVeris process to refresh OAuth credentials",
+          );
+        }
+        await sleep(REFRESH_LOCK_WAIT_MS);
       }
-      if (now() >= deadline) {
-        throw new CliError("NET_TIMEOUT", "Timed out waiting for another QVeris process to refresh OAuth credentials");
-      }
-      await sleep(REFRESH_LOCK_WAIT_MS);
     }
-  }
-  try {
-    writeFileSync(descriptor, ownerRecord, "utf8");
+    try {
+      unlinkSync(ownerPath);
+    } catch {
+      // The lock path retains the same inode and complete owner record.
+    }
   } catch (error) {
     try {
-      closeSync(descriptor);
-      unlinkSync(lockPath);
+      unlinkSync(ownerPath);
     } catch {
-      // Preserve the lock initialization error.
+      // Preserve the lock acquisition error.
     }
     throw error;
   }

--- a/packages/cli/src/auth/storage.mjs
+++ b/packages/cli/src/auth/storage.mjs
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { deleteConfigValue, getConfigValue, setConfigValue } from "../config/store.mjs";
+
+const SERVICE = "qveris-cli";
+let memorySecret = null;
+let memoryMetadata = null;
+
+function accountForIssuer(issuer) {
+  return `oauth-${createHash("sha256").update(issuer).digest("hex").slice(0, 24)}`;
+}
+
+async function keyringEntry(issuer) {
+  if (process.env.QVERIS_DISABLE_KEYRING === "1") return null;
+  try {
+    const { Entry } = await import("@napi-rs/keyring");
+    return new Entry(SERVICE, accountForIssuer(issuer));
+  } catch {
+    return null;
+  }
+}
+
+export function getOAuthSessionMetadata() {
+  if (memoryMetadata) return memoryMetadata;
+  const value = getConfigValue("oauth_session");
+  return value && typeof value === "object" && typeof value.issuer === "string" ? value : null;
+}
+
+export function hasOAuthSession() {
+  return getOAuthSessionMetadata() !== null;
+}
+
+export async function saveOAuthSession(metadata, secret) {
+  const entry = await keyringEntry(metadata.issuer);
+  let persisted = false;
+  if (entry) {
+    try {
+      entry.setPassword(JSON.stringify(secret));
+      persisted = true;
+    } catch {
+      // A desktop keyring may be unavailable in a headless session.
+    }
+  }
+  memorySecret = { issuer: metadata.issuer, secret };
+  memoryMetadata = { ...metadata, storage: persisted ? "keyring" : "session" };
+  if (persisted) setConfigValue("oauth_session", memoryMetadata);
+  else deleteConfigValue("oauth_session");
+  return persisted;
+}
+
+export async function loadOAuthSessionSecret(metadata = getOAuthSessionMetadata()) {
+  if (!metadata) return null;
+  if (memorySecret?.issuer === metadata.issuer) return memorySecret.secret;
+  const entry = await keyringEntry(metadata.issuer);
+  if (!entry) return null;
+  try {
+    const raw = entry.getPassword();
+    if (!raw) return null;
+    const secret = JSON.parse(raw);
+    return secret && typeof secret.access_token === "string" ? secret : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteOAuthSession() {
+  const metadata = getOAuthSessionMetadata();
+  if (metadata) {
+    const entry = await keyringEntry(metadata.issuer);
+    if (entry) {
+      try {
+        entry.deletePassword();
+      } catch {
+        // Local metadata must still be removed if the keyring entry is absent.
+      }
+    }
+  }
+  memorySecret = null;
+  memoryMetadata = null;
+  deleteConfigValue("oauth_session");
+}

--- a/packages/cli/src/auth/storage.mjs
+++ b/packages/cli/src/auth/storage.mjs
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
-import { deleteConfigValue, getConfigValue, setConfigValue } from "../config/store.mjs";
+import { getConfigValue, readConfig, writeConfig } from "../config/store.mjs";
 
 const SERVICE = "qveris-cli";
+const SECRET_CONFIG_KEY = "oauth_session_secret";
 let memorySecret = null;
 let memoryMetadata = null;
 
@@ -19,6 +20,15 @@ async function keyringEntry(issuer) {
   }
 }
 
+function persistSessionConfig(metadata, storedSecret = null) {
+  const config = readConfig();
+  if (metadata) config.oauth_session = metadata;
+  else delete config.oauth_session;
+  if (storedSecret) config[SECRET_CONFIG_KEY] = storedSecret;
+  else delete config[SECRET_CONFIG_KEY];
+  writeConfig(config);
+}
+
 export function getOAuthSessionMetadata() {
   if (memoryMetadata) return memoryMetadata;
   const value = getConfigValue("oauth_session");
@@ -29,27 +39,37 @@ export function hasOAuthSession() {
   return getOAuthSessionMetadata() !== null;
 }
 
-export async function saveOAuthSession(metadata, secret) {
+export async function saveOAuthSession(metadata, secret, { allowUnencryptedStorage = false } = {}) {
   const entry = await keyringEntry(metadata.issuer);
-  let persisted = false;
+  let storage = "session";
   if (entry) {
     try {
       entry.setPassword(JSON.stringify(secret));
-      persisted = true;
+      storage = "keyring";
     } catch {
       // A desktop keyring may be unavailable in a headless session.
     }
   }
+  const useConfigStorage = storage === "session" && (allowUnencryptedStorage || metadata.storage === "config");
+  if (useConfigStorage) storage = "config";
   memorySecret = { issuer: metadata.issuer, secret };
-  memoryMetadata = { ...metadata, storage: persisted ? "keyring" : "session" };
-  if (persisted) setConfigValue("oauth_session", memoryMetadata);
-  else deleteConfigValue("oauth_session");
-  return persisted;
+  memoryMetadata = { ...metadata, storage };
+  persistSessionConfig(
+    storage === "session" ? null : memoryMetadata,
+    storage === "config" ? { issuer: metadata.issuer, secret } : null,
+  );
+  return storage !== "session";
 }
 
 export async function loadOAuthSessionSecret(metadata = getOAuthSessionMetadata()) {
   if (!metadata) return null;
   if (memorySecret?.issuer === metadata.issuer) return memorySecret.secret;
+  if (metadata.storage === "config") {
+    const stored = getConfigValue(SECRET_CONFIG_KEY);
+    if (stored?.issuer !== metadata.issuer || !stored.secret) return null;
+    return typeof stored.secret.access_token === "string" ? stored.secret : null;
+  }
+  if (metadata.storage !== "keyring") return null;
   const entry = await keyringEntry(metadata.issuer);
   if (!entry) return null;
   try {
@@ -76,5 +96,5 @@ export async function deleteOAuthSession() {
   }
   memorySecret = null;
   memoryMetadata = null;
-  deleteConfigValue("oauth_session");
+  persistSessionConfig(null);
 }

--- a/packages/cli/src/auth/storage.mjs
+++ b/packages/cli/src/auth/storage.mjs
@@ -1,13 +1,32 @@
 import { createHash } from "node:crypto";
-import { getConfigValue, readConfig, writeConfig } from "../config/store.mjs";
+import { closeSync, mkdirSync, openSync, statSync, unlinkSync } from "node:fs";
+import { dirname } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { CliError } from "../errors/handler.mjs";
+import { getConfigPath, getConfigValue, readConfig, writeConfig } from "../config/store.mjs";
 
 const SERVICE = "qveris-cli";
 const SECRET_CONFIG_KEY = "oauth_session_secret";
+const REFRESH_LOCK_STALE_MS = 60000;
+const REFRESH_LOCK_WAIT_MS = 100;
+const REFRESH_LOCK_TIMEOUT_MS = 65000;
 let memorySecret = null;
 let memoryMetadata = null;
 
 function accountForIssuer(issuer) {
   return `oauth-${createHash("sha256").update(issuer).digest("hex").slice(0, 24)}`;
+}
+
+function isValidSecret(secret) {
+  return (
+    secret &&
+    typeof secret.access_token === "string" &&
+    secret.access_token.trim() &&
+    !/[\r\n]/.test(secret.access_token) &&
+    typeof secret.refresh_token === "string" &&
+    secret.refresh_token.trim() &&
+    !/[\r\n]/.test(secret.refresh_token)
+  );
 }
 
 async function keyringEntry(issuer) {
@@ -29,10 +48,12 @@ function persistSessionConfig(metadata, storedSecret = null) {
   writeConfig(config);
 }
 
-export function getOAuthSessionMetadata() {
-  if (memoryMetadata) return memoryMetadata;
+export function getOAuthSessionMetadata({ fresh = false } = {}) {
+  if (!fresh && memoryMetadata) return memoryMetadata;
   const value = getConfigValue("oauth_session");
-  return value && typeof value === "object" && typeof value.issuer === "string" ? value : null;
+  const metadata = value && typeof value === "object" && typeof value.issuer === "string" ? value : null;
+  if (fresh) memoryMetadata = metadata;
+  return metadata;
 }
 
 export function hasOAuthSession() {
@@ -40,6 +61,9 @@ export function hasOAuthSession() {
 }
 
 export async function saveOAuthSession(metadata, secret, { allowUnencryptedStorage = false } = {}) {
+  if (!isValidSecret(secret)) {
+    throw new CliError("API_ERROR", "Refusing to store an invalid OAuth credential response");
+  }
   const entry = await keyringEntry(metadata.issuer);
   let storage = "session";
   if (entry) {
@@ -61,40 +85,109 @@ export async function saveOAuthSession(metadata, secret, { allowUnencryptedStora
   return storage !== "session";
 }
 
-export async function loadOAuthSessionSecret(metadata = getOAuthSessionMetadata()) {
+export async function loadOAuthSessionSecret(metadata = getOAuthSessionMetadata(), { fresh = false } = {}) {
   if (!metadata) return null;
-  if (memorySecret?.issuer === metadata.issuer) return memorySecret.secret;
+  if (!fresh && memorySecret?.issuer === metadata.issuer) return memorySecret.secret;
   if (metadata.storage === "config") {
     const stored = getConfigValue(SECRET_CONFIG_KEY);
     if (stored?.issuer !== metadata.issuer || !stored.secret) return null;
-    return typeof stored.secret.access_token === "string" ? stored.secret : null;
+    const secret = isValidSecret(stored.secret) ? stored.secret : null;
+    if (fresh) memorySecret = secret ? { issuer: metadata.issuer, secret } : null;
+    return secret;
   }
   if (metadata.storage !== "keyring") return null;
   const entry = await keyringEntry(metadata.issuer);
-  if (!entry) return null;
+  if (!entry) {
+    if (fresh) memorySecret = null;
+    return null;
+  }
   try {
     const raw = entry.getPassword();
     if (!raw) return null;
     const secret = JSON.parse(raw);
-    return secret && typeof secret.access_token === "string" ? secret : null;
+    const validated = isValidSecret(secret) ? secret : null;
+    if (fresh) memorySecret = validated ? { issuer: metadata.issuer, secret: validated } : null;
+    return validated;
   } catch {
+    if (fresh) memorySecret = null;
     return null;
   }
 }
 
+export async function withOAuthRefreshLock(
+  callback,
+  { sleep = (milliseconds) => delay(milliseconds), now = () => Date.now() } = {},
+) {
+  const lockPath = `${getConfigPath()}.oauth-refresh.lock`;
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  const deadline = now() + REFRESH_LOCK_TIMEOUT_MS;
+  let descriptor;
+  while (descriptor === undefined) {
+    try {
+      descriptor = openSync(lockPath, "wx", 0o600);
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (now() - statSync(lockPath).mtimeMs >= REFRESH_LOCK_STALE_MS) {
+          unlinkSync(lockPath);
+          continue;
+        }
+      } catch (statError) {
+        if (statError?.code === "ENOENT") continue;
+        throw statError;
+      }
+      if (now() >= deadline) {
+        throw new CliError("NET_TIMEOUT", "Timed out waiting for another QVeris process to refresh OAuth credentials");
+      }
+      await sleep(REFRESH_LOCK_WAIT_MS);
+    }
+  }
+  let result;
+  let callbackError;
+  try {
+    result = await callback();
+  } catch (error) {
+    callbackError = error;
+  }
+  let cleanupError;
+  try {
+    closeSync(descriptor);
+    unlinkSync(lockPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") cleanupError = error;
+  }
+  if (callbackError) throw callbackError;
+  if (cleanupError) throw cleanupError;
+  return result;
+}
+
 export async function deleteOAuthSession() {
   const metadata = getOAuthSessionMetadata();
-  if (metadata) {
+  let keyringError = null;
+  if (metadata?.storage === "keyring") {
     const entry = await keyringEntry(metadata.issuer);
-    if (entry) {
+    if (!entry) {
+      keyringError = new CliError(
+        "API_ERROR",
+        "The operating-system credential store is unavailable; OAuth credentials were not removed",
+      );
+    } else {
       try {
         entry.deletePassword();
-      } catch {
-        // Local metadata must still be removed if the keyring entry is absent.
+      } catch (error) {
+        keyringError = new CliError(
+          "API_ERROR",
+          `OAuth credentials could not be removed from the operating-system credential store${error?.message ? `: ${error.message}` : ""}`,
+        );
       }
     }
   }
   memorySecret = null;
+  if (keyringError) {
+    memoryMetadata = metadata;
+    persistSessionConfig(metadata);
+    throw keyringError;
+  }
   memoryMetadata = null;
   persistSessionConfig(null);
 }

--- a/packages/cli/src/auth/storage.mjs
+++ b/packages/cli/src/auth/storage.mjs
@@ -20,6 +20,7 @@ const REFRESH_LOCK_STALE_MS = 60000;
 const REFRESH_LOCK_HEARTBEAT_MS = 10000;
 const REFRESH_LOCK_WAIT_MS = 100;
 const REFRESH_LOCK_TIMEOUT_MS = 65000;
+const MAX_OAUTH_TOKEN_LENGTH = 16384;
 let memorySecret = null;
 let memoryMetadata = null;
 
@@ -27,14 +28,27 @@ function accountForIssuer(issuer) {
   return `oauth-${createHash("sha256").update(issuer).digest("hex").slice(0, 24)}`;
 }
 
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
 function isValidSecret(secret) {
   return (
     secret &&
     typeof secret.access_token === "string" &&
     secret.access_token.trim() &&
+    secret.access_token.length <= MAX_OAUTH_TOKEN_LENGTH &&
     !/[\r\n]/.test(secret.access_token) &&
     typeof secret.refresh_token === "string" &&
     secret.refresh_token.trim() &&
+    secret.refresh_token.length <= MAX_OAUTH_TOKEN_LENGTH &&
     !/[\r\n]/.test(secret.refresh_token)
   );
 }
@@ -157,6 +171,7 @@ export async function withOAuthRefreshLock(
 ) {
   const lockPath = `${getConfigPath()}.oauth-refresh.lock`;
   const ownerToken = randomUUID();
+  const ownerRecord = JSON.stringify({ ownerToken, pid: process.pid });
   mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
   const deadline = now() + REFRESH_LOCK_TIMEOUT_MS;
   let descriptor;
@@ -167,8 +182,16 @@ export async function withOAuthRefreshLock(
       if (error?.code !== "EEXIST") throw error;
       try {
         if (now() - statSync(lockPath).mtimeMs >= REFRESH_LOCK_STALE_MS) {
-          unlinkSync(lockPath);
-          continue;
+          let ownerIsAlive = false;
+          try {
+            ownerIsAlive = isProcessAlive(JSON.parse(readFileSync(lockPath, "utf8")).pid);
+          } catch {
+            // Invalid records from a terminated writer are safe to reclaim once stale.
+          }
+          if (!ownerIsAlive) {
+            unlinkSync(lockPath);
+            continue;
+          }
         }
       } catch (statError) {
         if (statError?.code === "ENOENT") continue;
@@ -181,7 +204,7 @@ export async function withOAuthRefreshLock(
     }
   }
   try {
-    writeFileSync(descriptor, ownerToken, "utf8");
+    writeFileSync(descriptor, ownerRecord, "utf8");
   } catch (error) {
     try {
       closeSync(descriptor);
@@ -209,15 +232,14 @@ export async function withOAuthRefreshLock(
   } finally {
     clearInterval(heartbeat);
   }
-  let cleanupError;
   try {
     closeSync(descriptor);
-    if (readFileSync(lockPath, "utf8") === ownerToken) unlinkSync(lockPath);
-  } catch (error) {
-    if (error?.code !== "ENOENT") cleanupError = error;
+    if (readFileSync(lockPath, "utf8") === ownerRecord) unlinkSync(lockPath);
+  } catch {
+    // The stale-lock recovery path can reclaim this owner after the process exits.
+    // Do not turn a committed credential transaction into an ambiguous failure.
   }
   if (callbackError) throw callbackError;
-  if (cleanupError) throw cleanupError;
   return result;
 }
 

--- a/packages/cli/src/auth/storage.mjs
+++ b/packages/cli/src/auth/storage.mjs
@@ -1,5 +1,14 @@
-import { createHash } from "node:crypto";
-import { closeSync, mkdirSync, openSync, statSync, unlinkSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  futimesSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { CliError } from "../errors/handler.mjs";
@@ -8,6 +17,7 @@ import { getConfigPath, getConfigValue, readConfig, writeConfig } from "../confi
 const SERVICE = "qveris-cli";
 const SECRET_CONFIG_KEY = "oauth_session_secret";
 const REFRESH_LOCK_STALE_MS = 60000;
+const REFRESH_LOCK_HEARTBEAT_MS = 10000;
 const REFRESH_LOCK_WAIT_MS = 100;
 const REFRESH_LOCK_TIMEOUT_MS = 65000;
 let memorySecret = null;
@@ -66,22 +76,49 @@ export async function saveOAuthSession(metadata, secret, { allowUnencryptedStora
   }
   const entry = await keyringEntry(metadata.issuer);
   let storage = "session";
+  let previousKeyringSecret = null;
+  let keyringWriteError = null;
   if (entry) {
     try {
+      previousKeyringSecret = entry.getPassword();
       entry.setPassword(JSON.stringify(secret));
       storage = "keyring";
-    } catch {
+    } catch (error) {
+      keyringWriteError = error;
       // A desktop keyring may be unavailable in a headless session.
     }
   }
+  if (storage === "session" && metadata.storage === "keyring") {
+    throw new CliError(
+      "API_ERROR",
+      `Rotated OAuth credentials could not be persisted in the operating-system credential store${keyringWriteError?.message ? `: ${keyringWriteError.message}` : ""}`,
+    );
+  }
   const useConfigStorage = storage === "session" && (allowUnencryptedStorage || metadata.storage === "config");
   if (useConfigStorage) storage = "config";
-  memorySecret = { issuer: metadata.issuer, secret };
-  memoryMetadata = { ...metadata, storage };
-  persistSessionConfig(
-    storage === "session" ? null : memoryMetadata,
-    storage === "config" ? { issuer: metadata.issuer, secret } : null,
-  );
+  const nextMemorySecret = { issuer: metadata.issuer, secret };
+  const nextMemoryMetadata = { ...metadata, storage };
+  try {
+    persistSessionConfig(
+      storage === "session" ? null : nextMemoryMetadata,
+      storage === "config" ? nextMemorySecret : null,
+    );
+  } catch (error) {
+    if (storage === "keyring") {
+      try {
+        if (previousKeyringSecret) entry.setPassword(previousKeyringSecret);
+        else entry.deletePassword();
+      } catch (rollbackError) {
+        throw new CliError(
+          "API_ERROR",
+          `OAuth session metadata could not be saved and the credential-store rollback failed${rollbackError?.message ? `: ${rollbackError.message}` : ""}`,
+        );
+      }
+    }
+    throw error;
+  }
+  memorySecret = nextMemorySecret;
+  memoryMetadata = nextMemoryMetadata;
   return storage !== "session";
 }
 
@@ -119,6 +156,7 @@ export async function withOAuthRefreshLock(
   { sleep = (milliseconds) => delay(milliseconds), now = () => Date.now() } = {},
 ) {
   const lockPath = `${getConfigPath()}.oauth-refresh.lock`;
+  const ownerToken = randomUUID();
   mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
   const deadline = now() + REFRESH_LOCK_TIMEOUT_MS;
   let descriptor;
@@ -142,17 +180,39 @@ export async function withOAuthRefreshLock(
       await sleep(REFRESH_LOCK_WAIT_MS);
     }
   }
+  try {
+    writeFileSync(descriptor, ownerToken, "utf8");
+  } catch (error) {
+    try {
+      closeSync(descriptor);
+      unlinkSync(lockPath);
+    } catch {
+      // Preserve the lock initialization error.
+    }
+    throw error;
+  }
   let result;
   let callbackError;
+  const heartbeat = setInterval(() => {
+    try {
+      const timestamp = new Date();
+      futimesSync(descriptor, timestamp, timestamp);
+    } catch {
+      // Cleanup below reports lock failures that affect ownership.
+    }
+  }, REFRESH_LOCK_HEARTBEAT_MS);
+  heartbeat.unref?.();
   try {
     result = await callback();
   } catch (error) {
     callbackError = error;
+  } finally {
+    clearInterval(heartbeat);
   }
   let cleanupError;
   try {
     closeSync(descriptor);
-    unlinkSync(lockPath);
+    if (readFileSync(lockPath, "utf8") === ownerToken) unlinkSync(lockPath);
   } catch (error) {
     if (error?.code !== "ENOENT") cleanupError = error;
   }

--- a/packages/cli/src/auth/storage.mjs
+++ b/packages/cli/src/auth/storage.mjs
@@ -41,17 +41,16 @@ function isProcessAlive(pid) {
 }
 
 function isValidSecret(secret) {
-  return (
-    secret &&
-    typeof secret.access_token === "string" &&
-    secret.access_token.trim() &&
-    secret.access_token.length <= MAX_OAUTH_TOKEN_LENGTH &&
-    !/[\r\n]/.test(secret.access_token) &&
-    typeof secret.refresh_token === "string" &&
-    secret.refresh_token.trim() &&
-    secret.refresh_token.length <= MAX_OAUTH_TOKEN_LENGTH &&
-    !/[\r\n]/.test(secret.refresh_token)
-  );
+  const validToken = (value, { allowInternalSpaces = false } = {}) =>
+    typeof value === "string" &&
+    value.length > 0 &&
+    value === value.trim() &&
+    value.length <= MAX_OAUTH_TOKEN_LENGTH &&
+    Array.from(value).every((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint >= (allowInternalSpaces ? 0x20 : 0x21) && codePoint <= 0x7e;
+    });
+  return secret && validToken(secret.access_token) && validToken(secret.refresh_token, { allowInternalSpaces: true });
 }
 
 async function keyringEntry(issuer) {
@@ -224,7 +223,7 @@ export async function withOAuthRefreshLock(
         if (now() >= deadline) {
           throw new CliError(
             "NET_TIMEOUT",
-            "Timed out waiting for another QVeris process to refresh OAuth credentials",
+            `Timed out waiting for another QVeris process to update credentials. If no QVeris process is running, remove the stale lock: ${lockPath}`,
           );
         }
         await sleep(REFRESH_LOCK_WAIT_MS);

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -89,6 +89,9 @@ async function requestJson(
         } catch {
           /* not JSON */
         }
+        if ((status === 401 || status === 403) && credentialProvider.authType === "oauth") {
+          throw new CliError("AUTH_OAUTH_FAILED", errorDetail);
+        }
         if (status === 401 || status === 403) {
           const err = new CliError("AUTH_INVALID_KEY", errorDetail);
           err.hint = `Check your key at ${getSiteUrl(baseUrl)}/account`;

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -13,12 +13,22 @@ import {
 
 import { getOAuthSessionMetadata } from "../auth/storage.mjs";
 
-function getBaseUrl(baseUrlFlag, preferOAuth = false) {
+export function resolveApiBaseUrl({ baseUrlFlag, preferOAuth = false } = {}) {
   if (preferOAuth && baseUrlFlag === undefined && typeof process.env.QVERIS_BASE_URL !== "string") {
     const session = getOAuthSessionMetadata();
-    if (session?.api_base_url) return session.api_base_url;
+    if (session?.api_base_url) {
+      const { baseUrl } = resolveBaseUrl({ baseUrlFlag: session.api_base_url });
+      if (new URL(baseUrl).origin !== session.issuer) {
+        throw new CliError("API_ERROR", "Stored OAuth endpoint does not match its issuer");
+      }
+      return { baseUrl, source: "oauth session" };
+    }
   }
-  return resolveBaseUrl({ baseUrlFlag }).baseUrl;
+  return resolveBaseUrl({ baseUrlFlag });
+}
+
+function getBaseUrl(baseUrlFlag, preferOAuth = false) {
+  return resolveApiBaseUrl({ baseUrlFlag, preferOAuth }).baseUrl;
 }
 
 async function requestJson(
@@ -63,6 +73,7 @@ async function requestJson(
         },
         ...(body === undefined ? {} : { body: JSON.stringify(body) }),
         signal: controller.signal,
+        redirect: "error",
       });
 
       if (response.status === 401 && !authRetried && typeof credentialProvider.refreshCredential === "function") {
@@ -89,8 +100,13 @@ async function requestJson(
         } catch {
           /* not JSON */
         }
-        if ((status === 401 || status === 403) && credentialProvider.authType === "oauth") {
+        if (status === 401 && credentialProvider.authType === "oauth") {
           throw new CliError("AUTH_OAUTH_FAILED", errorDetail);
+        }
+        if (status === 403 && credentialProvider.authType === "oauth") {
+          const err = new CliError("API_ERROR", `HTTP 403: ${errorDetail || rawText}`);
+          if (jsonBody) err.responseData = jsonBody;
+          throw err;
         }
         if (status === 401 || status === 403) {
           const err = new CliError("AUTH_INVALID_KEY", errorDetail);

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -11,7 +11,13 @@ import {
   sleep,
 } from "./retry.mjs";
 
-function getBaseUrl(baseUrlFlag) {
+import { getOAuthSessionMetadata } from "../auth/storage.mjs";
+
+function getBaseUrl(baseUrlFlag, preferOAuth = false) {
+  if (preferOAuth && baseUrlFlag === undefined && typeof process.env.QVERIS_BASE_URL !== "string") {
+    const session = getOAuthSessionMetadata();
+    if (session?.api_base_url) return session.api_base_url;
+  }
   return resolveBaseUrl({ baseUrlFlag }).baseUrl;
 }
 
@@ -36,6 +42,7 @@ async function requestJson(
     }
   }
 
+  let authRetried = false;
   for (let attempt = 0; ; attempt++) {
     // Credential acquisition is outside the API request timeout and happens
     // on every attempt so retries can refresh short-lived tokens.
@@ -58,7 +65,12 @@ async function requestJson(
         signal: controller.signal,
       });
 
-      if (RETRYABLE_STATUS.has(response.status) && attempt < maxRetries) {
+      if (response.status === 401 && !authRetried && typeof credentialProvider.refreshCredential === "function") {
+        authRetried = true;
+        await response.body?.cancel?.().catch(() => {});
+        await credentialProvider.refreshCredential();
+        continue;
+      } else if (RETRYABLE_STATUS.has(response.status) && attempt < maxRetries) {
         retryDelayMs = computeRetryDelayMs({
           retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
           attempt,
@@ -134,7 +146,7 @@ export async function discoverTools({
   limit = 5,
   timeoutMs = 30000,
 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
   return requestJson("/search", {
     credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
     baseUrl,
@@ -151,7 +163,7 @@ export async function inspectToolsByIds({
   discoveryId,
   timeoutMs = 30000,
 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
   const body = { tool_ids: toolIds };
   if (discoveryId) body.search_id = discoveryId;
   return requestJson("/tools/by-ids", {
@@ -172,7 +184,7 @@ export async function callTool({
   maxResponseSize = 102400,
   timeoutMs = 120000,
 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
   return requestJson("/tools/execute", {
     credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
     baseUrl,
@@ -187,7 +199,7 @@ export async function callTool({
 }
 
 export async function getCredits({ apiKey, credentialProvider, baseUrl: baseUrlFlag, timeoutMs = 30000 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
   return requestJson("/auth/credits", {
     method: "GET",
     credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
@@ -203,7 +215,7 @@ export async function getUsageHistory({
   query = {},
   timeoutMs = 30000,
 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
   return requestJson("/auth/usage/history/v2", {
     method: "GET",
     credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
@@ -220,7 +232,7 @@ export async function getCreditsLedger({
   query = {},
   timeoutMs = 30000,
 }) {
-  const baseUrl = getBaseUrl(baseUrlFlag);
+  const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
   return requestJson("/auth/credits/ledger", {
     method: "GET",
     credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),

--- a/packages/cli/src/client/auth.mjs
+++ b/packages/cli/src/client/auth.mjs
@@ -60,7 +60,7 @@ export async function getCredential(provider, context) {
   try {
     credential = await provider.getCredential(context);
   } catch (error) {
-    if (error instanceof CliError && error.code === "AUTH_OAUTH_FAILED") throw error;
+    if (error instanceof CliError) throw error;
     throw new CliError("API_ERROR", "Credential provider failed to provide a credential");
   }
   if (typeof credential !== "string" || !credential.trim() || /[\r\n]/.test(credential)) {

--- a/packages/cli/src/client/auth.mjs
+++ b/packages/cli/src/client/auth.mjs
@@ -1,5 +1,7 @@
 import { resolve } from "../config/resolve.mjs";
 import { CliError } from "../errors/handler.mjs";
+import { createStoredOAuthCredentialProvider } from "../auth/oauth.mjs";
+import { hasOAuthSession } from "../auth/storage.mjs";
 
 const PLACEHOLDER_PATTERNS = [/^your[_-]?(qveris)?[_-]?api[_-]?key/i, /^sk-1_xxx/, /^sk-1_$/, /^YOUR_/];
 
@@ -7,6 +9,7 @@ export function resolveApiKey(flagValue) {
   const { value } = resolve("api_key", flagValue);
 
   if (!value || !value.trim()) {
+    if (hasOAuthSession()) return undefined;
     throw new CliError("AUTH_MISSING_KEY");
   }
 
@@ -46,6 +49,9 @@ export function resolveCredentialProvider({ apiKey, credentialProvider } = {}) {
     }
     return credentialProvider;
   }
+  if (apiKey === undefined && hasOAuthSession()) {
+    return createStoredOAuthCredentialProvider();
+  }
   return createApiKeyCredentialProvider(apiKey);
 }
 
@@ -53,7 +59,8 @@ export async function getCredential(provider, context) {
   let credential;
   try {
     credential = await provider.getCredential(context);
-  } catch {
+  } catch (error) {
+    if (error instanceof CliError && error.code === "AUTH_OAUTH_FAILED") throw error;
     throw new CliError("API_ERROR", "Credential provider failed to provide a credential");
   }
   if (typeof credential !== "string" || !credential.trim() || /[\r\n]/.test(credential)) {

--- a/packages/cli/src/client/auth.mjs
+++ b/packages/cli/src/client/auth.mjs
@@ -8,9 +8,12 @@ const PLACEHOLDER_PATTERNS = [/^your[_-]?(qveris)?[_-]?api[_-]?key/i, /^sk-1_xxx
 export function resolveApiKey(flagValue) {
   const { value } = resolve("api_key", flagValue);
 
-  if (!value || !value.trim()) {
+  if (value === undefined || value === null || (typeof value === "string" && !value.trim())) {
     if (hasOAuthSession()) return undefined;
     throw new CliError("AUTH_MISSING_KEY");
+  }
+  if (typeof value !== "string") {
+    throw new CliError("AUTH_MISSING_KEY", "Configured API key must be a string. Run qveris login to replace it.");
   }
 
   const trimmed = value.trim();

--- a/packages/cli/src/client/preflight.mjs
+++ b/packages/cli/src/client/preflight.mjs
@@ -1,6 +1,7 @@
 import { resolve } from "../config/resolve.mjs";
-import { resolveBaseUrl, getSiteUrl } from "../config/endpoint.mjs";
-import { discoverTools } from "./api.mjs";
+import { getSiteUrl } from "../config/endpoint.mjs";
+import { getOAuthSessionMetadata } from "../auth/storage.mjs";
+import { discoverTools, resolveApiBaseUrl } from "./api.mjs";
 import { ERROR_CODES } from "../errors/codes.mjs";
 
 /**
@@ -31,6 +32,7 @@ export function nodeCheck(nodeVersion = process.version) {
 /** Map a thrown CliError code to a friendlier check name. */
 function codeToName(code) {
   if (code === "AUTH_INVALID_KEY") return "api_key_valid";
+  if (code === "AUTH_OAUTH_FAILED") return "oauth";
   if (code === "CREDITS_INSUFFICIENT") return "credits";
   return "connectivity";
 }
@@ -44,9 +46,15 @@ function endpointRecoveryHint(code, baseUrl) {
   return null;
 }
 
-async function defaultProbe({ apiKey, baseUrl }) {
+async function defaultProbe({ apiKey, baseUrl, authType }) {
   // "test" matches the probe query login/whoami use to validate a key.
-  return discoverTools({ apiKey, baseUrl, query: "test", limit: 1, timeoutMs: 10000 });
+  return discoverTools({
+    ...(authType === "oauth" ? {} : { apiKey }),
+    baseUrl,
+    query: "test",
+    limit: 1,
+    timeoutMs: 10000,
+  });
 }
 
 /**
@@ -58,23 +66,30 @@ export function localPreflight({ apiKeyFlag, baseUrlFlag, nodeVersion = process.
   const checks = [nodeCheck(nodeVersion)];
 
   const { value: apiKey, source } = resolve("api_key", apiKeyFlag);
+  let authType = "api_key";
   if (!apiKey || typeof apiKey !== "string" || !apiKey.trim()) {
-    checks.push(check("api_key", "fail", ERROR_CODES.AUTH_MISSING_KEY.message, ERROR_CODES.AUTH_MISSING_KEY.hint));
-    return { checks, ok: false, apiKey: null, baseUrl: null };
+    const oauthSession = !apiKey ? getOAuthSessionMetadata() : null;
+    if (!oauthSession) {
+      checks.push(check("api_key", "fail", ERROR_CODES.AUTH_MISSING_KEY.message, ERROR_CODES.AUTH_MISSING_KEY.hint));
+      return { checks, ok: false, apiKey: null, authType: null, baseUrl: null };
+    }
+    authType = "oauth";
+    checks.push(check("oauth", "ok", "OAuth session configured"));
+  } else {
+    checks.push(check("api_key", "ok", `API key configured (${maskKey(apiKey)} via ${source})`));
   }
-  checks.push(check("api_key", "ok", `API key configured (${maskKey(apiKey)} via ${source})`));
 
   let endpoint;
   try {
-    endpoint = resolveBaseUrl({ baseUrlFlag });
+    endpoint = resolveApiBaseUrl({ baseUrlFlag, preferOAuth: authType === "oauth" });
   } catch (err) {
     checks.push(check("endpoint", "fail", err.message, err.hint));
-    return { checks, ok: false, apiKey, baseUrl: null };
+    return { checks, ok: false, apiKey, authType, baseUrl: null };
   }
   const { baseUrl, source: endpointSource } = endpoint;
   checks.push(check("endpoint", "ok", `API endpoint ${baseUrl} (${endpointSource})`));
 
-  return { checks, ok: checks.every((c) => c.status !== "fail"), apiKey, baseUrl };
+  return { checks, ok: checks.every((c) => c.status !== "fail"), apiKey, authType, baseUrl };
 }
 
 /**
@@ -94,13 +109,13 @@ export async function runPreflight({
   const checks = [...local.checks];
 
   // Without a key or with a failing local check we cannot probe safely.
-  if (!local.apiKey || local.checks.some((c) => c.status === "fail")) {
+  if (!local.authType || local.checks.some((c) => c.status === "fail")) {
     return { checks, ok: false, contractVersion: CLI_CONTRACT_VERSION };
   }
 
   let response;
   try {
-    response = await probe({ apiKey: local.apiKey, baseUrl: local.baseUrl });
+    response = await probe({ apiKey: local.apiKey, authType: local.authType, baseUrl: local.baseUrl });
   } catch (err) {
     // A diagnostic must never crash: anything (even a non-Error) can be thrown.
     const hint =

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -64,7 +64,19 @@ async function authLogin(flags) {
     revocation_endpoint: metadata.revocation_endpoint,
     expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
   };
-  await deleteOAuthSession();
+  try {
+    await deleteOAuthSession();
+  } catch (error) {
+    try {
+      await revokeOAuthSession(metadata, {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+      });
+    } catch {
+      // Preserve the local-cleanup error as the actionable failure.
+    }
+    throw error;
+  }
   const persisted = await saveOAuthSession(
     session,
     {
@@ -147,20 +159,36 @@ async function authLogout(flags) {
   const metadata = getOAuthSessionMetadata();
   const secret = await loadOAuthSessionSecret(metadata);
   let revokeError = null;
+  let localError = null;
   try {
     if (metadata && secret) {
       await revokeOAuthSession(metadata, secret);
     }
   } catch (error) {
     revokeError = error;
-  } finally {
-    await deleteOAuthSession();
   }
-  const result = { authenticated: false, local_credentials_removed: true, revoked: !revokeError };
+  try {
+    await deleteOAuthSession();
+  } catch (error) {
+    localError = error;
+  }
+  const remoteRevoked = !metadata || Boolean(secret && !revokeError);
+  const result = { authenticated: false, local_credentials_removed: !localError, revoked: remoteRevoked };
   if (flags.json) console.log(JSON.stringify(result, null, 2));
   else {
-    console.log(`  ${green("✓")} Local OAuth credentials removed.`);
-    if (revokeError) console.error(`  ${red("!")} Remote revocation failed; the local session was still cleared.`);
+    if (localError) console.error(`  ${red("!")} Local OAuth credentials could not be completely removed.`);
+    else console.log(`  ${green("✓")} Local OAuth credentials removed.`);
+    if (revokeError) {
+      console.error(
+        localError
+          ? `  ${red("!")} Remote revocation also failed; retry logout when the credential store is available.`
+          : `  ${red("!")} Remote revocation failed; the local session was still cleared.`,
+      );
+    } else if (metadata && !secret) {
+      console.error(
+        `  ${red("!")} Remote revocation could not be attempted because the stored credential is unavailable.`,
+      );
+    }
   }
-  if (revokeError) process.exitCode = 1;
+  if (!remoteRevoked || localError) process.exitCode = 1;
 }

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -11,6 +11,7 @@ import {
   revokeOAuthSession,
   startDeviceAuthorization,
   validateOAuthScopes,
+  validateOAuthTokenBinding,
 } from "../auth/oauth.mjs";
 import {
   deleteOAuthSession,
@@ -58,21 +59,22 @@ async function authLogin(flags) {
   }
 
   const tokens = await pollDeviceToken(metadata, authorization);
-  const session = {
-    issuer,
-    api_base_url: baseUrl,
-    resource: tokens.resource || resource,
-    scope: tokens.scope || scope,
-    token_endpoint: metadata.token_endpoint,
-    revocation_endpoint: metadata.revocation_endpoint,
-    expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
-  };
   const newSecret = {
     access_token: tokens.access_token,
     refresh_token: tokens.refresh_token,
   };
   let persisted;
+  let session;
   try {
+    const binding = validateOAuthTokenBinding(tokens, { resource, scope });
+    session = {
+      issuer,
+      api_base_url: baseUrl,
+      ...binding,
+      token_endpoint: metadata.token_endpoint,
+      revocation_endpoint: metadata.revocation_endpoint,
+      expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
+    };
     persisted = await withOAuthRefreshLock(async () => {
       const currentMetadata = getOAuthSessionMetadata({ fresh: true });
       const currentSecret = await loadOAuthSessionSecret(currentMetadata, { fresh: true });

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -1,5 +1,6 @@
 import { resolveBaseUrl } from "../config/endpoint.mjs";
 import { discoverTools } from "../client/api.mjs";
+import { CliError } from "../errors/handler.mjs";
 import { bold, cyan, dim, green, red } from "../output/colors.mjs";
 import { openUrl } from "../utils/open-url.mjs";
 import {
@@ -16,6 +17,7 @@ import {
   getOAuthSessionMetadata,
   loadOAuthSessionSecret,
   saveOAuthSession,
+  withOAuthRefreshLock,
 } from "../auth/storage.mjs";
 
 export async function runAuth(subcommand, flags) {
@@ -27,6 +29,8 @@ export async function runAuth(subcommand, flags) {
 }
 
 async function authLogin(flags) {
+  const previousMetadata = getOAuthSessionMetadata();
+  const previousSecret = await loadOAuthSessionSecret(previousMetadata);
   const { baseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
   const issuer = new URL(baseUrl).origin;
   const metadata = await discoverAuthorizationServer(issuer);
@@ -64,27 +68,42 @@ async function authLogin(flags) {
     revocation_endpoint: metadata.revocation_endpoint,
     expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
   };
+  const newSecret = {
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+  };
+  let persisted;
   try {
-    await deleteOAuthSession();
+    persisted = await withOAuthRefreshLock(async () => {
+      const currentMetadata = getOAuthSessionMetadata({ fresh: true });
+      const currentSecret = await loadOAuthSessionSecret(currentMetadata, { fresh: true });
+      const snapshotUnchanged =
+        previousMetadata === null
+          ? currentMetadata === null
+          : currentMetadata?.issuer === previousMetadata.issuer &&
+            currentMetadata?.api_base_url === previousMetadata.api_base_url &&
+            currentSecret?.access_token === previousSecret?.access_token &&
+            currentSecret?.refresh_token === previousSecret?.refresh_token;
+      if (!snapshotUnchanged) {
+        throw new CliError(
+          "API_ERROR",
+          "OAuth session changed while device authorization was in progress; retry login",
+        );
+      }
+      if (currentMetadata && currentSecret) await revokeOAuthSession(currentMetadata, currentSecret);
+      await deleteOAuthSession();
+      return saveOAuthSession(session, newSecret, {
+        allowUnencryptedStorage: flags.allowUnencryptedStorage,
+      });
+    });
   } catch (error) {
     try {
-      await revokeOAuthSession(metadata, {
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-      });
+      await revokeOAuthSession(metadata, newSecret);
     } catch {
-      // Preserve the local-cleanup error as the actionable failure.
+      // Preserve the local-storage error as the actionable failure.
     }
     throw error;
   }
-  const persisted = await saveOAuthSession(
-    session,
-    {
-      access_token: tokens.access_token,
-      refresh_token: tokens.refresh_token,
-    },
-    { allowUnencryptedStorage: flags.allowUnencryptedStorage },
-  );
   const storage = getOAuthSessionMetadata()?.storage || "session";
   const result = {
     authenticated: true,

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -1,14 +1,13 @@
-import { execFile } from "node:child_process";
-import { platform } from "node:os";
 import { resolveBaseUrl } from "../config/endpoint.mjs";
 import { discoverTools } from "../client/api.mjs";
 import { bold, cyan, dim, green, red } from "../output/colors.mjs";
+import { openUrl } from "../utils/open-url.mjs";
 import {
   DEFAULT_OAUTH_SCOPES,
   createStoredOAuthCredentialProvider,
   discoverAuthorizationServer,
   pollDeviceToken,
-  revokeOAuthToken,
+  revokeOAuthSession,
   startDeviceAuthorization,
 } from "../auth/oauth.mjs";
 import {
@@ -17,12 +16,6 @@ import {
   loadOAuthSessionSecret,
   saveOAuthSession,
 } from "../auth/storage.mjs";
-
-function openBrowser(url) {
-  const command = { darwin: "open", win32: "cmd", linux: "xdg-open" }[platform()] || "xdg-open";
-  const args = platform() === "win32" ? ["/c", "start", "", url] : [url];
-  execFile(command, args, () => {});
-}
 
 export async function runAuth(subcommand, flags) {
   if (subcommand === "login") return authLogin(flags);
@@ -59,7 +52,7 @@ async function authLogin(flags) {
     );
   }
   if (!flags.noBrowser) {
-    openBrowser(authorization.verification_uri_complete || authorization.verification_uri);
+    openUrl(authorization.verification_uri_complete || authorization.verification_uri);
   }
 
   const tokens = await pollDeviceToken(metadata, authorization);
@@ -73,18 +66,32 @@ async function authLogin(flags) {
     expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
   };
   await deleteOAuthSession();
-  const persisted = await saveOAuthSession(session, {
-    access_token: tokens.access_token,
-    refresh_token: tokens.refresh_token,
-  });
-  const result = { authenticated: true, issuer, resource: session.resource, scope: session.scope, persisted };
+  const persisted = await saveOAuthSession(
+    session,
+    {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+    },
+    { allowUnencryptedStorage: flags.allowUnencryptedStorage },
+  );
+  const storage = getOAuthSessionMetadata()?.storage || "session";
+  const result = {
+    authenticated: true,
+    issuer,
+    resource: session.resource,
+    scope: session.scope,
+    persisted,
+    storage,
+  };
   if (flags.json) console.log(JSON.stringify(result, null, 2));
   else {
     console.log(`  ${green("✓")} Device authorization completed.`);
     console.log(
-      persisted
+      storage === "keyring"
         ? `  ${dim("Refresh credentials saved in the operating-system credential store.")}`
-        : `  ${red("!")} No operating-system credential store is available; credentials last only for this process.`,
+        : storage === "config"
+          ? `  ${red("!")} Refresh credentials saved unencrypted in the user-only config file.`
+          : `  ${red("!")} No credential store is available; rerun with --allow-unencrypted-storage to persist this session.`,
     );
   }
 }
@@ -100,13 +107,26 @@ async function authStatus(flags) {
     return;
   }
   const provider = createStoredOAuthCredentialProvider();
-  await discoverTools({
-    credentialProvider: provider,
-    baseUrl: metadata.api_base_url,
-    query: "test",
-    limit: 1,
-    timeoutMs: 10000,
-  });
+  try {
+    await discoverTools({
+      credentialProvider: provider,
+      baseUrl: metadata.api_base_url,
+      query: "test",
+      limit: 1,
+      timeoutMs: 10000,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "OAuth session validation failed";
+    const result = { authenticated: false, type: "oauth", error: message };
+    if (flags.json) console.log(JSON.stringify(result, null, 2));
+    else {
+      console.log(`  ${red("!")} OAuth session is invalid or expired.`);
+      console.log(`  Error: ${message}`);
+      console.log(`  Run ${cyan("qveris auth login")} to log in again.`);
+    }
+    process.exitCode = 1;
+    return;
+  }
   const result = {
     authenticated: true,
     type: "oauth",
@@ -130,8 +150,7 @@ async function authLogout(flags) {
   let revokeError = null;
   try {
     if (metadata && secret) {
-      await revokeOAuthToken(metadata, secret.refresh_token, "refresh_token");
-      await revokeOAuthToken(metadata, secret.access_token, "access_token");
+      await revokeOAuthSession(metadata, secret);
     }
   } catch (error) {
     revokeError = error;

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -9,6 +9,7 @@ import {
   pollDeviceToken,
   revokeOAuthSession,
   startDeviceAuthorization,
+  validateOAuthScopes,
 } from "../auth/oauth.mjs";
 import {
   deleteOAuthSession,
@@ -30,9 +31,7 @@ async function authLogin(flags) {
   const issuer = new URL(baseUrl).origin;
   const metadata = await discoverAuthorizationServer(issuer);
   const scope = flags.scope || DEFAULT_OAUTH_SCOPES;
-  const requestedScopes = scope.split(/\s+/).filter(Boolean);
-  const unsupported = requestedScopes.filter((item) => !metadata.scopes_supported.includes(item));
-  if (unsupported.length) throw new Error(`OAuth scopes are not supported: ${unsupported.join(", ")}`);
+  validateOAuthScopes(metadata, scope);
   const resource = flags.resource || `${issuer}/tools`;
   const authorization = await startDeviceAuthorization(metadata, { scope, resource });
 

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -34,8 +34,7 @@ async function authLogin(flags) {
   const { baseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
   const issuer = new URL(baseUrl).origin;
   const metadata = await discoverAuthorizationServer(issuer);
-  const scope = flags.scope || DEFAULT_OAUTH_SCOPES;
-  validateOAuthScopes(metadata, scope);
+  const scope = validateOAuthScopes(metadata, flags.scope || DEFAULT_OAUTH_SCOPES).join(" ");
   const resource = flags.resource || `${issuer}/tools`;
   const authorization = await startDeviceAuthorization(metadata, { scope, resource });
 
@@ -175,23 +174,31 @@ async function authStatus(flags) {
 }
 
 async function authLogout(flags) {
-  const metadata = getOAuthSessionMetadata();
-  const secret = await loadOAuthSessionSecret(metadata);
+  let metadata = null;
+  let secret = null;
   let revokeError = null;
   let localError = null;
+  let lockAcquired = false;
   try {
-    if (metadata && secret) {
-      await revokeOAuthSession(metadata, secret);
-    }
+    await withOAuthRefreshLock(async () => {
+      lockAcquired = true;
+      metadata = getOAuthSessionMetadata({ fresh: true });
+      secret = await loadOAuthSessionSecret(metadata, { fresh: true });
+      try {
+        if (metadata && secret) await revokeOAuthSession(metadata, secret);
+      } catch (error) {
+        revokeError = error;
+      }
+      try {
+        await deleteOAuthSession();
+      } catch (error) {
+        localError = error;
+      }
+    });
   } catch (error) {
-    revokeError = error;
+    localError ||= error;
   }
-  try {
-    await deleteOAuthSession();
-  } catch (error) {
-    localError = error;
-  }
-  const remoteRevoked = !metadata || Boolean(secret && !revokeError);
+  const remoteRevoked = lockAcquired && (!metadata || Boolean(secret && !revokeError));
   const result = { authenticated: false, local_credentials_removed: !localError, revoked: remoteRevoked };
   if (flags.json) console.log(JSON.stringify(result, null, 2));
   else {

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -1,0 +1,148 @@
+import { execFile } from "node:child_process";
+import { platform } from "node:os";
+import { resolveBaseUrl } from "../config/endpoint.mjs";
+import { discoverTools } from "../client/api.mjs";
+import { bold, cyan, dim, green, red } from "../output/colors.mjs";
+import {
+  DEFAULT_OAUTH_SCOPES,
+  createStoredOAuthCredentialProvider,
+  discoverAuthorizationServer,
+  pollDeviceToken,
+  revokeOAuthToken,
+  startDeviceAuthorization,
+} from "../auth/oauth.mjs";
+import {
+  deleteOAuthSession,
+  getOAuthSessionMetadata,
+  loadOAuthSessionSecret,
+  saveOAuthSession,
+} from "../auth/storage.mjs";
+
+function openBrowser(url) {
+  const command = { darwin: "open", win32: "cmd", linux: "xdg-open" }[platform()] || "xdg-open";
+  const args = platform() === "win32" ? ["/c", "start", "", url] : [url];
+  execFile(command, args, () => {});
+}
+
+export async function runAuth(subcommand, flags) {
+  if (subcommand === "login") return authLogin(flags);
+  if (subcommand === "status") return authStatus(flags);
+  if (subcommand === "logout") return authLogout(flags);
+  console.error("  Usage: qveris auth <login|status|logout>");
+  process.exitCode = 2;
+}
+
+async function authLogin(flags) {
+  const { baseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const issuer = new URL(baseUrl).origin;
+  const metadata = await discoverAuthorizationServer(issuer);
+  const scope = flags.scope || DEFAULT_OAUTH_SCOPES;
+  const requestedScopes = scope.split(/\s+/).filter(Boolean);
+  const unsupported = requestedScopes.filter((item) => !metadata.scopes_supported.includes(item));
+  if (unsupported.length) throw new Error(`OAuth scopes are not supported: ${unsupported.join(", ")}`);
+  const resource = flags.resource || `${issuer}/tools`;
+  const authorization = await startDeviceAuthorization(metadata, { scope, resource });
+
+  if (!flags.json) {
+    console.log(`\n  ${bold("Authorize QVeris CLI")}`);
+    console.log(`  Open: ${cyan(authorization.verification_uri)}`);
+    console.log(`  Code: ${bold(authorization.user_code)}`);
+    console.log(`  ${dim("Waiting for approval...")}\n`);
+  } else {
+    console.error(
+      JSON.stringify({
+        status: "authorization_pending",
+        verification_uri: authorization.verification_uri,
+        user_code: authorization.user_code,
+        expires_in: authorization.expires_in,
+      }),
+    );
+  }
+  if (!flags.noBrowser) {
+    openBrowser(authorization.verification_uri_complete || authorization.verification_uri);
+  }
+
+  const tokens = await pollDeviceToken(metadata, authorization);
+  const session = {
+    issuer,
+    api_base_url: baseUrl,
+    resource: tokens.resource || resource,
+    scope: tokens.scope || scope,
+    token_endpoint: metadata.token_endpoint,
+    revocation_endpoint: metadata.revocation_endpoint,
+    expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
+  };
+  await deleteOAuthSession();
+  const persisted = await saveOAuthSession(session, {
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+  });
+  const result = { authenticated: true, issuer, resource: session.resource, scope: session.scope, persisted };
+  if (flags.json) console.log(JSON.stringify(result, null, 2));
+  else {
+    console.log(`  ${green("✓")} Device authorization completed.`);
+    console.log(
+      persisted
+        ? `  ${dim("Refresh credentials saved in the operating-system credential store.")}`
+        : `  ${red("!")} No operating-system credential store is available; credentials last only for this process.`,
+    );
+  }
+}
+
+async function authStatus(flags) {
+  const metadata = getOAuthSessionMetadata();
+  const secret = await loadOAuthSessionSecret(metadata);
+  if (!metadata || !secret) {
+    const result = { authenticated: false, type: "oauth" };
+    if (flags.json) console.log(JSON.stringify(result, null, 2));
+    else console.log(`  Not authenticated with OAuth. Run ${cyan("qveris auth login")}.`);
+    process.exitCode = 1;
+    return;
+  }
+  const provider = createStoredOAuthCredentialProvider();
+  await discoverTools({
+    credentialProvider: provider,
+    baseUrl: metadata.api_base_url,
+    query: "test",
+    limit: 1,
+    timeoutMs: 10000,
+  });
+  const result = {
+    authenticated: true,
+    type: "oauth",
+    issuer: metadata.issuer,
+    resource: metadata.resource,
+    scope: metadata.scope,
+    storage: metadata.storage,
+  };
+  if (flags.json) console.log(JSON.stringify(result, null, 2));
+  else {
+    console.log(`  ${green("✓")} Authenticated with OAuth Device Flow`);
+    console.log(`  Issuer:   ${metadata.issuer}`);
+    console.log(`  Resource: ${metadata.resource}`);
+    console.log(`  Storage:  ${metadata.storage}`);
+  }
+}
+
+async function authLogout(flags) {
+  const metadata = getOAuthSessionMetadata();
+  const secret = await loadOAuthSessionSecret(metadata);
+  let revokeError = null;
+  try {
+    if (metadata && secret) {
+      await revokeOAuthToken(metadata, secret.refresh_token, "refresh_token");
+      await revokeOAuthToken(metadata, secret.access_token, "access_token");
+    }
+  } catch (error) {
+    revokeError = error;
+  } finally {
+    await deleteOAuthSession();
+  }
+  const result = { authenticated: false, local_credentials_removed: true, revoked: !revokeError };
+  if (flags.json) console.log(JSON.stringify(result, null, 2));
+  else {
+    console.log(`  ${green("✓")} Local OAuth credentials removed.`);
+    if (revokeError) console.error(`  ${red("!")} Remote revocation failed; the local session was still cleared.`);
+  }
+  if (revokeError) process.exitCode = 1;
+}

--- a/packages/cli/src/commands/call.mjs
+++ b/packages/cli/src/commands/call.mjs
@@ -1,12 +1,11 @@
 import { resolveApiKey } from "../client/auth.mjs";
-import { callTool } from "../client/api.mjs";
+import { callTool, resolveApiBaseUrl } from "../client/api.mjs";
 import { resolveToolId, getSessionDiscoveryId } from "../session/session.mjs";
 import { resolveParams } from "../utils/params.mjs";
 import { formatCallResult } from "../output/formatter.mjs";
 import { outputJson } from "../output/json.mjs";
 import { createSpinner } from "../output/spinner.mjs";
 import { generateSnippet } from "../output/codegen.mjs";
-import { resolveBaseUrl } from "../config/endpoint.mjs";
 import { CliError } from "../errors/handler.mjs";
 import { bold, dim, cyan } from "../output/colors.mjs";
 
@@ -33,7 +32,7 @@ export async function runCall(idOrIndex, flags) {
   const apiKey = resolveApiKey(flags.apiKey);
   const timeoutMs = (parseInt(flags.timeout, 10) || 60) * 1000;
   const maxSize = resolveMaxSize(flags);
-  const { baseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const { baseUrl } = resolveApiBaseUrl({ baseUrlFlag: flags.baseUrl, preferOAuth: apiKey === undefined });
 
   const resolved = resolveToolId(idOrIndex);
   const toolId = resolved.toolId;

--- a/packages/cli/src/commands/completions.mjs
+++ b/packages/cli/src/commands/completions.mjs
@@ -2,6 +2,7 @@ const COMMANDS = [
   "discover",
   "inspect",
   "call",
+  "auth",
   "login",
   "logout",
   "whoami",

--- a/packages/cli/src/commands/config.mjs
+++ b/packages/cli/src/commands/config.mjs
@@ -1,9 +1,9 @@
 import { getConfigPath, getConfigValue, setConfigValue, writeConfig } from "../config/store.mjs";
 import { resolveAll } from "../config/resolve.mjs";
-import { resolveBaseUrl } from "../config/endpoint.mjs";
+import { resolveApiBaseUrl } from "../client/api.mjs";
 import { bold, dim, cyan } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
-import { deleteOAuthSession } from "../auth/storage.mjs";
+import { deleteOAuthSession, hasOAuthSession } from "../auth/storage.mjs";
 
 const ALLOWED_KEYS = ["api_key", "default_limit", "default_max_size", "color", "output_format"];
 
@@ -61,6 +61,12 @@ function configGet(key, flags) {
     process.exitCode = 2;
     return;
   }
+  if (!ALLOWED_KEYS.includes(key)) {
+    console.error(`  Unknown config key: ${key}`);
+    console.error(`  Allowed: ${ALLOWED_KEYS.join(", ")}`);
+    process.exitCode = 2;
+    return;
+  }
   const val = getConfigValue(key);
   if (flags.json) {
     outputJson({ key, value: val ?? null });
@@ -72,7 +78,10 @@ function configGet(key, flags) {
 function configList(flags) {
   const all = resolveAll();
 
-  const { baseUrl, source: endpointSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const { baseUrl, source: endpointSource } = resolveApiBaseUrl({
+    baseUrlFlag: flags.baseUrl,
+    preferOAuth: !all.api_key?.value && hasOAuthSession(),
+  });
 
   if (flags.json) {
     const obj = {};

--- a/packages/cli/src/commands/config.mjs
+++ b/packages/cli/src/commands/config.mjs
@@ -3,7 +3,15 @@ import { resolveAll } from "../config/resolve.mjs";
 import { resolveApiBaseUrl } from "../client/api.mjs";
 import { bold, dim, cyan } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
-import { deleteOAuthSession, hasOAuthSession } from "../auth/storage.mjs";
+import { revokeOAuthSession } from "../auth/oauth.mjs";
+import {
+  deleteOAuthSession,
+  getOAuthSessionMetadata,
+  hasOAuthSession,
+  loadOAuthSessionSecret,
+  withOAuthRefreshLock,
+} from "../auth/storage.mjs";
+import { CliError } from "../errors/handler.mjs";
 
 const ALLOWED_KEYS = ["api_key", "default_limit", "default_max_size", "color", "output_format"];
 
@@ -26,7 +34,7 @@ export async function runConfig(subcommand, args, flags) {
   }
 }
 
-function configSet(key, value, flags) {
+async function configSet(key, value, flags) {
   if (!key || value === undefined) {
     console.error("  Usage: qveris config set <key> <value>");
     process.exitCode = 2;
@@ -47,7 +55,7 @@ function configSet(key, value, flags) {
       return;
     }
   }
-  setConfigValue(key, parsed);
+  await withOAuthRefreshLock(async () => setConfigValue(key, parsed));
   if (flags.json) {
     outputJson({ key, value: parsed });
   } else {
@@ -106,8 +114,26 @@ function configList(flags) {
 }
 
 async function configReset() {
-  await deleteOAuthSession();
-  writeConfig({});
+  let cleanupWarning = null;
+  await withOAuthRefreshLock(async () => {
+    const metadata = getOAuthSessionMetadata({ fresh: true });
+    const secret = await loadOAuthSessionSecret(metadata, { fresh: true });
+    if (metadata && secret) {
+      try {
+        await revokeOAuthSession(metadata, secret);
+      } catch (error) {
+        cleanupWarning = error;
+      }
+    } else if (metadata) {
+      cleanupWarning = new CliError(
+        "API_ERROR",
+        "Remote OAuth revocation could not be attempted because the stored credential is unavailable",
+      );
+    }
+    await deleteOAuthSession();
+    writeConfig({});
+  });
+  if (cleanupWarning) throw cleanupWarning;
   console.log("  Config reset to defaults.");
 }
 

--- a/packages/cli/src/commands/config.mjs
+++ b/packages/cli/src/commands/config.mjs
@@ -3,6 +3,7 @@ import { resolveAll } from "../config/resolve.mjs";
 import { resolveBaseUrl } from "../config/endpoint.mjs";
 import { bold, dim, cyan } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
+import { deleteOAuthSession } from "../auth/storage.mjs";
 
 const ALLOWED_KEYS = ["api_key", "default_limit", "default_max_size", "color", "output_format"];
 
@@ -95,7 +96,8 @@ function configList(flags) {
   console.log();
 }
 
-function configReset() {
+async function configReset() {
+  await deleteOAuthSession();
   writeConfig({});
   console.log("  Config reset to defaults.");
 }

--- a/packages/cli/src/commands/credits.mjs
+++ b/packages/cli/src/commands/credits.mjs
@@ -1,13 +1,13 @@
 import { resolveApiKey } from "../client/auth.mjs";
-import { getCredits, unwrapApiResponse } from "../client/api.mjs";
-import { resolveBaseUrl, getSiteUrl } from "../config/endpoint.mjs";
+import { getCredits, resolveApiBaseUrl, unwrapApiResponse } from "../client/api.mjs";
+import { getSiteUrl } from "../config/endpoint.mjs";
 import { bold, dim, cyan, yellow, green } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
 import { createSpinner } from "../output/spinner.mjs";
 
 export async function runCredits(flags) {
   const apiKey = resolveApiKey(flags.apiKey);
-  const { baseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const { baseUrl } = resolveApiBaseUrl({ baseUrlFlag: flags.baseUrl, preferOAuth: apiKey === undefined });
   const accountUrl = `${getSiteUrl(baseUrl)}/account`;
 
   const spinner = flags.json ? { stop() {} } : createSpinner("Checking credits...");

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -1,6 +1,5 @@
 import { resolveApiKey } from "../client/auth.mjs";
-import { discoverTools } from "../client/api.mjs";
-import { resolveBaseUrl } from "../config/endpoint.mjs";
+import { discoverTools, resolveApiBaseUrl } from "../client/api.mjs";
 import { writeSession } from "../session/session.mjs";
 import { formatDiscoverResult } from "../output/formatter.mjs";
 import { outputJson } from "../output/json.mjs";
@@ -8,7 +7,10 @@ import { createSpinner } from "../output/spinner.mjs";
 
 export async function runDiscover(query, flags) {
   const apiKey = resolveApiKey(flags.apiKey);
-  const { baseUrl: resolvedBaseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const { baseUrl: resolvedBaseUrl } = resolveApiBaseUrl({
+    baseUrlFlag: flags.baseUrl,
+    preferOAuth: apiKey === undefined,
+  });
   const limit = parseInt(flags.limit, 10) || 5;
   const timeoutMs = (parseInt(flags.timeout, 10) || 30) * 1000;
 

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -1,8 +1,7 @@
 import { resolveApiKey } from "../client/auth.mjs";
-import { callTool, discoverTools, inspectToolsByIds } from "../client/api.mjs";
+import { callTool, discoverTools, inspectToolsByIds, resolveApiBaseUrl } from "../client/api.mjs";
 import { nodeCheck } from "../client/preflight.mjs";
 import { resolve } from "../config/resolve.mjs";
-import { resolveBaseUrl } from "../config/endpoint.mjs";
 import { CliError } from "../errors/handler.mjs";
 import { bold, cyan, dim, green, red, yellow } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
@@ -31,10 +30,13 @@ export async function runInit(queryArg, flags) {
 
   const timeoutMs = (parseInt(flags.timeout, 10) || 60) * 1000;
   const apiKey = getInitApiKey(flags);
-  const { baseUrl, source: endpointSource } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
-  record(steps, "auth", "ok", "API key resolved", {
-    source: resolve("api_key", flags.apiKey || flags.token).source,
-    key: maskKey(apiKey),
+  const { baseUrl, source: endpointSource } = resolveApiBaseUrl({
+    baseUrlFlag: flags.baseUrl,
+    preferOAuth: apiKey === undefined,
+  });
+  record(steps, "auth", "ok", apiKey === undefined ? "OAuth session resolved" : "API key resolved", {
+    source: apiKey === undefined ? "oauth session" : resolve("api_key", flags.apiKey || flags.token).source,
+    ...(apiKey === undefined ? { type: "oauth" } : { type: "api_key", key: maskKey(apiKey) }),
     base_url: baseUrl,
     endpoint_source: endpointSource,
   });
@@ -210,7 +212,8 @@ function getInitApiKey(flags) {
     return resolveApiKey(flags.apiKey || flags.token);
   } catch (err) {
     if (err instanceof CliError && err.code === "AUTH_MISSING_KEY") {
-      err.hint = "Run 'qveris login', set QVERIS_API_KEY, or pass --api-key/--token to qveris init.";
+      err.hint =
+        "Run 'qveris auth login' or 'qveris login', set QVERIS_API_KEY, or pass --api-key/--token to qveris init.";
     }
     throw err;
   }

--- a/packages/cli/src/commands/interactive.mjs
+++ b/packages/cli/src/commands/interactive.mjs
@@ -1,7 +1,6 @@
 import { createInterface } from "node:readline";
 import { resolveApiKey } from "../client/auth.mjs";
-import { discoverTools, inspectToolsByIds, callTool } from "../client/api.mjs";
-import { resolveBaseUrl } from "../config/endpoint.mjs";
+import { discoverTools, inspectToolsByIds, callTool, resolveApiBaseUrl } from "../client/api.mjs";
 import { resolveParams } from "../utils/params.mjs";
 import { formatDiscoverResult, formatInspectResult, formatCallResult } from "../output/formatter.mjs";
 import { generateSnippet } from "../output/codegen.mjs";
@@ -14,7 +13,10 @@ import { createSpinner } from "../output/spinner.mjs";
 
 export async function runInteractive(flags) {
   const apiKey = resolveApiKey(flags.apiKey);
-  const { baseUrl: resolvedBaseUrl } = resolveBaseUrl({ baseUrlFlag: flags.baseUrl });
+  const { baseUrl: resolvedBaseUrl } = resolveApiBaseUrl({
+    baseUrlFlag: flags.baseUrl,
+    preferOAuth: apiKey === undefined,
+  });
   const limit = parseInt(flags.limit, 10) || 5;
   const discoverTimeout = (parseInt(flags.timeout, 10) || 30) * 1000;
   const callTimeout = (parseInt(flags.timeout, 10) || 60) * 1000;

--- a/packages/cli/src/commands/login.mjs
+++ b/packages/cli/src/commands/login.mjs
@@ -7,6 +7,7 @@ import { resolveBaseUrl, getSiteUrl } from "../config/endpoint.mjs";
 import { bold, green, red, dim, cyan } from "../output/colors.mjs";
 import { printLoginBanner } from "../output/banner.mjs";
 import { openUrl } from "../utils/open-url.mjs";
+import { withOAuthRefreshLock } from "../auth/storage.mjs";
 
 /**
  * Masked input prompt using raw mode.
@@ -132,21 +133,27 @@ async function validateAndSave(key, baseUrlFlag) {
 
   try {
     await discoverTools({ apiKey: key, baseUrl, query: "test", limit: 1, timeoutMs: 10000 });
-    setConfigValue("api_key", key);
-    const masked = key.slice(0, 6) + "..." + key.slice(-4);
-    console.error(`\r\x1b[K`);
-    console.log(`  ${green("\u2713")} Authenticated as ${bold(masked)}`);
-    console.log(`  ${dim("Endpoint:")} ${baseUrl} ${dim(`(${source})`)}`);
-    console.log(`  ${dim("Key saved to config.")}`);
   } catch {
     console.error(`\r\x1b[K`);
     console.error(`  ${red("\u2718")} Invalid API key. Please check and try again.`);
     process.exitCode = 1;
+    return;
   }
+  try {
+    await withOAuthRefreshLock(async () => setConfigValue("api_key", key));
+  } catch (error) {
+    console.error(`\r\x1b[K`);
+    throw error;
+  }
+  const masked = key.slice(0, 6) + "..." + key.slice(-4);
+  console.error(`\r\x1b[K`);
+  console.log(`  ${green("\u2713")} Authenticated as ${bold(masked)}`);
+  console.log(`  ${dim("Endpoint:")} ${baseUrl} ${dim(`(${source})`)}`);
+  console.log(`  ${dim("Key saved to config.")}`);
 }
 
 export async function runLogout() {
-  deleteConfigValue("api_key");
+  await withOAuthRefreshLock(async () => deleteConfigValue("api_key"));
   console.log(`  ${green("\u2713")} API key removed from config.`);
 }
 

--- a/packages/cli/src/commands/login.mjs
+++ b/packages/cli/src/commands/login.mjs
@@ -1,6 +1,4 @@
 import { createInterface } from "node:readline";
-import { execFile } from "node:child_process";
-import { platform } from "node:os";
 import { resolve } from "../config/resolve.mjs";
 import { setConfigValue, deleteConfigValue } from "../config/store.mjs";
 import { discoverTools } from "../client/api.mjs";
@@ -8,13 +6,7 @@ import { VERSION } from "../config/defaults.mjs";
 import { resolveBaseUrl, getSiteUrl } from "../config/endpoint.mjs";
 import { bold, green, red, dim, cyan } from "../output/colors.mjs";
 import { printLoginBanner } from "../output/banner.mjs";
-
-function openBrowser(url) {
-  const cmds = { darwin: "open", win32: "cmd", linux: "xdg-open" };
-  const cmd = cmds[platform()] || "xdg-open";
-  const args = platform() === "win32" ? ["/c", "start", "", url] : [url];
-  execFile(cmd, args, () => {});
-}
+import { openUrl } from "../utils/open-url.mjs";
 
 /**
  * Masked input prompt using raw mode.
@@ -114,7 +106,7 @@ export async function runLogin(flags) {
   console.log(`\n  Get your API key at: ${cyan(accountUrl)}\n`);
 
   if (!flags.noBrowser) {
-    openBrowser(accountUrl);
+    openUrl(accountUrl);
   }
 
   let key;

--- a/packages/cli/src/config/store.mjs
+++ b/packages/cli/src/config/store.mjs
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { chmodSync, readFileSync, renameSync, unlinkSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { CliError } from "../errors/handler.mjs";
 
 function configDir() {
   const xdg = process.env.XDG_CONFIG_HOME;
@@ -18,11 +19,29 @@ export function getConfigPath() {
 }
 
 export function readConfig() {
+  let raw;
   try {
-    return JSON.parse(readFileSync(configPath(), "utf-8"));
-  } catch {
-    return {};
+    raw = readFileSync(configPath(), "utf-8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return {};
+    throw new CliError("API_ERROR", `QVeris config could not be read: ${configPath()}`);
   }
+  let config;
+  try {
+    config = JSON.parse(raw);
+  } catch {
+    throw new CliError(
+      "API_ERROR",
+      `QVeris config contains invalid JSON: ${configPath()}. Repair or remove it before continuing`,
+    );
+  }
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new CliError(
+      "API_ERROR",
+      `QVeris config must contain a JSON object: ${configPath()}. Repair or remove it before continuing`,
+    );
+  }
+  return config;
 }
 
 export function writeConfig(config) {

--- a/packages/cli/src/config/store.mjs
+++ b/packages/cli/src/config/store.mjs
@@ -1,4 +1,5 @@
-import { chmodSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { chmodSync, readFileSync, renameSync, unlinkSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -26,9 +27,22 @@ export function readConfig() {
 
 export function writeConfig(config) {
   const dir = configDir();
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(configPath(), JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
-  chmodSync(configPath(), 0o600);
+  const target = configPath();
+  const temporary = join(dir, `.config-${process.pid}-${randomUUID()}.tmp`);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodSync(dir, 0o700);
+  try {
+    writeFileSync(temporary, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
+    chmodSync(temporary, 0o600);
+    renameSync(temporary, target);
+    chmodSync(target, 0o600);
+  } finally {
+    try {
+      unlinkSync(temporary);
+    } catch {
+      // The temporary path no longer exists after a successful rename.
+    }
+  }
 }
 
 export function getConfigValue(key) {

--- a/packages/cli/src/config/store.mjs
+++ b/packages/cli/src/config/store.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { chmodSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -28,6 +28,7 @@ export function writeConfig(config) {
   const dir = configDir();
   mkdirSync(dir, { recursive: true });
   writeFileSync(configPath(), JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(configPath(), 0o600);
 }
 
 export function getConfigValue(key) {

--- a/packages/cli/src/errors/codes.mjs
+++ b/packages/cli/src/errors/codes.mjs
@@ -9,7 +9,7 @@ export const EX_CONFIG = 78;
 export const ERROR_CODES = {
   AUTH_MISSING_KEY: {
     message: "No API key configured",
-    hint: "Run 'qveris login' or set QVERIS_API_KEY",
+    hint: "Run 'qveris auth login', 'qveris login', or set QVERIS_API_KEY",
     exit: EX_CONFIG,
   },
   NODE_UNSUPPORTED: {
@@ -25,6 +25,11 @@ export const ERROR_CODES = {
   AUTH_INVALID_KEY: {
     message: "Authentication failed",
     hint: "Check the API key for the configured endpoint",
+    exit: EX_NOPERM,
+  },
+  AUTH_OAUTH_FAILED: {
+    message: "OAuth authentication failed",
+    hint: "Run 'qveris auth login' again",
     exit: EX_NOPERM,
   },
   NET_TIMEOUT: {

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -74,6 +74,12 @@ export async function main(argv) {
         await runLogin(flags);
         break;
       }
+      case "auth": {
+        const subcommand = rest[0];
+        const { runAuth } = await import("./commands/auth.mjs");
+        await runAuth(subcommand, flags);
+        break;
+      }
       case "logout": {
         const { runLogout } = await import("./commands/login.mjs");
         await runLogout();
@@ -186,6 +192,8 @@ const VALUE_FLAGS = {
   direction: "direction",
   "min-credits": "minCredits",
   "max-credits": "maxCredits",
+  scope: "scope",
+  resource: "resource",
 };
 
 function takeNext(args, i, flag) {
@@ -370,6 +378,12 @@ function extractGlobalFlags(args) {
       case "--max-credits":
         flags.maxCredits = takeNext(args, i++, arg);
         break;
+      case "--scope":
+        flags.scope = takeNext(args, i++, arg);
+        break;
+      case "--resource":
+        flags.resource = takeNext(args, i++, arg);
+        break;
       default:
         flags._positional.push(arg);
     }
@@ -396,6 +410,7 @@ function printUsage(flags = {}) {
     ${cyan("call")}     <tool_id|index>     Execute a capability
 
   ${bold("Account:")}
+    ${cyan("auth")}      login|status|logout  OAuth Device Flow session
     ${cyan("login")}                        Authenticate with QVeris
     ${cyan("logout")}                       Remove stored API key
     ${cyan("whoami")}                       Show current auth status
@@ -417,6 +432,8 @@ function printUsage(flags = {}) {
     --json, -j             Output raw JSON
     --api-key <key>        Override API key
     --base-url <url>       Override API base URL
+    --scope <scopes>       OAuth scopes for auth login
+    --resource <url>       OAuth resource for auth login
     --timeout <seconds>    Request timeout
     --target <target>      MCP target: cursor | claude-desktop | claude-code | opencode | openclaw | generic
     --output <path>        MCP config output path

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -294,6 +294,9 @@ function extractGlobalFlags(args) {
       case "--no-browser":
         flags.noBrowser = true;
         break;
+      case "--allow-unencrypted-storage":
+        flags.allowUnencryptedStorage = true;
+        break;
       case "--clear":
         flags.clear = true;
         break;
@@ -434,6 +437,8 @@ function printUsage(flags = {}) {
     --base-url <url>       Override API base URL
     --scope <scopes>       OAuth scopes for auth login
     --resource <url>       OAuth resource for auth login
+    --allow-unencrypted-storage
+                           Persist OAuth tokens in the user-only config file when no keyring is available
     --timeout <seconds>    Request timeout
     --target <target>      MCP target: cursor | claude-desktop | claude-code | opencode | openclaw | generic
     --output <path>        MCP config output path

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -435,7 +435,7 @@ function printUsage(flags = {}) {
     --json, -j             Output raw JSON
     --api-key <key>        Override API key
     --base-url <url>       Override API base URL
-    --scope <scopes>       OAuth scopes for auth login
+    --scope <scopes>       OAuth scopes for auth login (must include offline_access)
     --resource <url>       OAuth resource for auth login
     --allow-unencrypted-storage
                            Persist OAuth tokens in the user-only config file when no keyring is available

--- a/packages/cli/src/utils/open-url.mjs
+++ b/packages/cli/src/utils/open-url.mjs
@@ -1,0 +1,15 @@
+import { execFile } from "node:child_process";
+import { platform } from "node:os";
+
+export function getOpenUrlCommand(url, currentPlatform = platform()) {
+  if (currentPlatform === "darwin") return { command: "open", args: [url] };
+  if (currentPlatform === "win32") {
+    return { command: "rundll32.exe", args: ["url.dll,FileProtocolHandler", url] };
+  }
+  return { command: "xdg-open", args: [url] };
+}
+
+export function openUrl(url) {
+  const { command, args } = getOpenUrlCommand(url);
+  execFile(command, args, () => {});
+}

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -175,6 +175,46 @@ test("API request timeout starts after the credential resolves", async () => {
   );
 });
 
+test("OAuth credentials refresh once on 401 and business 403 is not retried", async () => {
+  let credential = "expired-access";
+  let refreshes = 0;
+  const provider = {
+    async getCredential() {
+      return credential;
+    },
+    async refreshCredential() {
+      refreshes += 1;
+      credential = "fresh-access";
+    },
+  };
+  let requests = 0;
+  await withMockFetch(
+    (_url, options) => {
+      requests += 1;
+      return options.headers.Authorization === "Bearer expired-access"
+        ? jsonResponse({ message: "expired" }, { status: 401 })
+        : jsonResponse({ ok: true });
+    },
+    () => discoverTools({ credentialProvider: provider, baseUrl: "https://unit.test/api/v1", query: "weather" }),
+  );
+  assert.equal(refreshes, 1);
+  assert.equal(requests, 2);
+
+  requests = 0;
+  await assert.rejects(
+    withMockFetch(
+      () => {
+        requests += 1;
+        return jsonResponse({ message: "forbidden" }, { status: 403 });
+      },
+      () => discoverTools({ credentialProvider: provider, baseUrl: "https://unit.test/api/v1", query: "weather" }),
+    ),
+    /forbidden/,
+  );
+  assert.equal(requests, 1);
+  assert.equal(refreshes, 1);
+});
+
 test("API client rejects ambiguous or invalid provider credentials without exposing values", async () => {
   await assert.rejects(
     discoverTools({

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -213,6 +213,21 @@ test("OAuth credentials refresh once on 401 and business 403 is not retried", as
   );
   assert.equal(requests, 1);
   assert.equal(refreshes, 1);
+
+  const oauthProvider = {
+    authType: "oauth",
+    async getCredential() {
+      return "oauth-access";
+    },
+    async refreshCredential() {},
+  };
+  await assert.rejects(
+    withMockFetch(
+      () => jsonResponse({ message: "session expired" }, { status: 401 }),
+      () => discoverTools({ credentialProvider: oauthProvider, baseUrl: "https://unit.test/api/v1", query: "weather" }),
+    ),
+    (error) => error instanceof CliError && error.code === "AUTH_OAUTH_FAILED" && /session expired/.test(error.message),
+  );
 });
 
 test("API client rejects ambiguous or invalid provider credentials without exposing values", async () => {

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -33,6 +33,7 @@ test("API client maps discover, inspect, call, credits, usage, and ledger endpoi
   const requests = [];
   await withMockFetch(
     (url, options) => {
+      assert.equal(options.redirect, "error");
       requests.push({
         method: options.method,
         path: url.pathname,
@@ -228,6 +229,14 @@ test("OAuth credentials refresh once on 401 and business 403 is not retried", as
     ),
     (error) => error instanceof CliError && error.code === "AUTH_OAUTH_FAILED" && /session expired/.test(error.message),
   );
+
+  await assert.rejects(
+    withMockFetch(
+      () => jsonResponse({ message: "missing required scope" }, { status: 403 }),
+      () => discoverTools({ credentialProvider: oauthProvider, baseUrl: "https://unit.test/api/v1", query: "weather" }),
+    ),
+    (error) => error instanceof CliError && error.code === "API_ERROR" && /missing required scope/.test(error.message),
+  );
 });
 
 test("API client rejects ambiguous or invalid provider credentials without exposing values", async () => {
@@ -260,6 +269,22 @@ test("API client rejects ambiguous or invalid provider credentials without expos
     }),
     (err) =>
       err instanceof CliError && /failed to provide a credential/.test(err.message) && !err.message.includes(secret),
+  );
+});
+
+test("API client preserves actionable CLI errors from credential providers", async () => {
+  const providerError = new CliError("API_ERROR", "Rotated OAuth credentials could not be persisted");
+  await assert.rejects(
+    discoverTools({
+      credentialProvider: {
+        async getCredential() {
+          throw providerError;
+        },
+      },
+      baseUrl: "https://unit.test/api/v1",
+      query: "weather",
+    }),
+    (error) => error === providerError,
   );
 });
 

--- a/packages/cli/test/commands.test.mjs
+++ b/packages/cli/test/commands.test.mjs
@@ -15,7 +15,7 @@ import { runInspect } from "../src/commands/inspect.mjs";
 import { runLedger } from "../src/commands/ledger.mjs";
 import { runLogin, runLogout, runWhoami } from "../src/commands/login.mjs";
 import { runUsage } from "../src/commands/usage.mjs";
-import { getConfigPath } from "../src/config/store.mjs";
+import { getConfigPath, setConfigValue } from "../src/config/store.mjs";
 import { main } from "../src/main.mjs";
 
 function withTempConfig(fn) {
@@ -289,6 +289,17 @@ test("config command covers set, get, list, path, and reset", async () => {
 
     const get = await captureOutput(() => runConfig("get", ["api_key"], { json: true }));
     assert.deepEqual(jsonFromStdout(get.stdout), { key: "api_key", value: "sk-config" });
+
+    setConfigValue("oauth_session_secret", {
+      secret: { access_token: "never-print-access", refresh_token: "never-print-refresh" },
+    });
+    const previousSecretExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const secretGet = await captureOutput(() => runConfig("get", ["oauth_session_secret"], { json: true }));
+    assert.match(secretGet.stderr, /Unknown config key: oauth_session_secret/);
+    assert.doesNotMatch(`${secretGet.stdout}${secretGet.stderr}`, /never-print/);
+    assert.equal(process.exitCode, 2);
+    process.exitCode = previousSecretExitCode;
 
     const list = await captureOutput(() => runConfig("list", [], { json: true }));
     const listed = jsonFromStdout(list.stdout);

--- a/packages/cli/test/core.test.mjs
+++ b/packages/cli/test/core.test.mjs
@@ -47,6 +47,10 @@ test("endpoint resolution uses flag, environment, then default without key or re
   await withTempConfig(() => {
     assert.equal(resolveApiKey("sk-flag").trim(), "sk-flag");
     assert.throws(() => resolveApiKey("YOUR_QVERIS_API_KEY"), /placeholder/);
+    assert.throws(
+      () => resolveApiKey(12345),
+      (error) => error?.code === "AUTH_MISSING_KEY" && /must be a string/.test(error.message),
+    );
     process.env.QVERIS_REGION = "cn";
     assert.deepEqual(resolveBaseUrl({ apiKey: "sk-cn-test" }), {
       baseUrl: "https://qveris.ai/api/v1",

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -11,6 +11,7 @@ import {
   revokeOAuthSession,
   revokeOAuthToken,
   startDeviceAuthorization,
+  validateOAuthScopes,
 } from "../src/auth/oauth.mjs";
 import { deleteOAuthSession, getOAuthSessionMetadata, saveOAuthSession } from "../src/auth/storage.mjs";
 import { runAuth } from "../src/commands/auth.mjs";
@@ -42,6 +43,53 @@ test("OAuth discovery requires matching issuer, Device Flow, and a public client
       response({ ...discovery, token_endpoint_auth_methods_supported: ["client_secret_basic"] }),
     ),
     /public QVeris CLI client/,
+  );
+
+  const loopback = await discoverAuthorizationServer("http://[::1]:8787", async () =>
+    response({
+      ...discovery,
+      issuer: "http://[::1]:8787",
+      device_authorization_endpoint: "http://[::1]:8787/oauth/device/authorize",
+      token_endpoint: "http://[::1]:8787/oauth/token",
+      revocation_endpoint: "http://[::1]:8787/oauth/revoke",
+    }),
+  );
+  assert.equal(loopback.issuer, "http://[::1]:8787");
+
+  await assert.rejects(
+    discoverAuthorizationServer("https://unit.test", async () =>
+      response({ ...discovery, token_endpoint: "ftp://localhost/oauth/token" }),
+    ),
+    /token_endpoint must use HTTPS/,
+  );
+
+  await assert.rejects(
+    discoverAuthorizationServer("https://unit.test", async () =>
+      response({ ...discovery, token_endpoint: "https://other.test/oauth/token" }),
+    ),
+    /token_endpoint does not match the stored issuer/,
+  );
+
+  await assert.rejects(
+    discoverAuthorizationServer("https://unit.test", async () => {
+      const error = new Error("aborted");
+      error.name = "AbortError";
+      throw error;
+    }),
+    (error) => error.code === "NET_TIMEOUT" && /OAuth request timed out/.test(error.message),
+  );
+});
+
+test("OAuth scopes require offline access and reject unsupported values", () => {
+  assert.deepEqual(validateOAuthScopes(discovery, "openid offline_access tools.search"), [
+    "openid",
+    "offline_access",
+    "tools.search",
+  ]);
+  assert.throws(() => validateOAuthScopes(discovery, "openid tools.search"), /must include offline_access/);
+  assert.throws(
+    () => validateOAuthScopes(discovery, "openid offline_access tools.execute"),
+    /not supported: tools.execute/,
   );
 });
 
@@ -106,6 +154,80 @@ test("Device polling honors pending and slow_down before returning tokens", asyn
   assert.equal(tokens.access_token, "access-secret");
 });
 
+test("Device polling rejects a success response without a refresh token", async () => {
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 600, interval: 1 },
+      {
+        fetchImpl: async () => response({ access_token: "access-secret", token_type: "Bearer", expires_in: 3600 }),
+        sleep: async () => {},
+        now: () => 0,
+      },
+    ),
+    /required refresh token/,
+  );
+});
+
+test("Device and token responses reject invalid expiry values", async () => {
+  await assert.rejects(
+    startDeviceAuthorization(
+      discovery,
+      { scope: "openid offline_access", resource: "https://unit.test/tools" },
+      async () =>
+        response({
+          device_code: "device-secret",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://unit.test/oauth/device",
+          expires_in: 0,
+        }),
+    ),
+    /invalid expires_in/,
+  );
+
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 600, interval: 1 },
+      {
+        fetchImpl: async () =>
+          response({
+            access_token: "access-secret",
+            refresh_token: "refresh-secret",
+            token_type: "Bearer",
+          }),
+        sleep: async () => {},
+        now: () => 0,
+      },
+    ),
+    /invalid expires_in/,
+  );
+});
+
+test("Device polling does not call the token endpoint after authorization expires", async () => {
+  let currentTime = 0;
+  let requests = 0;
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 1, interval: 5 },
+      {
+        fetchImpl: async () => {
+          requests += 1;
+          return response({ error: "authorization_pending" }, { ok: false, status: 400 });
+        },
+        sleep: async (milliseconds) => {
+          currentTime += milliseconds;
+        },
+        now: () => currentTime,
+      },
+    ),
+    /expired/,
+  );
+  assert.equal(currentTime, 1000);
+  assert.equal(requests, 0);
+});
+
 for (const code of ["access_denied", "expired_token", "invalid_grant"]) {
   test(`Device polling stops on ${code}`, async () => {
     await assert.rejects(
@@ -168,6 +290,55 @@ test("Refresh rejects a response that violates the QVeris rotation contract", as
     ),
     /did not rotate the refresh token/,
   );
+
+  await assert.rejects(
+    refreshOAuthSession(
+      { ...discovery, api_base_url: "https://unit.test/api/v1", resource: "https://unit.test/tools" },
+      { access_token: "old-access", refresh_token: "same-refresh" },
+      async () =>
+        response({
+          access_token: "new-access",
+          refresh_token: "same-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+        }),
+    ),
+    /did not rotate the refresh token/,
+  );
+});
+
+test("Refresh reports when a previously persisted session cannot store rotated credentials", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-persist-failure-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  try {
+    await assert.rejects(
+      refreshOAuthSession(
+        {
+          ...discovery,
+          storage: "keyring",
+          api_base_url: "https://unit.test/api/v1",
+          resource: "https://unit.test/tools",
+        },
+        { access_token: "old-access", refresh_token: "old-refresh" },
+        async () =>
+          response({
+            access_token: "new-access",
+            refresh_token: "new-refresh",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+      ),
+      /could not be persisted/,
+    );
+  } finally {
+    await deleteOAuthSession();
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
 });
 
 test("Explicit config fallback persists across processes with owner-only permissions", async () => {

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -15,6 +15,7 @@ import {
 } from "../src/auth/oauth.mjs";
 import { deleteOAuthSession, getOAuthSessionMetadata, saveOAuthSession } from "../src/auth/storage.mjs";
 import { runAuth } from "../src/commands/auth.mjs";
+import { deleteConfigValue, setConfigValue } from "../src/config/store.mjs";
 
 function response(payload, status = 200, headers = {}) {
   return new Response(payload === null ? null : JSON.stringify(payload), {
@@ -33,8 +34,11 @@ const discovery = {
   scopes_supported: ["openid", "offline_access", "tools.search"],
 };
 
-test("OAuth discovery requires matching issuer, Device Flow, and a public client", async () => {
-  const metadata = await discoverAuthorizationServer("https://unit.test/api/v1", async () => response(discovery));
+test("OAuth discovery requires matching issuer, Device Flow, refresh, and a public client", async () => {
+  const metadata = await discoverAuthorizationServer("https://unit.test/api/v1", async (_url, options) => {
+    assert.equal(options.redirect, "error");
+    return response(discovery);
+  });
   assert.equal(metadata.issuer, "https://unit.test");
   assert.equal(metadata.device_authorization_endpoint, discovery.device_authorization_endpoint);
 
@@ -43,6 +47,13 @@ test("OAuth discovery requires matching issuer, Device Flow, and a public client
       response({ ...discovery, token_endpoint_auth_methods_supported: ["client_secret_basic"] }),
     ),
     /public QVeris CLI client/,
+  );
+
+  await assert.rejects(
+    discoverAuthorizationServer("https://unit.test", async () =>
+      response({ ...discovery, grant_types_supported: [DEVICE_CODE_GRANT] }),
+    ),
+    /Refresh Token Grant/,
   );
 
   const loopback = await discoverAuthorizationServer("http://[::1]:8787", async () =>
@@ -99,6 +110,7 @@ test("Device Authorization sends the registered public client and validates the 
     discovery,
     { scope: "openid offline_access tools.search", resource: "https://unit.test/tools" },
     async (_url, options) => {
+      assert.equal(options.redirect, "error");
       form = Object.fromEntries(options.body.entries());
       return response({
         device_code: "device-secret",
@@ -126,6 +138,19 @@ test("Device Authorization sends the registered public client and validates the 
       }),
     ),
     /verification_uri must use HTTPS/,
+  );
+
+  await assert.rejects(
+    startDeviceAuthorization(discovery, { scope: "openid", resource: "https://unit.test/tools" }, async () =>
+      response({
+        device_code: "device-secret",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://unit.test/oauth/device",
+        verification_uri_complete: "https://phishing.test/oauth/device?user_code=ABCD-EFGH",
+        expires_in: 600,
+      }),
+    ),
+    /verification_uri_complete does not match/,
   );
 });
 
@@ -167,6 +192,25 @@ test("Device polling rejects a success response without a refresh token", async 
     ),
     /required refresh token/,
   );
+
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 600, interval: 1 },
+      {
+        fetchImpl: async () =>
+          response({
+            access_token: "access-secret\nInjected: value",
+            refresh_token: "refresh-secret",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+        sleep: async () => {},
+        now: () => 0,
+      },
+    ),
+    /invalid access token response/,
+  );
 });
 
 test("Device and token responses reject invalid expiry values", async () => {
@@ -186,6 +230,21 @@ test("Device and token responses reject invalid expiry values", async () => {
   );
 
   await assert.rejects(
+    startDeviceAuthorization(
+      discovery,
+      { scope: "openid offline_access", resource: "https://unit.test/tools" },
+      async () =>
+        response({
+          device_code: "device-secret",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://unit.test/oauth/device",
+          expires_in: Number.MAX_VALUE,
+        }),
+    ),
+    /invalid expires_in/,
+  );
+
+  await assert.rejects(
     pollDeviceToken(
       discovery,
       { device_code: "device-secret", expires_in: 600, interval: 1 },
@@ -195,6 +254,25 @@ test("Device and token responses reject invalid expiry values", async () => {
             access_token: "access-secret",
             refresh_token: "refresh-secret",
             token_type: "Bearer",
+          }),
+        sleep: async () => {},
+        now: () => 0,
+      },
+    ),
+    /invalid expires_in/,
+  );
+
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 600, interval: 1 },
+      {
+        fetchImpl: async () =>
+          response({
+            access_token: "access-secret",
+            refresh_token: "refresh-secret",
+            token_type: "Bearer",
+            expires_in: Number.MAX_VALUE,
           }),
         sleep: async () => {},
         now: () => 0,
@@ -341,6 +419,54 @@ test("Refresh reports when a previously persisted session cannot store rotated c
   }
 });
 
+test("Keyring deletion failure retains issuer metadata for a later cleanup retry", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-keyring-cleanup-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  const isolatedStorage = await import(`../src/auth/storage.mjs?cleanup=${process.pid}-${Date.now()}`);
+  try {
+    setConfigValue("oauth_session", { ...discovery, storage: "keyring" });
+    await assert.rejects(isolatedStorage.deleteOAuthSession(), /credential store is unavailable/);
+    assert.equal(isolatedStorage.getOAuthSessionMetadata({ fresh: true }).storage, "keyring");
+    assert.equal(await isolatedStorage.loadOAuthSessionSecret(undefined, { fresh: true }), null);
+  } finally {
+    deleteConfigValue("oauth_session");
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("OAuth logout reports incomplete local deletion and unknown remote revocation", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousExitCode = process.exitCode;
+  const previousLog = console.log;
+  const lines = [];
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-logout-cleanup-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    setConfigValue("oauth_session", { ...discovery, storage: "keyring" });
+    process.exitCode = undefined;
+    await runAuth("logout", { json: true });
+    const result = JSON.parse(lines.join("\n"));
+    assert.deepEqual(result, { authenticated: false, local_credentials_removed: false, revoked: false });
+    assert.equal(process.exitCode, 1);
+    assert.equal(getOAuthSessionMetadata({ fresh: true }).storage, "keyring");
+  } finally {
+    console.log = previousLog;
+    deleteConfigValue("oauth_session");
+    process.exitCode = previousExitCode;
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
 test("Explicit config fallback persists across processes with owner-only permissions", async () => {
   const previous = process.env.XDG_CONFIG_HOME;
   const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
@@ -418,9 +544,58 @@ test("Concurrent providers coalesce refresh rotation", async () => {
   }
 });
 
+test("Independent OAuth module instances serialize persisted refresh rotation", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-process-lock-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  const suffix = `${process.pid}-${Date.now()}`;
+  try {
+    await saveOAuthSession(
+      {
+        ...discovery,
+        storage: "config",
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: 0,
+      },
+      { access_token: "expired-access", refresh_token: "old-refresh" },
+      { allowUnencryptedStorage: true },
+    );
+    const firstModule = await import(`../src/auth/oauth.mjs?first-process=${suffix}`);
+    const secondModule = await import(`../src/auth/oauth.mjs?second-process=${suffix}`);
+    let refreshes = 0;
+    const fetchImpl = async () => {
+      refreshes += 1;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return response({
+        access_token: "fresh-access",
+        refresh_token: "new-refresh",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    };
+    const context = { resource: "https://unit.test/api/v1", scopes: [] };
+    const first = firstModule.createStoredOAuthCredentialProvider({ fetchImpl });
+    const second = secondModule.createStoredOAuthCredentialProvider({ fetchImpl });
+    assert.deepEqual(await Promise.all([first.getCredential(context), second.getCredential(context)]), [
+      "fresh-access",
+      "fresh-access",
+    ]);
+    assert.equal(refreshes, 1);
+  } finally {
+    await deleteOAuthSession();
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
 test("Revocation accepts an empty success response and never puts tokens in the URL", async () => {
   let request;
   await revokeOAuthToken(discovery, "refresh-secret", "refresh_token", async (url, options) => {
+    assert.equal(options.redirect, "error");
     request = { url, form: Object.fromEntries(options.body.entries()) };
     return response(null, 200);
   });

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -191,7 +191,9 @@ test("Explicit config fallback persists across processes with owner-only permiss
       access_token: "access-secret",
       refresh_token: "refresh-secret",
     });
-    assert.equal(statSync(join(configHome, "qveris", "config.json")).mode & 0o777, 0o600);
+    if (process.platform !== "win32") {
+      assert.equal(statSync(join(configHome, "qveris", "config.json")).mode & 0o777, 0o600);
+    }
   } finally {
     await reader.deleteOAuthSession();
     if (previous === undefined) delete process.env.XDG_CONFIG_HOME;

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -13,7 +13,13 @@ import {
   startDeviceAuthorization,
   validateOAuthScopes,
 } from "../src/auth/oauth.mjs";
-import { deleteOAuthSession, getOAuthSessionMetadata, saveOAuthSession } from "../src/auth/storage.mjs";
+import {
+  deleteOAuthSession,
+  getOAuthSessionMetadata,
+  loadOAuthSessionSecret,
+  saveOAuthSession,
+  withOAuthRefreshLock,
+} from "../src/auth/storage.mjs";
 import { runAuth } from "../src/commands/auth.mjs";
 import { deleteConfigValue, setConfigValue } from "../src/config/store.mjs";
 
@@ -306,6 +312,28 @@ test("Device polling does not call the token endpoint after authorization expire
   assert.equal(requests, 0);
 });
 
+test("Device polling bounds an in-flight token request by the authorization deadline", async () => {
+  const startedAt = Date.now();
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 0.02, interval: 0.001 },
+      {
+        fetchImpl: async (_url, options) =>
+          new Promise((_resolve, reject) => {
+            options.signal.addEventListener("abort", () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            });
+          }),
+      },
+    ),
+    /expired/,
+  );
+  assert.ok(Date.now() - startedAt < 1000);
+});
+
 for (const code of ["access_denied", "expired_token", "invalid_grant"]) {
   test(`Device polling stops on ${code}`, async () => {
     await assert.rejects(
@@ -592,6 +620,79 @@ test("Independent OAuth module instances serialize persisted refresh rotation", 
   }
 });
 
+test("A refresh never returns credentials from a session replaced while waiting for the lock", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-session-switch-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  let releaseLock;
+  try {
+    await saveOAuthSession(
+      {
+        ...discovery,
+        storage: "config",
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: 0,
+      },
+      { access_token: "expired-access", refresh_token: "old-refresh" },
+      { allowUnencryptedStorage: true },
+    );
+    let lockAcquired;
+    const acquired = new Promise((resolve) => {
+      lockAcquired = resolve;
+    });
+    const release = new Promise((resolve) => {
+      releaseLock = resolve;
+    });
+    const holder = withOAuthRefreshLock(async () => {
+      lockAcquired();
+      await release;
+    });
+    await acquired;
+
+    let refreshes = 0;
+    const provider = createStoredOAuthCredentialProvider({
+      fetchImpl: async () => {
+        refreshes += 1;
+        return response({
+          access_token: "unexpected-access",
+          refresh_token: "unexpected-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      },
+    });
+    const credential = provider.getCredential({ resource: "https://unit.test/api/v1", scopes: [] });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await saveOAuthSession(
+      {
+        ...discovery,
+        issuer: "https://other.test",
+        token_endpoint: "https://other.test/oauth/token",
+        revocation_endpoint: "https://other.test/oauth/revoke",
+        storage: "config",
+        api_base_url: "https://other.test/api/v1",
+        resource: "https://other.test/tools",
+        expires_at: Date.now() + 3600000,
+      },
+      { access_token: "other-access", refresh_token: "other-refresh" },
+      { allowUnencryptedStorage: true },
+    );
+    releaseLock();
+    await holder;
+    await assert.rejects(credential, /session changed/);
+    assert.equal(refreshes, 0);
+  } finally {
+    releaseLock?.();
+    await deleteOAuthSession();
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
 test("Revocation accepts an empty success response and never puts tokens in the URL", async () => {
   let request;
   await revokeOAuthToken(discovery, "refresh-secret", "refresh_token", async (url, options) => {
@@ -621,6 +722,163 @@ test("Session revocation attempts the access token after refresh-token revocatio
     /OAuth request failed/,
   );
   assert.deepEqual(hints, ["refresh_token", "access_token"]);
+});
+
+test("A successful login revokes the previous OAuth session before replacing it", async () => {
+  const previousConfigHome = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousFetch = globalThis.fetch;
+  const previousLog = console.log;
+  const previousError = console.error;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-relogin-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  const revokedTokens = [];
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    await saveOAuthSession(
+      {
+        ...discovery,
+        storage: "config",
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: Date.now() + 3600000,
+      },
+      { access_token: "old-access", refresh_token: "old-refresh" },
+      { allowUnencryptedStorage: true },
+    );
+    globalThis.fetch = async (url, options = {}) => {
+      if (url.endsWith("/.well-known/oauth-authorization-server")) return response(discovery);
+      if (url === discovery.device_authorization_endpoint) {
+        return response({
+          device_code: "device-secret",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://unit.test/oauth/device",
+          expires_in: 30,
+          interval: 0.001,
+        });
+      }
+      if (url === discovery.token_endpoint) {
+        return response({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+      if (url === discovery.revocation_endpoint) {
+        revokedTokens.push(Object.fromEntries(options.body.entries()).token);
+        return response(null);
+      }
+      throw new Error(`Unexpected OAuth request: ${url}`);
+    };
+
+    await runAuth("login", {
+      baseUrl: "https://unit.test/api/v1",
+      scope: "openid offline_access tools.search",
+      resource: "https://unit.test/tools",
+      noBrowser: true,
+      json: true,
+      allowUnencryptedStorage: true,
+    });
+
+    assert.deepEqual(revokedTokens, ["old-refresh", "old-access"]);
+    assert.deepEqual(await loadOAuthSessionSecret(), {
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+    });
+  } finally {
+    console.log = previousLog;
+    console.error = previousError;
+    globalThis.fetch = previousFetch;
+    await deleteOAuthSession();
+    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousConfigHome;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("Login aborts without replacing a session that changed during device authorization", async () => {
+  const previousConfigHome = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousFetch = globalThis.fetch;
+  const previousLog = console.log;
+  const previousError = console.error;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-login-race-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  const revokedTokens = [];
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    globalThis.fetch = async (url, options = {}) => {
+      if (url.endsWith("/.well-known/oauth-authorization-server")) return response(discovery);
+      if (url === discovery.device_authorization_endpoint) {
+        return response({
+          device_code: "device-secret",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://unit.test/oauth/device",
+          expires_in: 30,
+          interval: 0.001,
+        });
+      }
+      if (url === discovery.token_endpoint) {
+        await saveOAuthSession(
+          {
+            ...discovery,
+            issuer: "https://other.test",
+            token_endpoint: "https://other.test/oauth/token",
+            revocation_endpoint: "https://other.test/oauth/revoke",
+            storage: "config",
+            api_base_url: "https://other.test/api/v1",
+            resource: "https://other.test/tools",
+            expires_at: Date.now() + 3600000,
+          },
+          { access_token: "other-access", refresh_token: "other-refresh" },
+          { allowUnencryptedStorage: true },
+        );
+        return response({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+      if (url === discovery.revocation_endpoint) {
+        revokedTokens.push(Object.fromEntries(options.body.entries()).token);
+        return response(null);
+      }
+      throw new Error(`Unexpected OAuth request: ${url}`);
+    };
+
+    await assert.rejects(
+      runAuth("login", {
+        baseUrl: "https://unit.test/api/v1",
+        scope: "openid offline_access tools.search",
+        resource: "https://unit.test/tools",
+        noBrowser: true,
+        json: true,
+        allowUnencryptedStorage: true,
+      }),
+      /session changed/,
+    );
+
+    assert.deepEqual(revokedTokens, ["new-refresh", "new-access"]);
+    assert.equal(getOAuthSessionMetadata({ fresh: true }).issuer, "https://other.test");
+    assert.deepEqual(await loadOAuthSessionSecret(undefined, { fresh: true }), {
+      access_token: "other-access",
+      refresh_token: "other-refresh",
+    });
+  } finally {
+    console.log = previousLog;
+    console.error = previousError;
+    globalThis.fetch = previousFetch;
+    await deleteOAuthSession();
+    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousConfigHome;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
 });
 
 test("Auth status reports validation failures without throwing", async () => {

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { statSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 import {
   DEVICE_CODE_GRANT,
@@ -6,10 +8,12 @@ import {
   discoverAuthorizationServer,
   pollDeviceToken,
   refreshOAuthSession,
+  revokeOAuthSession,
   revokeOAuthToken,
   startDeviceAuthorization,
 } from "../src/auth/oauth.mjs";
-import { deleteOAuthSession, getOAuthSessionMetadata } from "../src/auth/storage.mjs";
+import { deleteOAuthSession, getOAuthSessionMetadata, saveOAuthSession } from "../src/auth/storage.mjs";
+import { runAuth } from "../src/commands/auth.mjs";
 
 function response(payload, status = 200, headers = {}) {
   return new Response(payload === null ? null : JSON.stringify(payload), {
@@ -64,6 +68,17 @@ test("Device Authorization sends the registered public client and validates the 
     resource: "https://unit.test/tools",
   });
   assert.equal(result.device_code, "device-secret");
+
+  await assert.rejects(
+    startDeviceAuthorization(discovery, { scope: "openid", resource: "https://unit.test/tools" }, async () =>
+      response({
+        device_code: "device-secret",
+        user_code: "ABCD-EFGH",
+        verification_uri: "javascript:alert(1)",
+      }),
+    ),
+    /verification_uri must use HTTPS/,
+  );
 });
 
 test("Device polling honors pending and slow_down before returning tokens", async () => {
@@ -144,6 +159,48 @@ test("Refresh uses the public client and rotates the refresh token", async () =>
   }
 });
 
+test("Refresh rejects a response that violates the QVeris rotation contract", async () => {
+  await assert.rejects(
+    refreshOAuthSession(
+      { ...discovery, api_base_url: "https://unit.test/api/v1", resource: "https://unit.test/tools" },
+      { access_token: "old-access", refresh_token: "old-refresh" },
+      async () => response({ access_token: "new-access", token_type: "Bearer", expires_in: 3600 }),
+    ),
+    /did not rotate the refresh token/,
+  );
+});
+
+test("Explicit config fallback persists across processes with owner-only permissions", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const configHome = `/tmp/qveris-oauth-fallback-${process.pid}-${Date.now()}`;
+  process.env.XDG_CONFIG_HOME = configHome;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  const suffix = `${process.pid}-${Date.now()}`;
+  const writer = await import(`../src/auth/storage.mjs?writer=${suffix}`);
+  const reader = await import(`../src/auth/storage.mjs?reader=${suffix}`);
+  try {
+    await writer.saveOAuthSession(
+      { ...discovery, expires_at: Date.now() + 3600000 },
+      { access_token: "access-secret", refresh_token: "refresh-secret" },
+      { allowUnencryptedStorage: true },
+    );
+    const metadata = reader.getOAuthSessionMetadata();
+    assert.equal(metadata.storage, "config");
+    assert.deepEqual(await reader.loadOAuthSessionSecret(metadata), {
+      access_token: "access-secret",
+      refresh_token: "refresh-secret",
+    });
+    assert.equal(statSync(join(configHome, "qveris", "config.json")).mode & 0o777, 0o600);
+  } finally {
+    await reader.deleteOAuthSession();
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
 test("Concurrent providers coalesce refresh rotation", async () => {
   const previous = process.env.XDG_CONFIG_HOME;
   const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
@@ -197,4 +254,62 @@ test("Revocation accepts an empty success response and never puts tokens in the 
   assert.equal(request.url.includes("refresh-secret"), false);
   assert.equal(request.form.token, "refresh-secret");
   assert.equal(request.form.client_id, "qveris-cli");
+});
+
+test("Session revocation attempts the access token after refresh-token revocation fails", async () => {
+  const hints = [];
+  await assert.rejects(
+    revokeOAuthSession(
+      discovery,
+      { refresh_token: "refresh-secret", access_token: "access-secret" },
+      async (_url, options) => {
+        const form = Object.fromEntries(options.body.entries());
+        hints.push(form.token_type_hint);
+        return form.token_type_hint === "refresh_token"
+          ? response({ error: "invalid_token" }, 400)
+          : response(null, 200);
+      },
+    ),
+    /OAuth request failed/,
+  );
+  assert.deepEqual(hints, ["refresh_token", "access_token"]);
+});
+
+test("Auth status reports validation failures without throwing", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousFetch = globalThis.fetch;
+  const previousExitCode = process.exitCode;
+  const lines = [];
+  const previousLog = console.log;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-status-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  globalThis.fetch = async () => {
+    throw new Error("network unavailable");
+  };
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    await saveOAuthSession(
+      {
+        ...discovery,
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: Date.now() + 3600000,
+      },
+      { access_token: "access-secret", refresh_token: "refresh-secret" },
+    );
+    await runAuth("status", { json: true });
+    assert.equal(process.exitCode, 1);
+    assert.match(lines.join("\n"), /"authenticated": false/);
+    assert.match(lines.join("\n"), /network unavailable/);
+  } finally {
+    console.log = previousLog;
+    globalThis.fetch = previousFetch;
+    await deleteOAuthSession();
+    process.exitCode = previousExitCode;
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
 });

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEVICE_CODE_GRANT,
+  createStoredOAuthCredentialProvider,
+  discoverAuthorizationServer,
+  pollDeviceToken,
+  refreshOAuthSession,
+  revokeOAuthToken,
+  startDeviceAuthorization,
+} from "../src/auth/oauth.mjs";
+import { deleteOAuthSession, getOAuthSessionMetadata } from "../src/auth/storage.mjs";
+
+function response(payload, status = 200, headers = {}) {
+  return new Response(payload === null ? null : JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+const discovery = {
+  issuer: "https://unit.test",
+  device_authorization_endpoint: "https://unit.test/oauth/device/authorize",
+  token_endpoint: "https://unit.test/oauth/token",
+  revocation_endpoint: "https://unit.test/oauth/revoke",
+  grant_types_supported: [DEVICE_CODE_GRANT, "refresh_token"],
+  token_endpoint_auth_methods_supported: ["none"],
+  scopes_supported: ["openid", "offline_access", "tools.search"],
+};
+
+test("OAuth discovery requires matching issuer, Device Flow, and a public client", async () => {
+  const metadata = await discoverAuthorizationServer("https://unit.test/api/v1", async () => response(discovery));
+  assert.equal(metadata.issuer, "https://unit.test");
+  assert.equal(metadata.device_authorization_endpoint, discovery.device_authorization_endpoint);
+
+  await assert.rejects(
+    discoverAuthorizationServer("https://unit.test", async () =>
+      response({ ...discovery, token_endpoint_auth_methods_supported: ["client_secret_basic"] }),
+    ),
+    /public QVeris CLI client/,
+  );
+});
+
+test("Device Authorization sends the registered public client and validates the response", async () => {
+  let form;
+  const result = await startDeviceAuthorization(
+    discovery,
+    { scope: "openid offline_access tools.search", resource: "https://unit.test/tools" },
+    async (_url, options) => {
+      form = Object.fromEntries(options.body.entries());
+      return response({
+        device_code: "device-secret",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://unit.test/oauth/device",
+        verification_uri_complete: "https://unit.test/oauth/device?user_code=ABCD-EFGH",
+        expires_in: 600,
+        interval: 5,
+      });
+    },
+  );
+  assert.deepEqual(form, {
+    client_id: "qveris-cli",
+    scope: "openid offline_access tools.search",
+    resource: "https://unit.test/tools",
+  });
+  assert.equal(result.device_code, "device-secret");
+});
+
+test("Device polling honors pending and slow_down before returning tokens", async () => {
+  const replies = [
+    response({ error: "authorization_pending" }, 400),
+    response({ error: "slow_down" }, 400),
+    response({
+      access_token: "access-secret",
+      refresh_token: "refresh-secret",
+      token_type: "Bearer",
+      expires_in: 3600,
+    }),
+  ];
+  const waits = [];
+  const tokens = await pollDeviceToken(
+    discovery,
+    { device_code: "device-secret", expires_in: 600, interval: 5 },
+    {
+      fetchImpl: async () => replies.shift(),
+      sleep: async (ms) => waits.push(ms),
+      now: () => 0,
+    },
+  );
+  assert.deepEqual(waits, [5000, 5000, 10000]);
+  assert.equal(tokens.access_token, "access-secret");
+});
+
+for (const code of ["access_denied", "expired_token", "invalid_grant"]) {
+  test(`Device polling stops on ${code}`, async () => {
+    await assert.rejects(
+      pollDeviceToken(
+        discovery,
+        { device_code: "device-secret", expires_in: 600, interval: 1 },
+        {
+          fetchImpl: async () => response({ error: code, error_description: "stopped" }, 400),
+          sleep: async () => {},
+          now: () => 0,
+        },
+      ),
+      (error) => error.oauthCode === code && !error.message.includes("device-secret"),
+    );
+  });
+}
+
+test("Refresh uses the public client and rotates the refresh token", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-test-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  try {
+    let form;
+    const result = await refreshOAuthSession(
+      { ...discovery, api_base_url: "https://unit.test/api/v1", resource: "https://unit.test/tools" },
+      { access_token: "old-access", refresh_token: "old-refresh" },
+      async (_url, options) => {
+        form = Object.fromEntries(options.body.entries());
+        return response({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      },
+    );
+    assert.deepEqual(form, {
+      grant_type: "refresh_token",
+      client_id: "qveris-cli",
+      refresh_token: "old-refresh",
+    });
+    assert.equal(result.secret.refresh_token, "new-refresh");
+    assert.equal(getOAuthSessionMetadata().storage, "session");
+  } finally {
+    await deleteOAuthSession();
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("Concurrent providers coalesce refresh rotation", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-concurrency-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  try {
+    const { saveOAuthSession } = await import("../src/auth/storage.mjs");
+    await saveOAuthSession(
+      {
+        ...discovery,
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: 0,
+      },
+      { access_token: "expired-access", refresh_token: "old-refresh" },
+    );
+    let refreshes = 0;
+    const fetchImpl = async () => {
+      refreshes += 1;
+      await Promise.resolve();
+      return response({
+        access_token: "fresh-access",
+        refresh_token: "new-refresh",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    };
+    const first = createStoredOAuthCredentialProvider({ fetchImpl });
+    const second = createStoredOAuthCredentialProvider({ fetchImpl });
+    const context = { resource: "https://unit.test/api/v1", scopes: [] };
+    assert.deepEqual(await Promise.all([first.getCredential(context), second.getCredential(context)]), [
+      "fresh-access",
+      "fresh-access",
+    ]);
+    assert.equal(refreshes, 1);
+  } finally {
+    await deleteOAuthSession();
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("Revocation accepts an empty success response and never puts tokens in the URL", async () => {
+  let request;
+  await revokeOAuthToken(discovery, "refresh-secret", "refresh_token", async (url, options) => {
+    request = { url, form: Object.fromEntries(options.body.entries()) };
+    return response(null, 200);
+  });
+  assert.equal(request.url.includes("refresh-secret"), false);
+  assert.equal(request.form.token, "refresh-secret");
+  assert.equal(request.form.client_id, "qveris-cli");
+});

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -12,6 +12,7 @@ import {
   revokeOAuthToken,
   startDeviceAuthorization,
   validateOAuthScopes,
+  validateOAuthTokenBinding,
 } from "../src/auth/oauth.mjs";
 import {
   deleteOAuthSession,
@@ -128,6 +129,32 @@ test("OAuth scopes require offline access and reject unsupported values", () => 
     "offline_access",
     "tools.search",
   ]);
+});
+
+test("Token bindings reject resource and scope escalation while accepting scope narrowing", () => {
+  assert.throws(
+    () =>
+      validateOAuthTokenBinding(
+        { resource: "https://other.test/tools" },
+        { resource: "https://unit.test/tools", scope: "openid tools.search" },
+      ),
+    /unexpected resource/,
+  );
+  assert.throws(
+    () =>
+      validateOAuthTokenBinding(
+        { scope: "openid tools.execute" },
+        { resource: "https://unit.test/tools", scope: "openid tools.search" },
+      ),
+    /unexpected scope/,
+  );
+  assert.deepEqual(
+    validateOAuthTokenBinding(
+      { scope: "tools.search" },
+      { resource: "https://unit.test/tools", scope: "openid tools.search" },
+    ),
+    { resource: "https://unit.test/tools", scope: "tools.search" },
+  );
 });
 
 test("Device Authorization sends the registered public client and validates the response", async () => {
@@ -516,6 +543,39 @@ test("Refresh rejects a response that violates the QVeris rotation contract", as
     ),
     /did not rotate the refresh token/,
   );
+});
+
+test("Refresh revokes rotated credentials when the token binding changes", async () => {
+  const revoked = [];
+  await assert.rejects(
+    refreshOAuthSession(
+      {
+        ...discovery,
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        scope: "openid offline_access tools.search",
+      },
+      { access_token: "old-access", refresh_token: "old-refresh" },
+      async (url, options) => {
+        if (url === discovery.token_endpoint) {
+          return response({
+            access_token: "new-access",
+            refresh_token: "new-refresh",
+            token_type: "Bearer",
+            expires_in: 3600,
+            resource: "https://other.test/tools",
+          });
+        }
+        if (url === discovery.revocation_endpoint) {
+          revoked.push(Object.fromEntries(options.body.entries()).token);
+          return response(null);
+        }
+        throw new Error(`Unexpected OAuth request: ${url}`);
+      },
+    ),
+    /unexpected resource/,
+  );
+  assert.deepEqual(revoked.sort(), ["new-access", "new-refresh"]);
 });
 
 test("Refresh reports when a previously persisted session cannot store rotated credentials", async () => {
@@ -1141,6 +1201,71 @@ test("A successful login revokes the previous OAuth session before replacing it"
       access_token: "new-access",
       refresh_token: "new-refresh",
     });
+  } finally {
+    console.log = previousLog;
+    console.error = previousError;
+    globalThis.fetch = previousFetch;
+    await deleteOAuthSession();
+    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousConfigHome;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("Login revokes newly issued credentials when their resource binding changes", async () => {
+  const previousConfigHome = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousFetch = globalThis.fetch;
+  const previousLog = console.log;
+  const previousError = console.error;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-login-binding-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  const revokedTokens = [];
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    globalThis.fetch = async (url, options = {}) => {
+      if (url.endsWith("/.well-known/oauth-authorization-server")) return response(discovery);
+      if (url === discovery.device_authorization_endpoint) {
+        return response({
+          device_code: "device-secret",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://unit.test/oauth/device",
+          expires_in: 30,
+          interval: 0.001,
+        });
+      }
+      if (url === discovery.token_endpoint) {
+        return response({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+          resource: "https://other.test/tools",
+        });
+      }
+      if (url === discovery.revocation_endpoint) {
+        revokedTokens.push(Object.fromEntries(options.body.entries()).token);
+        return response(null);
+      }
+      throw new Error(`Unexpected OAuth request: ${url}`);
+    };
+
+    await assert.rejects(
+      runAuth("login", {
+        baseUrl: "https://unit.test/api/v1",
+        scope: "openid offline_access tools.search",
+        resource: "https://unit.test/tools",
+        noBrowser: true,
+        json: true,
+        allowUnencryptedStorage: true,
+      }),
+      /unexpected resource/,
+    );
+
+    assert.deepEqual(revokedTokens.sort(), ["new-access", "new-refresh"]);
+    assert.equal(getOAuthSessionMetadata({ fresh: true }), null);
   } finally {
     console.log = previousLog;
     console.error = previousError;

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { statSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, existsSync, mkdirSync, statSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import {
   DEVICE_CODE_GRANT,
@@ -21,7 +21,8 @@ import {
   withOAuthRefreshLock,
 } from "../src/auth/storage.mjs";
 import { runAuth } from "../src/commands/auth.mjs";
-import { deleteConfigValue, setConfigValue } from "../src/config/store.mjs";
+import { runConfig } from "../src/commands/config.mjs";
+import { deleteConfigValue, getConfigPath, getConfigValue, setConfigValue } from "../src/config/store.mjs";
 
 function response(payload, status = 200, headers = {}) {
   return new Response(payload === null ? null : JSON.stringify(payload), {
@@ -47,6 +48,13 @@ test("OAuth discovery requires matching issuer, Device Flow, refresh, and a publ
   });
   assert.equal(metadata.issuer, "https://unit.test");
   assert.equal(metadata.device_authorization_endpoint, discovery.device_authorization_endpoint);
+
+  await assert.rejects(
+    discoverAuthorizationServer("javascript:alert(1)", async () => {
+      assert.fail("unsafe issuers must be rejected before discovery");
+    }),
+    /issuer must use HTTPS/,
+  );
 
   await assert.rejects(
     discoverAuthorizationServer("https://unit.test", async () =>
@@ -95,6 +103,13 @@ test("OAuth discovery requires matching issuer, Device Flow, refresh, and a publ
     }),
     (error) => error.code === "NET_TIMEOUT" && /OAuth request timed out/.test(error.message),
   );
+
+  await assert.rejects(
+    discoverAuthorizationServer("https://unit.test", async () =>
+      response({ ...discovery, padding: "x".repeat(1024 * 1024) }),
+    ),
+    /maximum response size/,
+  );
 });
 
 test("OAuth scopes require offline access and reject unsupported values", () => {
@@ -108,6 +123,11 @@ test("OAuth scopes require offline access and reject unsupported values", () => 
     () => validateOAuthScopes(discovery, "openid offline_access tools.execute"),
     /not supported: tools.execute/,
   );
+  assert.deepEqual(validateOAuthScopes(discovery, "  openid\n offline_access\ttools.search  "), [
+    "openid",
+    "offline_access",
+    "tools.search",
+  ]);
 });
 
 test("Device Authorization sends the registered public client and validates the response", async () => {
@@ -136,6 +156,13 @@ test("Device Authorization sends the registered public client and validates the 
   assert.equal(result.device_code, "device-secret");
 
   await assert.rejects(
+    startDeviceAuthorization(discovery, { scope: "openid", resource: "file:///tmp/token" }, async () => {
+      assert.fail("unsafe resources must be rejected before authorization");
+    }),
+    /resource must use HTTPS/,
+  );
+
+  await assert.rejects(
     startDeviceAuthorization(discovery, { scope: "openid", resource: "https://unit.test/tools" }, async () =>
       response({
         device_code: "device-secret",
@@ -157,6 +184,18 @@ test("Device Authorization sends the registered public client and validates the 
       }),
     ),
     /verification_uri_complete does not match/,
+  );
+
+  await assert.rejects(
+    startDeviceAuthorization(discovery, { scope: "openid", resource: "https://unit.test/tools" }, async () =>
+      response({
+        device_code: "device-secret",
+        user_code: "ABCD\u001b[2J",
+        verification_uri: "https://unit.test/oauth/device",
+        expires_in: 600,
+      }),
+    ),
+    /invalid user_code/,
   );
 });
 
@@ -207,6 +246,45 @@ test("Device polling rejects a success response without a refresh token", async 
         fetchImpl: async () =>
           response({
             access_token: "access-secret\nInjected: value",
+            refresh_token: "refresh-secret",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+        sleep: async () => {},
+        now: () => 0,
+      },
+    ),
+    /invalid access token response/,
+  );
+
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 600, interval: 1 },
+      {
+        fetchImpl: async () =>
+          response({
+            access_token: "access-secret",
+            refresh_token: "refresh-secret",
+            token_type: "Bearer",
+            expires_in: 3600,
+            resource: "javascript:alert(1)",
+          }),
+        sleep: async () => {},
+        now: () => 0,
+      },
+    ),
+    /resource must use HTTPS/,
+  );
+
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 600, interval: 1 },
+      {
+        fetchImpl: async () =>
+          response({
+            access_token: "x".repeat(16385),
             refresh_token: "refresh-secret",
             token_type: "Bearer",
             expires_in: 3600,
@@ -327,6 +405,33 @@ test("Device polling bounds an in-flight token request by the authorization dead
               reject(error);
             });
           }),
+      },
+    ),
+    /expired/,
+  );
+  assert.ok(Date.now() - startedAt < 1000);
+});
+
+test("Device polling timeout also covers a response body that stalls after headers", async () => {
+  const startedAt = Date.now();
+  await assert.rejects(
+    pollDeviceToken(
+      discovery,
+      { device_code: "device-secret", expires_in: 0.02, interval: 0.001 },
+      {
+        fetchImpl: async (_url, options) =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                options.signal.addEventListener("abort", () => {
+                  const error = new Error("aborted");
+                  error.name = "AbortError";
+                  controller.error(error);
+                });
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
       },
     ),
     /expired/,
@@ -490,6 +595,185 @@ test("OAuth logout reports incomplete local deletion and unknown remote revocati
     process.exitCode = previousExitCode;
     if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("Logout waits for an in-flight refresh and revokes the rotated session", async () => {
+  const previousConfigHome = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousFetch = globalThis.fetch;
+  const previousExitCode = process.exitCode;
+  const previousLog = console.log;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-logout-refresh-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  console.log = () => {};
+  let releaseRefresh;
+  try {
+    await saveOAuthSession(
+      {
+        ...discovery,
+        storage: "config",
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: 0,
+      },
+      { access_token: "expired-access", refresh_token: "old-refresh" },
+      { allowUnencryptedStorage: true },
+    );
+    let markRefreshStarted;
+    const refreshStarted = new Promise((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    const refreshGate = new Promise((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const provider = createStoredOAuthCredentialProvider({
+      fetchImpl: async () => {
+        markRefreshStarted();
+        await refreshGate;
+        return response({
+          access_token: "fresh-access",
+          refresh_token: "fresh-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      },
+    });
+    const credential = provider.getCredential({ resource: "https://unit.test/api/v1", scopes: [] });
+    await refreshStarted;
+
+    const revokedTokens = [];
+    globalThis.fetch = async (_url, options) => {
+      revokedTokens.push(Object.fromEntries(options.body.entries()).token);
+      return response(null);
+    };
+    const logout = runAuth("logout", { json: true });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual(revokedTokens, []);
+
+    releaseRefresh();
+    assert.equal(await credential, "fresh-access");
+    await logout;
+    assert.deepEqual(revokedTokens, ["fresh-refresh", "fresh-access"]);
+    assert.equal(getOAuthSessionMetadata({ fresh: true }), null);
+  } finally {
+    releaseRefresh?.();
+    console.log = previousLog;
+    globalThis.fetch = previousFetch;
+    process.exitCode = previousExitCode;
+    if (getOAuthSessionMetadata({ fresh: true })) await deleteOAuthSession();
+    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousConfigHome;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("Config writes wait for refresh rotation without restoring stale OAuth credentials", async () => {
+  const previousConfigHome = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousLog = console.log;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-config-refresh-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  console.log = () => {};
+  let releaseRefresh;
+  try {
+    await saveOAuthSession(
+      {
+        ...discovery,
+        storage: "config",
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: 0,
+      },
+      { access_token: "expired-access", refresh_token: "old-refresh" },
+      { allowUnencryptedStorage: true },
+    );
+    let markRefreshStarted;
+    const refreshStarted = new Promise((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    const refreshGate = new Promise((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const provider = createStoredOAuthCredentialProvider({
+      fetchImpl: async () => {
+        markRefreshStarted();
+        await refreshGate;
+        return response({
+          access_token: "fresh-access",
+          refresh_token: "fresh-refresh",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      },
+    });
+    const credential = provider.getCredential({ resource: "https://unit.test/api/v1", scopes: [] });
+    await refreshStarted;
+
+    const configWrite = runConfig("set", ["api_key", "sk-config"], {});
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(getConfigValue("api_key"), undefined);
+
+    releaseRefresh();
+    assert.equal(await credential, "fresh-access");
+    await configWrite;
+    assert.equal(getConfigValue("api_key"), "sk-config");
+    assert.deepEqual(await loadOAuthSessionSecret(undefined, { fresh: true }), {
+      access_token: "fresh-access",
+      refresh_token: "fresh-refresh",
+    });
+  } finally {
+    releaseRefresh?.();
+    console.log = previousLog;
+    if (getOAuthSessionMetadata({ fresh: true })) await deleteOAuthSession();
+    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousConfigHome;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("Config reset revokes and removes a stored OAuth session", async () => {
+  const previousConfigHome = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  const previousFetch = globalThis.fetch;
+  const previousLog = console.log;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-config-reset-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  console.log = () => {};
+  try {
+    await saveOAuthSession(
+      {
+        ...discovery,
+        storage: "config",
+        api_base_url: "https://unit.test/api/v1",
+        resource: "https://unit.test/tools",
+        expires_at: Date.now() + 3600000,
+      },
+      { access_token: "access-secret", refresh_token: "refresh-secret" },
+      { allowUnencryptedStorage: true },
+    );
+    setConfigValue("api_key", "sk-config");
+    const revokedTokens = [];
+    globalThis.fetch = async (_url, options) => {
+      revokedTokens.push(Object.fromEntries(options.body.entries()).token);
+      return response(null);
+    };
+
+    await runConfig("reset", [], {});
+
+    assert.deepEqual(revokedTokens, ["refresh-secret", "access-secret"]);
+    assert.equal(getOAuthSessionMetadata({ fresh: true }), null);
+    assert.equal(getConfigValue("api_key"), undefined);
+  } finally {
+    console.log = previousLog;
+    globalThis.fetch = previousFetch;
+    if (getOAuthSessionMetadata({ fresh: true })) await deleteOAuthSession();
+    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousConfigHome;
     if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
     else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
   }
@@ -693,6 +977,69 @@ test("A refresh never returns credentials from a session replaced while waiting 
   }
 });
 
+test("A stale refresh lock is reclaimed only when its owning process is gone", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-stale-lock-${process.pid}-${Date.now()}`;
+  const lockPath = `${getConfigPath()}.oauth-refresh.lock`;
+  mkdirSync(dirname(lockPath), { recursive: true });
+  let currentTime = Date.now();
+  try {
+    writeFileSync(lockPath, JSON.stringify({ ownerToken: "live-owner", pid: process.pid }));
+    const staleTime = new Date(currentTime - 120000);
+    utimesSync(lockPath, staleTime, staleTime);
+    await assert.rejects(
+      withOAuthRefreshLock(async () => assert.fail("a live owner's lock must not be reclaimed"), {
+        now: () => currentTime,
+        sleep: async (milliseconds) => {
+          currentTime += milliseconds;
+        },
+      }),
+      /Timed out waiting/,
+    );
+    assert.equal(existsSync(lockPath), true);
+
+    unlinkSync(lockPath);
+    writeFileSync(lockPath, JSON.stringify({ ownerToken: "dead-owner", pid: 2147483647 }));
+    utimesSync(lockPath, staleTime, staleTime);
+    assert.equal(
+      await withOAuthRefreshLock(async () => "reclaimed", {
+        now: () => currentTime,
+        sleep: async () => {},
+      }),
+      "reclaimed",
+    );
+    assert.equal(existsSync(lockPath), false);
+  } finally {
+    if (existsSync(lockPath)) unlinkSync(lockPath);
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+  }
+});
+
+test(
+  "A committed lock callback stays successful when only lock-file cleanup fails",
+  { skip: process.platform === "win32" },
+  async () => {
+    const previous = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-lock-cleanup-${process.pid}-${Date.now()}`;
+    const lockPath = `${getConfigPath()}.oauth-refresh.lock`;
+    const configDirectory = dirname(lockPath);
+    try {
+      const result = await withOAuthRefreshLock(async () => {
+        chmodSync(configDirectory, 0o500);
+        return "committed";
+      });
+      assert.equal(result, "committed");
+      assert.equal(existsSync(lockPath), true);
+    } finally {
+      chmodSync(configDirectory, 0o700);
+      if (existsSync(lockPath)) unlinkSync(lockPath);
+      if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = previous;
+    }
+  },
+);
+
 test("Revocation accepts an empty success response and never puts tokens in the URL", async () => {
   let request;
   await revokeOAuthToken(discovery, "refresh-secret", "refresh_token", async (url, options) => {
@@ -707,13 +1054,19 @@ test("Revocation accepts an empty success response and never puts tokens in the 
 
 test("Session revocation attempts the access token after refresh-token revocation fails", async () => {
   const hints = [];
+  let activeRequests = 0;
+  let maximumConcurrency = 0;
   await assert.rejects(
     revokeOAuthSession(
       discovery,
       { refresh_token: "refresh-secret", access_token: "access-secret" },
       async (_url, options) => {
+        activeRequests += 1;
+        maximumConcurrency = Math.max(maximumConcurrency, activeRequests);
         const form = Object.fromEntries(options.body.entries());
         hints.push(form.token_type_hint);
+        await new Promise((resolve) => setImmediate(resolve));
+        activeRequests -= 1;
         return form.token_type_hint === "refresh_token"
           ? response({ error: "invalid_token" }, 400)
           : response(null, 200);
@@ -722,6 +1075,7 @@ test("Session revocation attempts the access token after refresh-token revocatio
     /OAuth request failed/,
   );
   assert.deepEqual(hints, ["refresh_token", "access_token"]);
+  assert.equal(maximumConcurrency, 2);
 });
 
 test("A successful login revokes the previous OAuth session before replacing it", async () => {

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -543,6 +543,23 @@ test("Refresh rejects a response that violates the QVeris rotation contract", as
     ),
     /did not rotate the refresh token/,
   );
+
+  for (const invalidRefreshToken of [" new-refresh", "new\trefresh", "nëw-refresh", "x".repeat(16385)]) {
+    await assert.rejects(
+      refreshOAuthSession(
+        { ...discovery, api_base_url: "https://unit.test/api/v1", resource: "https://unit.test/tools" },
+        { access_token: "old-access", refresh_token: "old-refresh" },
+        async () =>
+          response({
+            access_token: "new-access",
+            refresh_token: invalidRefreshToken,
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+      ),
+      /invalid refresh token/,
+    );
+  }
 });
 
 test("Refresh revokes rotated credentials when the token binding changes", async () => {

--- a/packages/cli/test/open-url.test.mjs
+++ b/packages/cli/test/open-url.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getOpenUrlCommand } from "../src/utils/open-url.mjs";
+
+test("Windows URL opening does not pass URL metacharacters through cmd.exe", () => {
+  const url = "https://unit.test/verify?user_code=ABCD&source=cli";
+  assert.deepEqual(getOpenUrlCommand(url, "win32"), {
+    command: "rundll32.exe",
+    args: ["url.dll,FileProtocolHandler", url],
+  });
+});

--- a/packages/cli/test/preflight.test.mjs
+++ b/packages/cli/test/preflight.test.mjs
@@ -6,6 +6,8 @@ import test from "node:test";
 
 import { runPreflight, nodeCheck, CLI_CONTRACT_VERSION } from "../src/client/preflight.mjs";
 import { CliError } from "../src/errors/handler.mjs";
+import { setConfigValue } from "../src/config/store.mjs";
+import { deleteOAuthSession } from "../src/auth/storage.mjs";
 
 const byName = (checks) => Object.fromEntries(checks.map((c) => [c.name, c]));
 
@@ -31,6 +33,49 @@ test("runPreflight: healthy probe reports connectivity, credits, and contract co
   assert.equal(c.credits.status, "ok");
   assert.match(c.credits.detail, /42 credits/);
   assert.equal(c.contract.status, "ok");
+});
+
+test("runPreflight: stored OAuth session restores its endpoint without environment configuration", async () => {
+  const previous = {
+    key: process.env.QVERIS_API_KEY,
+    base: process.env.QVERIS_BASE_URL,
+    xdg: process.env.XDG_CONFIG_HOME,
+  };
+  const dir = mkdtempSync(join(tmpdir(), "qveris-preflight-oauth-"));
+  process.env.XDG_CONFIG_HOME = dir;
+  delete process.env.QVERIS_API_KEY;
+  delete process.env.QVERIS_BASE_URL;
+  try {
+    setConfigValue("oauth_session", {
+      issuer: "https://test.qveris.cn",
+      api_base_url: "https://test.qveris.cn/api/v1",
+      storage: "config",
+    });
+    let probeContext;
+    const { checks, ok } = await runPreflight({
+      probe: async (context) => {
+        probeContext = context;
+        return { search_id: "s1", results: [] };
+      },
+    });
+    assert.equal(ok, true);
+    assert.equal(probeContext.authType, "oauth");
+    assert.equal(probeContext.apiKey, undefined);
+    assert.equal(probeContext.baseUrl, "https://test.qveris.cn/api/v1");
+    assert.equal(byName(checks).oauth.status, "ok");
+    assert.match(byName(checks).endpoint.detail, /oauth session/);
+  } finally {
+    await deleteOAuthSession();
+    rmSync(dir, { recursive: true, force: true });
+    for (const [key, value] of [
+      ["QVERIS_API_KEY", previous.key],
+      ["QVERIS_BASE_URL", previous.base],
+      ["XDG_CONFIG_HOME", previous.xdg],
+    ]) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
 });
 
 test("runPreflight: zero credits warns (not fails) with a purchase hint", async () => {

--- a/packages/cli/test/store.test.mjs
+++ b/packages/cli/test/store.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { getConfigPath, readConfig, setConfigValue } from "../src/config/store.mjs";
+
+function withTempConfig(callback) {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const directory = join(tmpdir(), `qveris-store-${process.pid}-${Date.now()}`);
+  process.env.XDG_CONFIG_HOME = directory;
+  try {
+    return callback();
+  } finally {
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("missing config is empty, but corrupt config is never overwritten", () => {
+  withTempConfig(() => {
+    assert.deepEqual(readConfig(), {});
+    const path = getConfigPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "{broken", "utf8");
+    assert.throws(() => readConfig(), /contains invalid JSON/);
+    assert.throws(() => setConfigValue("api_key", "must-not-be-written"), /contains invalid JSON/);
+    assert.equal(readFileSync(path, "utf8"), "{broken");
+  });
+});
+
+test("config root must be a JSON object", () => {
+  withTempConfig(() => {
+    const path = getConfigPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "[]", "utf8");
+    assert.throws(() => readConfig(), /must contain a JSON object/);
+  });
+});


### PR DESCRIPTION
## Summary

- add `qveris auth login/status/logout` using the discovery-advertised OAuth Device Authorization Grant
- rotate refresh tokens automatically, coalesce concurrent refreshes, and retry one 401 without retrying business 4xx responses
- store OAuth secrets in the operating-system credential store, with an explicit user-only config fallback for trusted hosts without a keyring
- preserve API key priority and all existing API key commands
- document the flow for each public documentation target

## Contract readiness

Both supported test deployments now advertise the Device Authorization endpoint and grant, public-client authentication, refresh rotation, and revocation. Redacted live smoke checks verified:

- Device Authorization returns 200 with `Cache-Control: no-store`
- the initial token poll returns `authorization_pending`
- an immediate second poll returns `slow_down`
- response shapes and verification origins match each deployment

No production deployment behavior is assumed by this change; the CLI fails clearly when the selected endpoint does not advertise the required contract.

## Security and resilience

- device codes and tokens are never written to logs, errors, or command arguments
- refresh credentials use the operating-system credential store by default; unencrypted config persistence requires explicit opt-in
- config replacement is atomic, corrupt or unreadable config fails closed, and the directory/file are restricted to the current user
- discovered token, revocation, and device authorization endpoints must match the issuer
- OAuth and authenticated API requests reject redirects so credentials and request bodies cannot be forwarded
- OAuth HTTP requests have bounded timeouts and response lifetimes are validated
- initial authorization requires a refresh token and refresh responses must rotate it
- persisted refresh rotation is serialized across CLI processes and fails closed if new credentials cannot be stored
- refresh and login transitions reject concurrent session replacement instead of returning or overwriting another session's credentials
- repeated login revokes the previous remote session before replacing local credentials
- refresh-lock ownership is published atomically and protected by an owner token, process check, stable-file check, and heartbeat
- keyring/config persistence failures roll back local writes and best-effort revoke newly issued credentials
- device polling bounds in-flight requests by the authorization deadline
- OAuth response timeouts cover both headers and body streaming, with bounded JSON and credential sizes
- stale refresh locks are reclaimed only after their owner process exits; committed transactions are not reversed by cleanup-only failures
- logout, config reset, config writes, and API-key credential writes serialize with OAuth rotation
- issuer, resource, user-code, scope, and terminal-visible response fields are validated before use
- issued and refreshed token resource/scope bindings must match the authorization request; rejected credentials are revoked
- access and refresh token values are length-bounded and restricted to their OAuth-safe character ranges before storage or use
- refresh-token and access-token revocation requests run independently within one bounded window
- internal OAuth config keys cannot be read through `qveris config get`
- a persisted OAuth session restores its API endpoint for later CLI processes and is supported by `qveris doctor`
- logout reports incomplete keyring deletion and retains non-sensitive issuer metadata so cleanup can be retried
- malformed non-string API-key config produces an actionable authentication error instead of a runtime type failure

## Verification

- `npm test`: 128 passed
- `npm run lint`: passed
- `npm run test:coverage`: passed
- `npm pack --dry-run`: passed
- dependency audit: 0 vulnerabilities
- public documentation boundary scans: passed; existing historical changelog entries only

Closes #227
