### PR TITLE
docs: standardize credential store terminology

### DIFF
--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -280,7 +280,7 @@ Refresh credentials are rotated automatically and stored in the operating-system
 
 The persisted OAuth session also remembers its API endpoint for later CLI processes. An explicit `--base-url` or `QVERIS_BASE_URL` still takes precedence and must match the session issuer.
 
-Use `--no-browser --allow-unencrypted-storage` on a trusted headless host that has no operating-system keyring. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract, and a custom scope must retain `offline_access` so the session can refresh safely.
+Use `--no-browser --allow-unencrypted-storage` on a trusted headless host that has no operating-system credential store. Advanced integrations can narrow the request with `--scope <scopes>` and `--resource <url>`; both must match the server's published contract, and a custom scope must retain `offline_access` so the session can refresh safely.
 
 ### `qveris login` (API key)
 


### PR DESCRIPTION
## Summary

- standardize the headless-host guidance on `operating-system credential store`
- keep the terminology consistent with the preceding OAuth storage paragraph

## Why

The English CLI guide used both `credential store` and `keyring` for the same abstraction. The website documentation is generated from this toolkit source, so the correction belongs here rather than in the synchronized output.

## Impact

Documentation-only change. Runtime behavior is unchanged. After merge, the normal documentation sync can propagate the corrected wording to the website.

## Validation

- `git diff --check`
- scanned public Markdown for the obsolete `operating-system keyring` wording
- ran the repository's public documentation boundary scans
