### PR TITLE
ci: reduce contract test runner usage

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -7,6 +7,8 @@ name: Contract tests
 on:
   pull_request:
     paths:
+      - "package.json"
+      - "package-lock.json"
       - "docs/openapi/**"
       - "packages/cli/src/**"
       - "packages/cli/test/**"

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,19 +1,24 @@
 name: Contract tests
 
-# Issue #37 phase 3 (#47): enforce, on every PR, that the CLI's API calls and
-# the Python SDK's consumed models stay aligned with the website-mirrored
-# public OpenAPI contract. The cli/python *-publish workflows only run on
-# release tags, so without this the contract guards would not gate PRs.
+# Keep contract consumers aligned on PRs without rerunning the same full matrix
+# after merge. A weekly full run retains Windows coverage; package release
+# workflows keep their own release-time matrices.
 
 on:
   pull_request:
     paths:
       - "docs/openapi/**"
       - "packages/cli/src/**"
-      - "packages/cli/test/openapi-contract.test.mjs"
+      - "packages/cli/test/**"
+      - "packages/cli/scripts/**"
+      - "packages/cli/bin/**"
       - "packages/python-sdk/qveris/**"
-      - "packages/python-sdk/tests/test_openapi_contract.py"
+      - "packages/python-sdk/tests/**"
+      - "packages/python-sdk/examples/**"
+      - "packages/python-sdk/docs-api/**"
       - "packages/js-sdk/src/**"
+      - "packages/js-sdk/test/**"
+      - "packages/js-sdk/docs-api/**"
       - "packages/js-sdk/package.json"
       - "packages/js-sdk/package-lock.json"
       - "packages/cli/package.json"
@@ -21,6 +26,9 @@ on:
       - "packages/python-sdk/pyproject.toml"
       - "packages/python-sdk/uv.lock"
       - "packages/mcp/src/**"
+      - "packages/mcp/test/**"
+      - "packages/mcp/scripts/**"
+      - "packages/mcp/schemas/**"
       - "packages/mcp/package.json"
       - "packages/mcp/package-lock.json"
       - "packages/mcp/tsconfig.json"
@@ -34,48 +42,60 @@ on:
       - ".prettierrc.json"
       - ".prettierignore"
       - "packages/*/eslint.config.mjs"
+      - "scripts/plan-contract-tests.mjs"
+      - "scripts/plan-contract-tests.test.mjs"
       - ".github/workflows/contract-tests.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/openapi/**"
-      - "packages/cli/src/**"
-      - "packages/cli/test/openapi-contract.test.mjs"
-      - "packages/python-sdk/qveris/**"
-      - "packages/python-sdk/tests/test_openapi_contract.py"
-      - "packages/js-sdk/src/**"
-      - "packages/js-sdk/package.json"
-      - "packages/js-sdk/package-lock.json"
-      - "packages/cli/package.json"
-      - "packages/cli/package-lock.json"
-      - "packages/python-sdk/pyproject.toml"
-      - "packages/python-sdk/uv.lock"
-      - "packages/mcp/src/**"
-      - "packages/mcp/package.json"
-      - "packages/mcp/package-lock.json"
-      - "packages/mcp/tsconfig.json"
-      - "packages/openclaw-qveris-plugin/**"
-      - "packages/js-sdk/examples/**"
-      - "packages/js-sdk/tsconfig.examples.json"
-      - "packages/mcp/examples/**"
-      - "packages/mcp/tsconfig.examples.json"
-      - "packages/cli/examples/**"
-      - "benchmarks/discover-call/**"
-      - ".prettierrc.json"
-      - ".prettierignore"
-      - "packages/*/eslint.config.mjs"
-      - ".github/workflows/contract-tests.yml"
+  schedule:
+    - cron: "23 3 * * 0"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: contract-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  plan:
+    name: Plan affected contract tests
+    runs-on: ubuntu-latest
+    outputs:
+      benchmark: ${{ steps.plan.outputs.benchmark }}
+      cli: ${{ steps.plan.outputs.cli }}
+      python: ${{ steps.plan.outputs.python }}
+      js: ${{ steps.plan.outputs.js }}
+      mcp: ${{ steps.plan.outputs.mcp }}
+      plugin: ${{ steps.plan.outputs.plugin }}
+      lint: ${{ steps.plan.outputs.lint }}
+      lint_cli: ${{ steps.plan.outputs.lint_cli }}
+      lint_python: ${{ steps.plan.outputs.lint_python }}
+      lint_js: ${{ steps.plan.outputs.lint_js }}
+      lint_mcp: ${{ steps.plan.outputs.lint_mcp }}
+      lint_plugin: ${{ steps.plan.outputs.lint_plugin }}
+      examples: ${{ steps.plan.outputs.examples }}
+      os_matrix: ${{ steps.plan.outputs.os_matrix }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Test the affected-target planner
+        run: node --test scripts/plan-contract-tests.test.mjs
+      - name: Classify changed targets
+        id: plan
+        env:
+          CONTRACT_TEST_FULL: ${{ github.event_name != 'pull_request' }}
+          CONTRACT_TEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CONTRACT_TEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/plan-contract-tests.mjs
+
   discover-call-benchmark:
+    needs: plan
+    if: needs.plan.outputs.benchmark == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.plan.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -95,25 +115,39 @@ jobs:
         run: npm test
 
   cli-contract:
+    needs: plan
+    if: needs.plan.outputs.cli == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.plan.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: 20
-      - name: CLI tests (full suite, includes the OpenAPI contract test)
+          cache: "npm"
+          cache-dependency-path: packages/cli/package-lock.json
+      - name: Install dependencies
         working-directory: packages/cli
-        run: node --test
+        run: npm ci
+      - name: CLI tests with coverage (Linux)
+        if: runner.os == 'Linux'
+        working-directory: packages/cli
+        run: npm run test:coverage
+      - name: CLI tests (Windows)
+        if: runner.os == 'Windows'
+        working-directory: packages/cli
+        run: npm test
 
   python-contract:
+    needs: plan
+    if: needs.plan.outputs.python == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.plan.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -124,15 +158,22 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: packages/python-sdk/uv.lock
-      - name: Python SDK tests (full suite, includes the contract tests)
+      - name: Python SDK tests with coverage (Linux)
+        if: runner.os == 'Linux'
+        working-directory: packages/python-sdk
+        run: uv run --extra dev pytest -q --cov=qveris --cov-fail-under=82
+      - name: Python SDK tests (Windows)
+        if: runner.os == 'Windows'
         working-directory: packages/python-sdk
         run: uv run --extra dev pytest -q
 
   js-sdk-tests:
+    needs: plan
+    if: needs.plan.outputs.js == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.plan.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -150,14 +191,20 @@ jobs:
         run: npm run typecheck
       - name: Type check examples
         run: npm run typecheck:examples
-      - name: JS SDK client tests
+      - name: JS SDK client tests with coverage (Linux)
+        if: runner.os == 'Linux'
+        run: npm run test:coverage
+      - name: JS SDK client tests (Windows)
+        if: runner.os == 'Windows'
         run: npm test
 
   mcp-tests:
+    needs: plan
+    if: needs.plan.outputs.mcp == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.plan.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -175,7 +222,11 @@ jobs:
         run: npm run typecheck
       - name: Type check examples
         run: npm run typecheck:examples
-      - name: MCP server tests
+      - name: MCP server tests with coverage (Linux)
+        if: runner.os == 'Linux'
+        run: npm run test:coverage
+      - name: MCP server tests (Windows)
+        if: runner.os == 'Windows'
         run: npm test
       # Non-blocking by design: a red mcp-tests job always means "generated
       # card is invalid" (validated by vitest against the vendored pinned
@@ -185,10 +236,12 @@ jobs:
         run: node scripts/check-server-card-schema-url.mjs
 
   openclaw-plugin-tests:
+    needs: plan
+    if: needs.plan.outputs.plugin == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.plan.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -204,7 +257,11 @@ jobs:
         run: npm ci
       - name: Type check
         run: npm run typecheck
-      - name: Plugin tests
+      - name: Plugin tests with coverage (Linux)
+        if: runner.os == 'Linux'
+        run: npm run test:coverage
+      - name: Plugin tests (Windows)
+        if: runner.os == 'Windows'
         run: npm test
       - name: Verify npm package contents
         run: npm run check:pack
@@ -212,66 +269,50 @@ jobs:
           NPM_CONFIG_OFFLINE: "true"
 
   lint:
+    needs: plan
+    if: needs.plan.outputs.lint == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
+        if: needs.plan.outputs.lint_mcp == 'true' || needs.plan.outputs.lint_js == 'true' || needs.plan.outputs.lint_cli == 'true' || needs.plan.outputs.lint_plugin == 'true'
         with:
           node-version: 22.22.3
       - uses: astral-sh/setup-uv@v7
+        if: needs.plan.outputs.lint_python == 'true'
         with:
           enable-cache: true
           cache-dependency-glob: packages/python-sdk/uv.lock
       - name: Lint mcp
+        if: needs.plan.outputs.lint_mcp == 'true'
         working-directory: packages/mcp
         run: npm ci && npm run lint
       - name: Lint js-sdk
+        if: needs.plan.outputs.lint_js == 'true'
         working-directory: packages/js-sdk
         run: npm ci && npm run lint
       - name: Lint cli
+        if: needs.plan.outputs.lint_cli == 'true'
         working-directory: packages/cli
         run: npm ci && npm run lint
       - name: Lint openclaw plugin
+        if: needs.plan.outputs.lint_plugin == 'true'
         working-directory: packages/openclaw-qveris-plugin
         run: npm ci && npm run lint
       - name: Lint python-sdk (ruff)
+        if: needs.plan.outputs.lint_python == 'true'
         working-directory: packages/python-sdk
         run: |
           uv run --extra dev ruff check qveris tests examples docs-api
           uv run --extra dev ruff format --check qveris tests examples docs-api
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 22.22.3
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: packages/python-sdk/uv.lock
-      - name: mcp coverage (thresholds in vitest.config.ts)
-        working-directory: packages/mcp
-        run: npm ci && npm run test:coverage
-      - name: js-sdk coverage
-        working-directory: packages/js-sdk
-        run: npm ci && npm run test:coverage
-      - name: openclaw plugin coverage
-        working-directory: packages/openclaw-qveris-plugin
-        run: npm ci && npm run test:coverage
-      - name: cli coverage (thresholds in .c8rc.json)
-        working-directory: packages/cli
-        run: npm ci && npm run test:coverage
-      - name: python-sdk coverage
-        working-directory: packages/python-sdk
-        run: uv run --extra dev pytest -q --cov=qveris --cov-fail-under=82
 
   # Shellcheck the CLI scripting examples. The TypeScript examples are type
   # checked in the js-sdk-tests / mcp-tests jobs; the Python examples are linted
   # by the ruff step above; the recipe run.sh scripts are checked in
   # ecosystem-validate.yml (which triggers on recipes/**).
   examples:
+    needs: plan
+    if: needs.plan.outputs.examples == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/scripts/plan-contract-tests.mjs
+++ b/scripts/plan-contract-tests.mjs
@@ -15,6 +15,8 @@ const ALL_TARGETS = Object.keys(PACKAGE_PREFIXES);
 const OPENAPI_TARGETS = ['cli', 'python', 'js', 'mcp'];
 const PLANNER_FILES = new Set([
   '.github/workflows/contract-tests.yml',
+  'package.json',
+  'package-lock.json',
   'scripts/plan-contract-tests.mjs',
   'scripts/plan-contract-tests.test.mjs',
 ]);
@@ -78,9 +80,35 @@ export function classifyContractChanges(files, { full = false } = {}) {
 
 function changedFiles(baseSha, headSha) {
   if (!baseSha || !headSha) throw new Error('CONTRACT_TEST_BASE_SHA and CONTRACT_TEST_HEAD_SHA are required');
-  return execFileSync('git', ['diff', '--name-only', `${baseSha}...${headSha}`], {
+  return execFileSync('git', ['diff', '--name-only', `${baseSha}...${headSha}`, '--'], {
     encoding: 'utf8',
   }).split('\n');
+}
+
+export function resolveContractPlan({
+  full = false,
+  baseSha,
+  headSha,
+  diff = changedFiles,
+  onFallback = () => {},
+} = {}) {
+  let effectiveFull = full;
+  let files = [];
+
+  if (!effectiveFull) {
+    try {
+      files = diff(baseSha, headSha);
+    } catch (error) {
+      effectiveFull = true;
+      onFallback(error);
+    }
+  }
+
+  return {
+    full: effectiveFull,
+    files: files.filter(Boolean),
+    plan: classifyContractChanges(files, { full: effectiveFull }),
+  };
 }
 
 function writeOutputs(plan, outputPath) {
@@ -92,12 +120,18 @@ function writeOutputs(plan, outputPath) {
 }
 
 function main() {
-  const full = process.env.CONTRACT_TEST_FULL === 'true';
-  const files = full ? [] : changedFiles(process.env.CONTRACT_TEST_BASE_SHA, process.env.CONTRACT_TEST_HEAD_SHA);
-  const plan = classifyContractChanges(files, { full });
+  const result = resolveContractPlan({
+    full: process.env.CONTRACT_TEST_FULL === 'true',
+    baseSha: process.env.CONTRACT_TEST_BASE_SHA,
+    headSha: process.env.CONTRACT_TEST_HEAD_SHA,
+    onFallback: (error) => {
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error(`Failed to resolve changed files; falling back to the full test matrix: ${reason}`);
+    },
+  });
 
-  if (process.env.GITHUB_OUTPUT) writeOutputs(plan, process.env.GITHUB_OUTPUT);
-  process.stdout.write(`${JSON.stringify({ full, files: files.filter(Boolean), plan }, null, 2)}\n`);
+  if (process.env.GITHUB_OUTPUT) writeOutputs(result.plan, process.env.GITHUB_OUTPUT);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/plan-contract-tests.mjs
+++ b/scripts/plan-contract-tests.mjs
@@ -1,0 +1,103 @@
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const PACKAGE_PREFIXES = {
+  benchmark: ['benchmarks/discover-call/'],
+  cli: ['packages/cli/'],
+  python: ['packages/python-sdk/'],
+  js: ['packages/js-sdk/'],
+  mcp: ['packages/mcp/'],
+  plugin: ['packages/openclaw-qveris-plugin/'],
+};
+
+const ALL_TARGETS = Object.keys(PACKAGE_PREFIXES);
+const OPENAPI_TARGETS = ['cli', 'python', 'js', 'mcp'];
+const PLANNER_FILES = new Set([
+  '.github/workflows/contract-tests.yml',
+  'scripts/plan-contract-tests.mjs',
+  'scripts/plan-contract-tests.test.mjs',
+]);
+const SHARED_LINT_FILES = new Set(['.prettierrc.json', '.prettierignore']);
+const LINT_PACKAGE_NAMES = {
+  cli: 'cli',
+  'python-sdk': 'python',
+  'js-sdk': 'js',
+  mcp: 'mcp',
+  'openclaw-qveris-plugin': 'plugin',
+};
+
+export function classifyContractChanges(files, { full = false } = {}) {
+  const normalized = [...new Set(files.map((file) => file.trim()).filter(Boolean))];
+  const selected = new Set(full ? ALL_TARGETS : []);
+  const packageTargets = ['cli', 'python', 'js', 'mcp', 'plugin'];
+  const lintTargets = new Set(full ? packageTargets : []);
+
+  for (const file of normalized) {
+    if (PLANNER_FILES.has(file)) {
+      ALL_TARGETS.forEach((target) => selected.add(target));
+      continue;
+    }
+
+    if (file.startsWith('docs/openapi/')) {
+      OPENAPI_TARGETS.forEach((target) => selected.add(target));
+    }
+
+    if (SHARED_LINT_FILES.has(file)) {
+      packageTargets.forEach((target) => lintTargets.add(target));
+    }
+
+    const eslintPackage = file.match(/^packages\/([^/]+)\/eslint\.config\.mjs$/)?.[1];
+    if (eslintPackage && LINT_PACKAGE_NAMES[eslintPackage]) {
+      lintTargets.add(LINT_PACKAGE_NAMES[eslintPackage]);
+    }
+
+    for (const [target, prefixes] of Object.entries(PACKAGE_PREFIXES)) {
+      if (prefixes.some((prefix) => file.startsWith(prefix))) selected.add(target);
+    }
+  }
+
+  packageTargets.filter((target) => selected.has(target)).forEach((target) => lintTargets.add(target));
+  return {
+    benchmark: selected.has('benchmark'),
+    cli: selected.has('cli'),
+    python: selected.has('python'),
+    js: selected.has('js'),
+    mcp: selected.has('mcp'),
+    plugin: selected.has('plugin'),
+    lint: lintTargets.size > 0,
+    lint_cli: lintTargets.has('cli'),
+    lint_python: lintTargets.has('python'),
+    lint_js: lintTargets.has('js'),
+    lint_mcp: lintTargets.has('mcp'),
+    lint_plugin: lintTargets.has('plugin'),
+    examples: selected.has('cli'),
+    os_matrix: full ? ['ubuntu-latest', 'windows-latest'] : ['ubuntu-latest'],
+  };
+}
+
+function changedFiles(baseSha, headSha) {
+  if (!baseSha || !headSha) throw new Error('CONTRACT_TEST_BASE_SHA and CONTRACT_TEST_HEAD_SHA are required');
+  return execFileSync('git', ['diff', '--name-only', `${baseSha}...${headSha}`], {
+    encoding: 'utf8',
+  }).split('\n');
+}
+
+function writeOutputs(plan, outputPath) {
+  const lines = Object.entries(plan).map(([key, value]) => {
+    const serialized = Array.isArray(value) ? JSON.stringify(value) : String(value);
+    return `${key}=${serialized}`;
+  });
+  appendFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function main() {
+  const full = process.env.CONTRACT_TEST_FULL === 'true';
+  const files = full ? [] : changedFiles(process.env.CONTRACT_TEST_BASE_SHA, process.env.CONTRACT_TEST_HEAD_SHA);
+  const plan = classifyContractChanges(files, { full });
+
+  if (process.env.GITHUB_OUTPUT) writeOutputs(plan, process.env.GITHUB_OUTPUT);
+  process.stdout.write(`${JSON.stringify({ full, files: files.filter(Boolean), plan }, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/plan-contract-tests.test.mjs
+++ b/scripts/plan-contract-tests.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { classifyContractChanges } from './plan-contract-tests.mjs';
+import { classifyContractChanges, resolveContractPlan } from './plan-contract-tests.mjs';
 
 test('a CLI-only change does not schedule unrelated SDKs', () => {
   assert.deepEqual(classifyContractChanges(['packages/cli/src/main.mjs']), {
@@ -71,6 +71,39 @@ test('workflow changes and full runs exercise every target and both operating sy
   assert.equal(fullPlan.lint_mcp, true);
   assert.equal(fullPlan.lint_plugin, true);
   assert.equal(fullPlan.examples, true);
+});
+
+test('root task-runner configuration and lockfile schedule every package on the PR platform', () => {
+  for (const file of ['package.json', 'package-lock.json']) {
+    const plan = classifyContractChanges([file]);
+
+    for (const target of ['benchmark', 'cli', 'python', 'js', 'mcp', 'plugin']) {
+      assert.equal(plan[target], true);
+    }
+    assert.deepEqual(plan.os_matrix, ['ubuntu-latest']);
+  }
+});
+
+test('missing git history fails safe to the full cross-platform matrix', () => {
+  let fallbackReason = '';
+  const result = resolveContractPlan({
+    baseSha: 'missing-base',
+    headSha: 'missing-head',
+    diff: () => {
+      throw new Error('base commit is unavailable');
+    },
+    onFallback: (error) => {
+      fallbackReason = error.message;
+    },
+  });
+
+  assert.equal(result.full, true);
+  assert.deepEqual(result.files, []);
+  assert.equal(fallbackReason, 'base commit is unavailable');
+  for (const target of ['benchmark', 'cli', 'python', 'js', 'mcp', 'plugin']) {
+    assert.equal(result.plan[target], true);
+  }
+  assert.deepEqual(result.plan.os_matrix, ['ubuntu-latest', 'windows-latest']);
 });
 
 test('duplicate and empty filenames do not create false-positive targets', () => {

--- a/scripts/plan-contract-tests.test.mjs
+++ b/scripts/plan-contract-tests.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyContractChanges } from './plan-contract-tests.mjs';
+
+test('a CLI-only change does not schedule unrelated SDKs', () => {
+  assert.deepEqual(classifyContractChanges(['packages/cli/src/main.mjs']), {
+    benchmark: false,
+    cli: true,
+    python: false,
+    js: false,
+    mcp: false,
+    plugin: false,
+    lint: true,
+    lint_cli: true,
+    lint_python: false,
+    lint_js: false,
+    lint_mcp: false,
+    lint_plugin: false,
+    examples: true,
+    os_matrix: ['ubuntu-latest'],
+  });
+});
+
+test('the public OpenAPI contract schedules every contract consumer', () => {
+  const plan = classifyContractChanges(['docs/openapi/qveris-public-api.openapi.json']);
+
+  assert.equal(plan.cli, true);
+  assert.equal(plan.python, true);
+  assert.equal(plan.js, true);
+  assert.equal(plan.mcp, true);
+  assert.equal(plan.plugin, false);
+  assert.equal(plan.benchmark, false);
+});
+
+test('shared lint configuration schedules lint without expensive test suites', () => {
+  const plan = classifyContractChanges(['.prettierrc.json']);
+
+  assert.deepEqual(plan, {
+    benchmark: false,
+    cli: false,
+    python: false,
+    js: false,
+    mcp: false,
+    plugin: false,
+    lint: true,
+    lint_cli: true,
+    lint_python: true,
+    lint_js: true,
+    lint_mcp: true,
+    lint_plugin: true,
+    examples: false,
+    os_matrix: ['ubuntu-latest'],
+  });
+});
+
+test('workflow changes and full runs exercise every target and both operating systems', () => {
+  const workflowPlan = classifyContractChanges(['.github/workflows/contract-tests.yml']);
+  const fullPlan = classifyContractChanges([], { full: true });
+
+  for (const target of ['benchmark', 'cli', 'python', 'js', 'mcp', 'plugin']) {
+    assert.equal(workflowPlan[target], true);
+    assert.equal(fullPlan[target], true);
+  }
+  assert.deepEqual(workflowPlan.os_matrix, ['ubuntu-latest']);
+  assert.deepEqual(fullPlan.os_matrix, ['ubuntu-latest', 'windows-latest']);
+  assert.equal(fullPlan.lint, true);
+  assert.equal(fullPlan.lint_cli, true);
+  assert.equal(fullPlan.lint_python, true);
+  assert.equal(fullPlan.lint_js, true);
+  assert.equal(fullPlan.lint_mcp, true);
+  assert.equal(fullPlan.lint_plugin, true);
+  assert.equal(fullPlan.examples, true);
+});
+
+test('duplicate and empty filenames do not create false-positive targets', () => {
+  assert.deepEqual(classifyContractChanges(['', 'README.md', 'README.md']), {
+    benchmark: false,
+    cli: false,
+    python: false,
+    js: false,
+    mcp: false,
+    plugin: false,
+    lint: false,
+    lint_cli: false,
+    lint_python: false,
+    lint_js: false,
+    lint_mcp: false,
+    lint_plugin: false,
+    examples: false,
+    os_matrix: ['ubuntu-latest'],
+  });
+});


### PR DESCRIPTION
## What changed

- stop rerunning the full Contract tests workflow after every merge to `main`
- add an affected-target planner so PRs run only the changed package suites
- keep PR coverage gates while folding coverage into each Linux package test job
- reserve Windows/full-package coverage for the weekly scheduled run and manual runs
- cancel superseded runs for the same PR
- broaden relevant test/config path coverage so changed tests are not missed

## Why

The previous workflow launched every package on Linux and Windows, plus a second coverage pass, for any matching PR and then repeated the matrix after merge. This was the largest GitHub-hosted runner consumer in the repository.

A typical CLI-only PR now schedules the planner, CLI Linux suite, affected lint, and CLI examples instead of the full monorepo matrix. Package release workflows retain their release-time matrices, and the weekly full run continues to detect cross-platform drift.

## Validation

- `node --test scripts/plan-contract-tests.test.mjs`
- YAML parse and formatting checks for the modified workflow and planner
- CLI coverage: 128 tests passed
- JS SDK coverage: 58 tests passed
- MCP coverage: 167 tests passed
- OpenClaw plugin coverage: 78 tests passed
- Python SDK coverage: 142 tests passed, 86.33% coverage
- discover/call benchmark: 20 tests passed and fixtures validated

The first MCP run was blocked by the local sandbox's port policy; rerunning with local loopback binding enabled passed all tests.
