### PR TITLE
feat: add projection support across clients

### DIFF
--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -98,6 +98,8 @@ qveris discover <query> [flags]
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
 | `--limit <n>` | 最大结果数 | 5 |
+| `--view <routing\|full>` | 精简 routing card 或完整结果 | full |
+| `--lang <zh\|en>` | 响应语言 | 服务端协商 |
 | `--json` | 输出原始 JSON | false |
 
 **示例：**
@@ -106,6 +108,7 @@ qveris discover <query> [flags]
 qveris discover "股票价格 API"
 qveris discover "将文本翻译成法语" --limit 10
 qveris discover "加密货币市场数据" --json
+qveris discover "天气预报" --view routing --lang zh
 ```
 
 **每个工具的输出字段：**
@@ -169,6 +172,7 @@ qveris call <tool_id|index> [flags]
 | `--params <json\|@file\|->` | JSON、文件路径或 stdin | `{}` |
 | `--discovery-id <id>` | 发现会话 ID | 自动从会话获取 |
 | `--max-size <bytes>` | 响应大小限制（-1 = 无限制） | 4KB (TTY) / 20KB (管道) |
+| `--respond-with <mode>` | `full`、`summary` 或 `fields:<JSONPath,...>` | full |
 | `--dry-run` | 预览请求，不实际执行 | false |
 | `--codegen <lang>` | 调用后生成代码片段 | — |
 | `--json` | 输出原始 JSON | false |
@@ -184,7 +188,15 @@ qveris call 1 --params @params.json
 
 # 从 stdin
 echo '{"city": "London"}' | qveris call 1 --params -
+
+# 返回 schema、大小摘要和完整内容签名 URL
+qveris call 1 --params '{"city": "London"}' --respond-with summary
+
+# 选择以 result.data 为根的字段
+qveris call 1 --params '{"city": "London"}' --respond-with 'fields:$.temperature,$.humidity'
 ```
+
+投影参数仅在显式指定时发送。如果旧服务明确把投影字段判定为未知字段，CLI 只移除该字段并重试一次；无效投影仍按 `422` 错误返回。
 
 **试运行（不消耗 credits）：**
 

--- a/docs/cn/zh-CN/js-sdk.md
+++ b/docs/cn/zh-CN/js-sdk.md
@@ -88,18 +88,20 @@ console.log(usage.total, ledger.total);
 
 | 方法 | REST 端点 | 用途 |
 |------|-----------|------|
-| `discover(query, options?)` | `POST /search` | 用自然语言发现能力（免费） |
+| `discover(query, options?)` | `POST /search` | 发现能力；`view: 'routing'` 返回精简 routing card（免费） |
 | `inspect(toolIds, options?)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
-| `call(toolId, options)` | `POST /tools/execute` | 执行能力（可能消耗积分） |
+| `call(toolId, options)` | `POST /tools/execute` | 执行能力；`respondWith` 可选择完整、摘要或 JSONPath 字段 |
 | `credits()` | `GET /auth/credits` | 当前积分余额与分桶 |
 | `usage(filters?)` | `GET /auth/usage/history/v2` | 审计请求状态与扣费结果 |
 | `ledger(filters?)` | `GET /auth/credits/ledger` | 查看最终积分余额变动 |
 
 选项结构：
 
-- `discover(query, { limit?, sessionId?, timeoutMs? })`
+- `discover(query, { limit?, sessionId?, view?, lang?, timeoutMs? })`
 - `inspect(toolIds, { searchId?, sessionId?, timeoutMs? })` —— `toolIds` 接受单个字符串或数组；**空数组会短路**，直接返回空响应而不发起网络请求。
-- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, timeoutMs? })`
+- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs? })`
+
+投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
 
 `usage(...)` 和 `ledger(...)` 接受过滤对象，如 `start_date`、`end_date`、`summary`、`bucket`、`charge_outcome`、`execution_id`、`search_id`、`direction`、`entry_type`、`min_credits`、`max_credits`、`limit`、`page`、`page_size`。
 

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -169,13 +169,17 @@ https://mcp.qveris.cn/mcp
 | `query` | string | 是 | 用自然语言描述所需能力 |
 | `limit` | number | 否 | 最大返回数量（`1-100`，默认 `20`） |
 | `session_id` | string | 否 | 用于追踪的会话标识符 |
+| `view` | string | 否 | `routing` 返回精简 routing card；`full` 或省略返回完整结果 |
+| `lang` | string | 否 | 响应语言：`zh` 或 `en`；省略时由服务端协商 |
 
 示例：
 
 ```json
 {
   "query": "天气预报 API",
-  "limit": 10
+  "limit": 10,
+  "view": "routing",
+  "lang": "zh"
 }
 ```
 
@@ -236,6 +240,7 @@ https://mcp.qveris.cn/mcp
 | `params_to_tool` | object | 是 | 传递给工具的参数字典 |
 | `session_id` | string | 否 | 用于追踪的会话标识符 |
 | `max_response_size` | number | 否 | 最大响应字节数（默认 `20480`） |
+| `respond_with` | string | 否 | `full`、`summary` 或 `fields:<JSONPath,...>`；省略时为 full |
 
 示例：
 
@@ -243,16 +248,19 @@ https://mcp.qveris.cn/mcp
 {
   "tool_id": "openweathermap.weather.execute.v1",
   "search_id": "YOUR_SEARCH_ID",
-  "params_to_tool": {"city": "北京", "units": "metric"}
+  "params_to_tool": {"city": "北京", "units": "metric"},
+  "respond_with": "summary"
 }
 ```
+
+投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
 
 典型成功响应字段：
 
 - `execution_id`
-- `tool_id`
+- `tool_id`（所选投影返回时）
 - `success`
-- `result.data`
+- `result.data`，或显式请求的精简摘要字段
 - `elapsed_time_ms` 或 `execution_time`
 - `billing` / `pre_settlement_bill`（如可用）
 

--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -195,9 +195,11 @@ agent = Agent(
 
 | 方法 | REST 端点 | 用途 |
 |------|-----------|------|
-| `discover(query, limit=20, session_id=None)` | `POST /search` | 用自然语言发现能力（免费） |
+| `discover(query, limit=20, session_id=None, view=None, lang=None)` | `POST /search` | 发现能力；`view="routing"` 返回精简 routing card（免费） |
 | `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
-| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None)` | `POST /tools/execute` | 执行能力（可能消耗积分） |
+| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None, respond_with=None)` | `POST /tools/execute` | 执行能力；可选择完整、摘要或 JSONPath 字段 |
+
+投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
 | `usage(**filters)` | `GET /auth/usage/history/v2` | 审计请求状态与扣费结果 |
 | `ledger(**filters)` | `GET /auth/credits/ledger` | 查看最终积分余额变动 |
 | `handle_tool_call(func_name, func_args, session_id=None)` | — | 把 LLM 工具调用桥接到对应的 QVeris 方法 |

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -96,6 +96,8 @@ qveris discover <query> [flags]
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--limit <n>` | Max results to return | 5 |
+| `--view <routing\|full>` | Compact routing cards or complete results | full |
+| `--lang <zh\|en>` | Response language | server negotiation |
 | `--json` | Output raw JSON | false |
 
 **Examples:**
@@ -104,6 +106,7 @@ qveris discover <query> [flags]
 qveris discover "stock price API"
 qveris discover "translate text to French" --limit 10
 qveris discover "cryptocurrency market data" --json
+qveris discover "weather forecast" --view routing --lang en
 ```
 
 **Output fields per tool:**
@@ -167,6 +170,7 @@ qveris call <tool_id|index> [flags]
 | `--params <json\|@file\|->` | Parameters as JSON, file path, or stdin | `{}` |
 | `--discovery-id <id>` | Discovery session ID | auto from session |
 | `--max-size <bytes>` | Response size limit (-1 = unlimited) | 4KB (TTY) / 20KB (pipe) |
+| `--respond-with <mode>` | `full`, `summary`, or `fields:<JSONPath,...>` | full |
 | `--dry-run` | Preview request without executing | false |
 | `--codegen <lang>` | Generate code snippet after call | — |
 | `--json` | Output raw JSON | false |
@@ -182,7 +186,15 @@ qveris call 1 --params @params.json
 
 # From stdin
 echo '{"city": "London"}' | qveris call 1 --params -
+
+# Compact schema/size summary with a signed full-content URL
+qveris call 1 --params '{"city": "London"}' --respond-with summary
+
+# Select fields rooted at result.data
+qveris call 1 --params '{"city": "London"}' --respond-with 'fields:$.temperature,$.humidity'
 ```
+
+Projection flags are opt-in. If an older service explicitly rejects a projection field as unknown, the CLI retries once without only that field. Invalid projections remain `422` errors.
 
 **Dry run (no credits consumed):**
 

--- a/docs/en-US/js-sdk-api.md
+++ b/docs/en-US/js-sdk-api.md
@@ -701,6 +701,12 @@ Max response bytes before truncation (-1 for no limit, server default 20480)
 
 Key-value parameters matching the tool's parameter schema
 
+##### respondWith?
+
+> `optional` **respondWith?**: `"full"` \| `` `fields:${string}` `` \| `"summary"`
+
+Server-side result projection. Omit for the legacy/full response.
+
 ##### searchId?
 
 > `optional` **searchId?**: `string`
@@ -963,6 +969,12 @@ Options for [Qveris.discover](#discover).
 
 #### Properties
 
+##### lang?
+
+> `optional` **lang?**: `"zh"` \| `"en"`
+
+Response language. Omit to use server-side language negotiation.
+
 ##### limit?
 
 > `optional` **limit?**: `number`
@@ -980,6 +992,12 @@ Session identifier for tracking
 > `optional` **timeoutMs?**: `number`
 
 Per-request timeout override in milliseconds
+
+##### view?
+
+> `optional` **view?**: `"routing"` \| `"full"`
+
+Response projection. Omit for the legacy/full response shape.
 
 ***
 
@@ -1010,6 +1028,12 @@ Minimum: -1 (`-1` means no limit).
 
 Key-value pairs of parameters to pass to the tool.
 Must match the parameter schema from the tool's definition.
+
+##### respond\_with?
+
+> `optional` **respond\_with?**: `"full"` \| `` `fields:${string}` `` \| `"summary"`
+
+Server-side result projection. Omit for the legacy/full response.
 
 ##### search\_id
 
@@ -1075,9 +1099,9 @@ Unique identifier for this execution record
 
 Execution duration in seconds
 
-##### parameters
+##### parameters?
 
-> **parameters**: `Record`\<`string`, `unknown`\>
+> `optional` **parameters?**: `Record`\<`string`, `unknown`\>
 
 The parameters that were passed to the tool
 
@@ -1106,9 +1130,9 @@ Contains either `data` (if within size limit) or truncation info.
 
 Whether the execution completed successfully
 
-##### tool\_id
+##### tool\_id?
 
-> **tool\_id**: `string`
+> `optional` **tool\_id?**: `string`
 
 The tool that was executed
 
@@ -1125,6 +1149,66 @@ Result data when the response fits within max_response_size.
 > **data**: `unknown`
 
 The actual result data from the tool execution
+
+***
+
+### ExecuteResultFields
+
+Selected result fields returned by a `fields:<JSONPath,...>` projection.
+
+#### Properties
+
+##### data?
+
+> `optional` **data?**: `unknown`
+
+##### respond\_with
+
+> **respond\_with**: `` `fields:${string}` ``
+
+***
+
+### ExecuteResultSummary
+
+Compact result returned by `respond_with: "summary"`.
+
+#### Properties
+
+##### content\_schema?
+
+> `optional` **content\_schema?**: `Record`\<`string`, `unknown`\>
+
+##### full\_content\_file\_url?
+
+> `optional` **full\_content\_file\_url?**: `string`
+
+##### message?
+
+> `optional` **message?**: `string`
+
+##### respond\_with
+
+> **respond\_with**: `"summary"`
+
+##### summary?
+
+> `optional` **summary?**: `object`
+
+###### Index Signature
+
+\[`key`: `string`\]: `unknown`
+
+###### fields?
+
+> `optional` **fields?**: `string`[]
+
+###### row\_count?
+
+> `optional` **row\_count?**: `number`
+
+###### size\_bytes?
+
+> `optional` **size\_bytes?**: `number`
 
 ***
 
@@ -1256,6 +1340,12 @@ Request body for the Search Tools API.
 
 #### Properties
 
+##### lang?
+
+> `optional` **lang?**: `"zh"` \| `"en"`
+
+Response language. Omit to use server-side language negotiation.
+
 ##### limit?
 
 > `optional` **limit?**: `number`
@@ -1280,6 +1370,12 @@ Natural language search query describing the tool capability you need.
 > `optional` **session\_id?**: `string`
 
 Session identifier for tracking user sessions.
+
+##### view?
+
+> `optional` **view?**: `"routing"` \| `"full"`
+
+Response projection. Omit for the legacy/full response shape.
 
 ***
 
@@ -1444,6 +1540,12 @@ Contains everything needed to understand and execute the tool.
 
 #### Properties
 
+##### as\_of\_support?
+
+> `optional` **as\_of\_support?**: `boolean`
+
+Whether the capability supports point-in-time requests.
+
 ##### billing\_rule?
 
 > `optional` **billing\_rule?**: [`BillingRule`](#billingrule)
@@ -1456,15 +1558,27 @@ Structured rule-level billing metadata when available
 
 Standardized capability descriptors with coverage tags
 
+##### capability?
+
+> `optional` **capability?**: `string`
+
+Compact capability label returned by the routing projection.
+
 ##### categories?
 
 > `optional` **categories?**: (`string` \| [`ToolCategory`](#toolcategory))[]
 
 Tool categories/tags: category objects, or plain strings in legacy responses
 
-##### description
+##### cost\_class?
 
-> **description**: `string`
+> `optional` **cost\_class?**: `string`
+
+Compact cost class returned by the routing projection.
+
+##### description?
+
+> `optional` **description?**: `string`
 
 Detailed description of what the tool does
 
@@ -1504,9 +1618,9 @@ Whether this tool has been executed before (verified in production)
 
 Most recent execution record, if available
 
-##### name
+##### name?
 
-> **name**: `string`
+> `optional` **name?**: `string`
 
 Human-readable display name
 
@@ -1554,6 +1668,12 @@ Geographic availability of the tool.
 - "global" - Available worldwide
 - "US|CA" - Whitelist: only available in US and Canada
 - "-CN|RU" - Blacklist: not available in China and Russia
+
+##### reliability?
+
+> `optional` **reliability?**: `string`
+
+Compact reliability grade returned by the routing projection.
 
 ##### stats?
 
@@ -1857,7 +1977,7 @@ Error response from the Qveris API.
 
 ### ExecuteResult
 
-> **ExecuteResult** = [`ExecuteResultData`](#executeresultdata) \| [`ExecuteResultTruncated`](#executeresulttruncated)
+> **ExecuteResult** = [`ExecuteResultData`](#executeresultdata) \| [`ExecuteResultTruncated`](#executeresulttruncated) \| [`ExecuteResultSummary`](#executeresultsummary) \| [`ExecuteResultFields`](#executeresultfields) \| `unknown`[] \| `string` \| `number` \| `boolean` \| `null`
 
 Union type for execution results (either full data or truncated).
 

--- a/docs/en-US/js-sdk.md
+++ b/docs/en-US/js-sdk.md
@@ -93,18 +93,20 @@ in CI.
 
 | Method | REST endpoint | Purpose |
 |--------|---------------|---------|
-| `discover(query, options?)` | `POST /search` | Find capabilities with natural language (free) |
+| `discover(query, options?)` | `POST /search` | Find capabilities; `view: 'routing'` returns compact routing cards (free) |
 | `inspect(toolIds, options?)` | `POST /tools/by-ids` | Fetch full capability metadata (free) |
-| `call(toolId, options)` | `POST /tools/execute` | Execute a capability (may consume credits) |
+| `call(toolId, options)` | `POST /tools/execute` | Execute a capability; `respondWith` selects full, summary, or JSONPath fields |
 | `credits()` | `GET /auth/credits` | Current credit balance and buckets |
 | `usage(filters?)` | `GET /auth/usage/history/v2` | Audit request status and charge outcome |
 | `ledger(filters?)` | `GET /auth/credits/ledger` | Inspect final credit balance movements |
 
 Option shapes:
 
-- `discover(query, { limit?, sessionId?, timeoutMs? })`
+- `discover(query, { limit?, sessionId?, view?, lang?, timeoutMs? })`
 - `inspect(toolIds, { searchId?, sessionId?, timeoutMs? })` — `toolIds` accepts a single string or an array; an **empty array short-circuits** and returns an empty response without a network request.
-- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, timeoutMs? })`
+- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs? })`
+
+Projection options are opt-in. A legacy `422 extra_forbidden` response causes one retry without only the rejected optional field; invalid projections remain errors.
 
 `usage(...)` and `ledger(...)` take filter objects such as `start_date`, `end_date`, `summary`, `bucket`, `charge_outcome`, `execution_id`, `search_id`, `direction`, `entry_type`, `min_credits`, `max_credits`, `limit`, `page`, `page_size`.
 

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -194,13 +194,17 @@ This is the **Discover** action and is **free**.
 | `query` | string | Yes | Natural-language description of the capability you need |
 | `limit` | number | No | Max results to return (`1-100`, default `20`) |
 | `session_id` | string | No | Session identifier for tracking |
+| `view` | string | No | `routing` for compact routing cards; `full` or omitted for complete results |
+| `lang` | string | No | Response language: `zh` or `en`; omitted uses server negotiation |
 
 Example:
 
 ```json
 {
   "query": "weather forecast API",
-  "limit": 10
+  "limit": 10,
+  "view": "routing",
+  "lang": "en"
 }
 ```
 
@@ -261,6 +265,7 @@ The call response may include compact pre-settlement `billing`. Final charge sta
 | `params_to_tool` | object | Yes | Dictionary of parameters to pass to the tool |
 | `session_id` | string | No | Session identifier for tracking |
 | `max_response_size` | number | No | Max response size in bytes (default `20480`) |
+| `respond_with` | string | No | `full`, `summary`, or `fields:<JSONPath,...>`; omitted defaults to full |
 
 Example:
 
@@ -268,16 +273,19 @@ Example:
 {
   "tool_id": "openweathermap.weather.execute.v1",
   "search_id": "YOUR_SEARCH_ID",
-  "params_to_tool": {"city": "London", "units": "metric"}
+  "params_to_tool": {"city": "London", "units": "metric"},
+  "respond_with": "summary"
 }
 ```
+
+Projection inputs are opt-in. A legacy `422 extra_forbidden` response causes one retry without only the rejected optional field; invalid projections remain errors.
 
 Typical successful response fields:
 
 - `execution_id`
-- `tool_id`
+- `tool_id` when returned by the selected projection
 - `success`
-- `result.data`
+- `result.data`, or compact summary fields when requested
 - `elapsed_time_ms` or `execution_time`
 - `billing` / `pre_settlement_bill` when available
 

--- a/docs/en-US/python-sdk-api.md
+++ b/docs/en-US/python-sdk-api.md
@@ -32,7 +32,7 @@ Call this if you create QverisClient directly and want to free network resources
 
 <a id="qveris.QverisClient.discover"></a>
 
-#### *async* discover(query: str, limit: int = 20, session_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
+#### *async* discover(query: str, limit: int = 20, session_id: str | None = None, view: Literal['routing', 'full'] | None = None, lang: Literal['zh', 'en'] | None = None) → [SearchResponse](#qveris.SearchResponse)
 
 Discover capabilities using natural language.
 
@@ -40,6 +40,8 @@ Discover capabilities using natural language.
   * **query** – Natural-language description of the capability you want (not parameters). Example: “weather forecast API” or “search recent news”.
   * **limit** – Maximum number of tools to return (server may cap this).
   * **session_id** – Optional correlation id.
+  * **view** – Optional response projection. Omit for the legacy/full response.
+  * **lang** – Optional response language; omit for server-side negotiation.
 * **Returns:**
   SearchResponse containing results (tools) and search_id used for execution.
 
@@ -70,7 +72,7 @@ Deprecated alias for inspect(…).
 
 <a id="qveris.QverisClient.call"></a>
 
-#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
+#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None, respond_with: str | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
 
 Call a specific capability.
 
@@ -80,6 +82,7 @@ Call a specific capability.
   * **search_id** – Search ID returned by discover(…) (recommended for traceability).
   * **session_id** – Optional correlation id.
   * **max_response_size** – Optional max response size in bytes. Large responses may be truncated.
+  * **respond_with** – Optional server-side projection (full, summary, or fields:<JSONPath,…>).
 * **Returns:**
   ToolExecutionResponse with success, result, and metadata.
 
@@ -347,7 +350,7 @@ Current API responses return category objects; legacy responses returned plain s
 
 <a id="qveris.ToolInfo"></a>
 
-### *class* qveris.ToolInfo(\*, tool_id: str, name: str | None = None, description: Any | None = None, categories: List[str | [ToolCategory](#qveris.ToolCategory)] | None = None, category: str | None = None, capabilities: List[[ToolCapability](#qveris.ToolCapability)] | None = None, provider_id: str | None = None, provider_name: str | None = None, provider_description: Any | None = None, provider_website_url: str | None = None, region: str | None = None, params: List[[ToolParameter](#qveris.ToolParameter)] | None = None, examples: ToolExamples | None = None, stats: ToolStats | None = None, billing_rule: BillingRule | None = None, expected_cost: str | float | None = None, final_score: float | None = None, score: float | None = None, why_recommended: str | None = None, has_last_execution: bool | None = None, last_execution_record: Dict[str, Any] | None = None, docs_url: str | None = None, protocol: str | None = None, \*\*extra_data: Any)
+### *class* qveris.ToolInfo(\*, tool_id: str, name: str | None = None, description: Any | None = None, capability: str | None = None, cost_class: str | None = None, reliability: str | None = None, as_of_support: bool | None = None, categories: List[str | [ToolCategory](#qveris.ToolCategory)] | None = None, category: str | None = None, capabilities: List[[ToolCapability](#qveris.ToolCapability)] | None = None, provider_id: str | None = None, provider_name: str | None = None, provider_description: Any | None = None, provider_website_url: str | None = None, region: str | None = None, params: List[[ToolParameter](#qveris.ToolParameter)] | None = None, examples: ToolExamples | None = None, stats: ToolStats | None = None, billing_rule: BillingRule | None = None, expected_cost: str | float | None = None, final_score: float | None = None, score: float | None = None, why_recommended: str | None = None, has_last_execution: bool | None = None, last_execution_record: Dict[str, Any] | None = None, docs_url: str | None = None, protocol: str | None = None, \*\*extra_data: Any)
 
 <a id="qveris.ToolParameter"></a>
 

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -192,9 +192,11 @@ drift.
 
 | Method | REST endpoint | Purpose |
 |--------|---------------|---------|
-| `discover(query, limit=20, session_id=None)` | `POST /search` | Find capabilities with natural language (free) |
+| `discover(query, limit=20, session_id=None, view=None, lang=None)` | `POST /search` | Find capabilities; `view="routing"` returns compact routing cards (free) |
 | `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | Fetch full capability metadata (free) |
-| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None)` | `POST /tools/execute` | Execute a capability (may consume credits) |
+| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None, respond_with=None)` | `POST /tools/execute` | Execute a capability; select full, summary, or JSONPath fields |
+
+Projection arguments are opt-in. A legacy `422 extra_forbidden` response causes one retry without only the rejected optional field; invalid projections remain errors.
 | `usage(**filters)` | `GET /auth/usage/history/v2` | Audit request status and charge outcome |
 | `ledger(**filters)` | `GET /auth/credits/ledger` | Inspect final credit balance movements |
 | `handle_tool_call(func_name, func_args, session_id=None)` | — | Bridge an LLM tool call to the right QVeris method |

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -96,6 +96,8 @@ qveris discover <query> [flags]
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
 | `--limit <n>` | 最大结果数 | 5 |
+| `--view <routing\|full>` | 精简 routing card 或完整结果 | full |
+| `--lang <zh\|en>` | 响应语言 | 服务端协商 |
 | `--json` | 输出原始 JSON | false |
 
 **示例：**
@@ -104,6 +106,7 @@ qveris discover <query> [flags]
 qveris discover "股票价格 API"
 qveris discover "将文本翻译成法语" --limit 10
 qveris discover "加密货币市场数据" --json
+qveris discover "天气预报" --view routing --lang zh
 ```
 
 **每个工具的输出字段：**
@@ -167,6 +170,7 @@ qveris call <tool_id|index> [flags]
 | `--params <json\|@file\|->` | JSON、文件路径或 stdin | `{}` |
 | `--discovery-id <id>` | 发现会话 ID | 自动从会话获取 |
 | `--max-size <bytes>` | 响应大小限制（-1 = 无限制） | 4KB (TTY) / 20KB (管道) |
+| `--respond-with <mode>` | `full`、`summary` 或 `fields:<JSONPath,...>` | full |
 | `--dry-run` | 预览请求，不实际执行 | false |
 | `--codegen <lang>` | 调用后生成代码片段 | — |
 | `--json` | 输出原始 JSON | false |
@@ -182,7 +186,15 @@ qveris call 1 --params @params.json
 
 # 从 stdin
 echo '{"city": "London"}' | qveris call 1 --params -
+
+# 返回 schema、大小摘要和完整内容签名 URL
+qveris call 1 --params '{"city": "London"}' --respond-with summary
+
+# 选择以 result.data 为根的字段
+qveris call 1 --params '{"city": "London"}' --respond-with 'fields:$.temperature,$.humidity'
 ```
+
+投影参数仅在显式指定时发送。如果旧服务明确把投影字段判定为未知字段，CLI 只移除该字段并重试一次；无效投影仍按 `422` 错误返回。
 
 **试运行（不消耗积分）：**
 

--- a/docs/zh-CN/js-sdk-api.md
+++ b/docs/zh-CN/js-sdk-api.md
@@ -699,6 +699,12 @@ Max response bytes before truncation (-1 for no limit, server default 20480)
 
 Key-value parameters matching the tool's parameter schema
 
+##### respondWith?
+
+> `optional` **respondWith?**: `"full"` \| `` `fields:${string}` `` \| `"summary"`
+
+Server-side result projection. Omit for the legacy/full response.
+
 ##### searchId?
 
 > `optional` **searchId?**: `string`
@@ -961,6 +967,12 @@ Options for [Qveris.discover](#discover).
 
 #### 属性
 
+##### lang?
+
+> `optional` **lang?**: `"zh"` \| `"en"`
+
+Response language. Omit to use server-side language negotiation.
+
 ##### limit?
 
 > `optional` **limit?**: `number`
@@ -978,6 +990,12 @@ Session identifier for tracking
 > `optional` **timeoutMs?**: `number`
 
 Per-request timeout override in milliseconds
+
+##### view?
+
+> `optional` **view?**: `"routing"` \| `"full"`
+
+Response projection. Omit for the legacy/full response shape.
 
 ***
 
@@ -1008,6 +1026,12 @@ Minimum: -1 (`-1` means no limit).
 
 Key-value pairs of parameters to pass to the tool.
 Must match the parameter schema from the tool's definition.
+
+##### respond\_with?
+
+> `optional` **respond\_with?**: `"full"` \| `` `fields:${string}` `` \| `"summary"`
+
+Server-side result projection. Omit for the legacy/full response.
 
 ##### search\_id
 
@@ -1073,9 +1097,9 @@ Unique identifier for this execution record
 
 Execution duration in seconds
 
-##### parameters
+##### parameters?
 
-> **parameters**: `Record`\<`string`, `unknown`\>
+> `optional` **parameters?**: `Record`\<`string`, `unknown`\>
 
 The parameters that were passed to the tool
 
@@ -1104,9 +1128,9 @@ Contains either `data` (if within size limit) or truncation info.
 
 Whether the execution completed successfully
 
-##### tool\_id
+##### tool\_id?
 
-> **tool\_id**: `string`
+> `optional` **tool\_id?**: `string`
 
 The tool that was executed
 
@@ -1123,6 +1147,66 @@ Result data when the response fits within max_response_size.
 > **data**: `unknown`
 
 The actual result data from the tool execution
+
+***
+
+### ExecuteResultFields
+
+Selected result fields returned by a `fields:<JSONPath,...>` projection.
+
+#### 属性
+
+##### data?
+
+> `optional` **data?**: `unknown`
+
+##### respond\_with
+
+> **respond\_with**: `` `fields:${string}` ``
+
+***
+
+### ExecuteResultSummary
+
+Compact result returned by `respond_with: "summary"`.
+
+#### 属性
+
+##### content\_schema?
+
+> `optional` **content\_schema?**: `Record`\<`string`, `unknown`\>
+
+##### full\_content\_file\_url?
+
+> `optional` **full\_content\_file\_url?**: `string`
+
+##### message?
+
+> `optional` **message?**: `string`
+
+##### respond\_with
+
+> **respond\_with**: `"summary"`
+
+##### summary?
+
+> `optional` **summary?**: `object`
+
+###### 索引签名
+
+\[`key`: `string`\]: `unknown`
+
+###### fields?
+
+> `optional` **fields?**: `string`[]
+
+###### row\_count?
+
+> `optional` **row\_count?**: `number`
+
+###### size\_bytes?
+
+> `optional` **size\_bytes?**: `number`
 
 ***
 
@@ -1254,6 +1338,12 @@ Request body for the Search Tools API.
 
 #### 属性
 
+##### lang?
+
+> `optional` **lang?**: `"zh"` \| `"en"`
+
+Response language. Omit to use server-side language negotiation.
+
 ##### limit?
 
 > `optional` **limit?**: `number`
@@ -1278,6 +1368,12 @@ Natural language search query describing the tool capability you need.
 > `optional` **session\_id?**: `string`
 
 Session identifier for tracking user sessions.
+
+##### view?
+
+> `optional` **view?**: `"routing"` \| `"full"`
+
+Response projection. Omit for the legacy/full response shape.
 
 ***
 
@@ -1442,6 +1538,12 @@ Contains everything needed to understand and execute the tool.
 
 #### 属性
 
+##### as\_of\_support?
+
+> `optional` **as\_of\_support?**: `boolean`
+
+Whether the capability supports point-in-time requests.
+
 ##### billing\_rule?
 
 > `optional` **billing\_rule?**: [`BillingRule`](#billingrule)
@@ -1454,15 +1556,27 @@ Structured rule-level billing metadata when available
 
 Standardized capability descriptors with coverage tags
 
+##### capability?
+
+> `optional` **capability?**: `string`
+
+Compact capability label returned by the routing projection.
+
 ##### categories?
 
 > `optional` **categories?**: (`string` \| [`ToolCategory`](#toolcategory))[]
 
 Tool categories/tags: category objects, or plain strings in legacy responses
 
-##### description
+##### cost\_class?
 
-> **description**: `string`
+> `optional` **cost\_class?**: `string`
+
+Compact cost class returned by the routing projection.
+
+##### description?
+
+> `optional` **description?**: `string`
 
 Detailed description of what the tool does
 
@@ -1502,9 +1616,9 @@ Whether this tool has been executed before (verified in production)
 
 Most recent execution record, if available
 
-##### name
+##### name?
 
-> **name**: `string`
+> `optional` **name?**: `string`
 
 Human-readable display name
 
@@ -1552,6 +1666,12 @@ Geographic availability of the tool.
 - "global" - Available worldwide
 - "US|CA" - Whitelist: only available in US and Canada
 - "-CN|RU" - Blacklist: not available in China and Russia
+
+##### reliability?
+
+> `optional` **reliability?**: `string`
+
+Compact reliability grade returned by the routing projection.
 
 ##### stats?
 
@@ -1855,7 +1975,7 @@ Error response from the Qveris API.
 
 ### ExecuteResult
 
-> **ExecuteResult** = [`ExecuteResultData`](#executeresultdata) \| [`ExecuteResultTruncated`](#executeresulttruncated)
+> **ExecuteResult** = [`ExecuteResultData`](#executeresultdata) \| [`ExecuteResultTruncated`](#executeresulttruncated) \| [`ExecuteResultSummary`](#executeresultsummary) \| [`ExecuteResultFields`](#executeresultfields) \| `unknown`[] \| `string` \| `number` \| `boolean` \| `null`
 
 Union type for execution results (either full data or truncated).
 

--- a/docs/zh-CN/js-sdk.md
+++ b/docs/zh-CN/js-sdk.md
@@ -91,18 +91,20 @@ AI SDK 集成。该页面直接根据 TypeScript 源码重新生成，并由 CI 
 
 | 方法 | REST 端点 | 用途 |
 |------|-----------|------|
-| `discover(query, options?)` | `POST /search` | 用自然语言发现能力（免费） |
+| `discover(query, options?)` | `POST /search` | 发现能力；`view: 'routing'` 返回精简 routing card（免费） |
 | `inspect(toolIds, options?)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
-| `call(toolId, options)` | `POST /tools/execute` | 执行能力（可能消耗积分） |
+| `call(toolId, options)` | `POST /tools/execute` | 执行能力；`respondWith` 可选择完整、摘要或 JSONPath 字段 |
 | `credits()` | `GET /auth/credits` | 当前积分余额与分桶 |
 | `usage(filters?)` | `GET /auth/usage/history/v2` | 审计请求状态与扣费结果 |
 | `ledger(filters?)` | `GET /auth/credits/ledger` | 查看最终积分余额变动 |
 
 选项结构：
 
-- `discover(query, { limit?, sessionId?, timeoutMs? })`
+- `discover(query, { limit?, sessionId?, view?, lang?, timeoutMs? })`
 - `inspect(toolIds, { searchId?, sessionId?, timeoutMs? })` —— `toolIds` 接受单个字符串或数组；**空数组会短路**，直接返回空响应而不发起网络请求。
-- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, timeoutMs? })`
+- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs? })`
+
+投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
 
 `usage(...)` 和 `ledger(...)` 接受过滤对象，如 `start_date`、`end_date`、`summary`、`bucket`、`charge_outcome`、`execution_id`、`search_id`、`direction`、`entry_type`、`min_credits`、`max_credits`、`limit`、`page`、`page_size`。
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -194,13 +194,17 @@ claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --
 | `query` | string | 是 | 用自然语言描述所需能力 |
 | `limit` | number | 否 | 最大返回数量（`1-100`，默认 `20`） |
 | `session_id` | string | 否 | 用于追踪的会话标识符 |
+| `view` | string | 否 | `routing` 返回精简 routing card；`full` 或省略返回完整结果 |
+| `lang` | string | 否 | 响应语言：`zh` 或 `en`；省略时由服务端协商 |
 
 示例：
 
 ```json
 {
   "query": "天气预报 API",
-  "limit": 10
+  "limit": 10,
+  "view": "routing",
+  "lang": "zh"
 }
 ```
 
@@ -261,6 +265,7 @@ claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --
 | `params_to_tool` | object | 是 | 传递给工具的参数字典 |
 | `session_id` | string | 否 | 用于追踪的会话标识符 |
 | `max_response_size` | number | 否 | 最大响应字节数（默认 `20480`） |
+| `respond_with` | string | 否 | `full`、`summary` 或 `fields:<JSONPath,...>`；省略时为 full |
 
 示例：
 
@@ -268,16 +273,19 @@ claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --
 {
   "tool_id": "openweathermap.weather.execute.v1",
   "search_id": "YOUR_SEARCH_ID",
-  "params_to_tool": {"city": "北京", "units": "metric"}
+  "params_to_tool": {"city": "北京", "units": "metric"},
+  "respond_with": "summary"
 }
 ```
+
+投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
 
 典型成功响应字段：
 
 - `execution_id`
-- `tool_id`
+- `tool_id`（所选投影返回时）
 - `success`
-- `result.data`
+- `result.data`，或显式请求的精简摘要字段
 - `elapsed_time_ms` 或 `execution_time`
 - `billing` / `pre_settlement_bill`（如可用）
 

--- a/docs/zh-CN/python-sdk-api.md
+++ b/docs/zh-CN/python-sdk-api.md
@@ -32,7 +32,7 @@ Call this if you create QverisClient directly and want to free network resources
 
 <a id="qveris.QverisClient.discover"></a>
 
-#### *async* discover(query: str, limit: int = 20, session_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
+#### *async* discover(query: str, limit: int = 20, session_id: str | None = None, view: Literal['routing', 'full'] | None = None, lang: Literal['zh', 'en'] | None = None) → [SearchResponse](#qveris.SearchResponse)
 
 Discover capabilities using natural language.
 
@@ -40,6 +40,8 @@ Discover capabilities using natural language.
   * **query** -- Natural-language description of the capability you want (not parameters). Example: "weather forecast API" or "search recent news".
   * **limit** -- Maximum number of tools to return (server may cap this).
   * **session_id** -- Optional correlation id.
+  * **view** -- Optional response projection. Omit for the legacy/full response.
+  * **lang** -- Optional response language; omit for server-side negotiation.
 * **返回:**
   SearchResponse containing results (tools) and search_id used for execution.
 
@@ -70,7 +72,7 @@ Deprecated alias for inspect(...).
 
 <a id="qveris.QverisClient.call"></a>
 
-#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
+#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None, respond_with: str | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
 
 Call a specific capability.
 
@@ -80,6 +82,7 @@ Call a specific capability.
   * **search_id** -- Search ID returned by discover(...) (recommended for traceability).
   * **session_id** -- Optional correlation id.
   * **max_response_size** -- Optional max response size in bytes. Large responses may be truncated.
+  * **respond_with** -- Optional server-side projection (full, summary, or fields:<JSONPath,...>).
 * **返回:**
   ToolExecutionResponse with success, result, and metadata.
 
@@ -347,7 +350,7 @@ Current API responses return category objects; legacy responses returned plain s
 
 <a id="qveris.ToolInfo"></a>
 
-### *class* qveris.ToolInfo(\*, tool_id: str, name: str | None = None, description: Any | None = None, categories: List[str | [ToolCategory](#qveris.ToolCategory)] | None = None, category: str | None = None, capabilities: List[[ToolCapability](#qveris.ToolCapability)] | None = None, provider_id: str | None = None, provider_name: str | None = None, provider_description: Any | None = None, provider_website_url: str | None = None, region: str | None = None, params: List[[ToolParameter](#qveris.ToolParameter)] | None = None, examples: ToolExamples | None = None, stats: ToolStats | None = None, billing_rule: BillingRule | None = None, expected_cost: str | float | None = None, final_score: float | None = None, score: float | None = None, why_recommended: str | None = None, has_last_execution: bool | None = None, last_execution_record: Dict[str, Any] | None = None, docs_url: str | None = None, protocol: str | None = None, \*\*extra_data: Any)
+### *class* qveris.ToolInfo(\*, tool_id: str, name: str | None = None, description: Any | None = None, capability: str | None = None, cost_class: str | None = None, reliability: str | None = None, as_of_support: bool | None = None, categories: List[str | [ToolCategory](#qveris.ToolCategory)] | None = None, category: str | None = None, capabilities: List[[ToolCapability](#qveris.ToolCapability)] | None = None, provider_id: str | None = None, provider_name: str | None = None, provider_description: Any | None = None, provider_website_url: str | None = None, region: str | None = None, params: List[[ToolParameter](#qveris.ToolParameter)] | None = None, examples: ToolExamples | None = None, stats: ToolStats | None = None, billing_rule: BillingRule | None = None, expected_cost: str | float | None = None, final_score: float | None = None, score: float | None = None, why_recommended: str | None = None, has_last_execution: bool | None = None, last_execution_record: Dict[str, Any] | None = None, docs_url: str | None = None, protocol: str | None = None, \*\*extra_data: Any)
 
 <a id="qveris.ToolParameter"></a>
 

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -190,9 +190,11 @@ Sphinx 会根据 Python 对象与 docstring 重新生成该页面，CI 同时检
 
 | 方法 | REST 端点 | 用途 |
 |------|-----------|------|
-| `discover(query, limit=20, session_id=None)` | `POST /search` | 用自然语言发现能力（免费） |
+| `discover(query, limit=20, session_id=None, view=None, lang=None)` | `POST /search` | 发现能力；`view="routing"` 返回精简 routing card（免费） |
 | `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
-| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None)` | `POST /tools/execute` | 执行能力（可能消耗积分） |
+| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None, respond_with=None)` | `POST /tools/execute` | 执行能力；可选择完整、摘要或 JSONPath 字段 |
+
+投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
 | `usage(**filters)` | `GET /auth/usage/history/v2` | 审计请求状态与扣费结果 |
 | `ledger(**filters)` | `GET /auth/credits/ledger` | 查看最终积分余额变动 |
 | `handle_tool_call(func_name, func_args, session_id=None)` | — | 把 LLM 工具调用桥接到对应的 QVeris 方法 |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ### Added
 
 - Added `qveris auth login/status/logout` using OAuth Device Authorization Grant, refresh-token rotation, revocation, and operating-system credential storage. Trusted headless hosts can explicitly opt into a user-only unencrypted config fallback. API key authentication remains fully compatible and takes precedence when configured.
+- Added opt-in server-side projections: `qveris discover --view routing [--lang zh|en]` and `qveris call --respond-with full|summary|fields:<JSONPath,...>`. Defaults remain unchanged; clients retry once without a projection only when a legacy service explicitly rejects that optional field as unknown.
 
 ## [0.8.2] - 2026-07-18
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -185,7 +185,10 @@ Search for capabilities using natural language. Each result shows the tool name,
 ```bash
 qveris discover "stock price API"
 qveris discover "translate text" --limit 10
+qveris discover "weather forecast" --view routing --lang en
 ```
+
+`--view routing` returns compact routing cards. `--view full` or omitting the flag preserves the existing complete response.
 
 ### Inspect
 
@@ -222,11 +225,19 @@ qveris call 1 --params '{"symbol": "AAPL"}' --dry-run
 # Full result (no truncation)
 qveris call 1 --params '{"symbol": "AAPL"}' --max-size -1
 
+# Compact schema/size summary with a signed full-content URL
+qveris call 1 --params '{"symbol": "AAPL"}' --respond-with summary
+
+# Select fields rooted at result.data
+qveris call 1 --params '{"symbol": "AAPL"}' --respond-with 'fields:$.price,$.currency'
+
 # Generate code snippet after call
 qveris call 1 --params '{"symbol": "AAPL"}' --codegen curl
 qveris call 1 --params '{"symbol": "AAPL"}' --codegen python
 qveris call 1 --params '{"symbol": "AAPL"}' --codegen js
 ```
+
+Projection flags are opt-in. If an older service explicitly rejects a projection field as unknown, the CLI retries once without only that field. Invalid projections are not downgraded and remain `422` errors.
 
 #### Response Truncation
 

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -120,6 +120,7 @@ async function requestJson(
         }
         if (status === 429) throw new CliError("RATE_LIMITED", errorDetail);
         const err = new CliError("API_ERROR", `HTTP ${status}: ${errorDetail || rawText}`);
+        err.status = status;
         if (jsonBody) err.responseData = jsonBody;
         throw err;
       } else {
@@ -139,6 +140,32 @@ async function requestJson(
 
     // Only reached on the retry path (success returns, errors throw above).
     await sleep(retryDelayMs ?? 0);
+  }
+}
+
+function unsupportedOptionalFields(error, allowedFields) {
+  if (error?.status !== 422 || !error.responseData) return [];
+  const body = error.responseData;
+  const candidates = Array.isArray(body.detail) ? body.detail : Array.isArray(body.details) ? body.details : [];
+  return [
+    ...new Set(
+      candidates
+        .filter((item) => item?.type === "extra_forbidden" && Array.isArray(item.loc))
+        .map((item) => item.loc.at(-1))
+        .filter((field) => typeof field === "string" && allowedFields.has(field)),
+    ),
+  ];
+}
+
+async function requestWithOptionalFieldFallback(path, options, allowedFields) {
+  try {
+    return await requestJson(path, options);
+  } catch (error) {
+    const unsupported = unsupportedOptionalFields(error, allowedFields);
+    if (unsupported.length === 0) throw error;
+    const body = { ...options.body };
+    for (const field of unsupported) delete body[field];
+    return requestJson(path, { ...options, body });
   }
 }
 
@@ -163,15 +190,26 @@ export async function discoverTools({
   baseUrl: baseUrlFlag,
   query,
   limit = 5,
+  view,
+  lang,
   timeoutMs = 30000,
 }) {
   const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
-  return requestJson("/search", {
-    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
-    baseUrl,
-    body: { query, limit },
-    timeoutMs,
-  });
+  return requestWithOptionalFieldFallback(
+    "/search",
+    {
+      credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
+      baseUrl,
+      body: {
+        query,
+        limit,
+        ...(view !== undefined && { view }),
+        ...(lang !== undefined && { lang }),
+      },
+      timeoutMs,
+    },
+    new Set(["view", "lang"]),
+  );
 }
 
 export async function inspectToolsByIds({
@@ -201,20 +239,26 @@ export async function callTool({
   discoveryId,
   parameters,
   maxResponseSize = 102400,
+  respondWith,
   timeoutMs = 120000,
 }) {
   const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
-  return requestJson("/tools/execute", {
-    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
-    baseUrl,
-    query: { tool_id: toolId },
-    body: {
-      search_id: discoveryId,
-      parameters,
-      max_response_size: maxResponseSize,
+  return requestWithOptionalFieldFallback(
+    "/tools/execute",
+    {
+      credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
+      baseUrl,
+      query: { tool_id: toolId },
+      body: {
+        search_id: discoveryId,
+        parameters,
+        max_response_size: maxResponseSize,
+        ...(respondWith !== undefined && { respond_with: respondWith }),
+      },
+      timeoutMs,
     },
-    timeoutMs,
-  });
+    new Set(["respond_with"]),
+  );
 }
 
 export async function getCredits({ apiKey, credentialProvider, baseUrl: baseUrlFlag, timeoutMs = 30000 }) {

--- a/packages/cli/src/commands/call.mjs
+++ b/packages/cli/src/commands/call.mjs
@@ -50,12 +50,20 @@ export async function runCall(idOrIndex, flags) {
 
   if (flags.dryRun) {
     if (flags.json) {
-      outputJson({ dry_run: true, tool_id: toolId, discovery_id: discoveryId, parameters, max_response_size: maxSize });
+      outputJson({
+        dry_run: true,
+        tool_id: toolId,
+        discovery_id: discoveryId,
+        parameters,
+        max_response_size: maxSize,
+        ...(flags.respondWith !== undefined && { respond_with: flags.respondWith }),
+      });
     } else {
       console.log(`\n  ${bold("Dry run")} -- would send:\n`);
       console.log(`  Tool:         ${cyan(toolId)}`);
       console.log(`  Discovery ID: ${dim(discoveryId)}`);
       console.log(`  Max size:     ${maxSize}`);
+      if (flags.respondWith !== undefined) console.log(`  Respond with: ${flags.respondWith}`);
       console.log(`  Parameters:`);
       console.log(
         JSON.stringify(parameters, null, 2)
@@ -77,6 +85,7 @@ export async function runCall(idOrIndex, flags) {
       discoveryId,
       parameters,
       maxResponseSize: maxSize,
+      respondWith: flags.respondWith,
       timeoutMs,
     });
 
@@ -95,6 +104,7 @@ export async function runCall(idOrIndex, flags) {
         discoveryId,
         parameters,
         maxResponseSize: maxSize,
+        respondWith: flags.respondWith,
       });
       console.log(`\n  ${dim("--- Code snippet (" + flags.codegen + ") ---")}\n`);
       console.log(snippet);

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -22,6 +22,8 @@ export async function runDiscover(query, flags) {
       baseUrl: resolvedBaseUrl,
       query,
       limit,
+      view: flags.view,
+      lang: flags.lang,
       timeoutMs,
     });
 

--- a/packages/cli/src/main.mjs
+++ b/packages/cli/src/main.mjs
@@ -169,9 +169,12 @@ const VALUE_FLAGS = {
   "base-url": "baseUrl",
   timeout: "timeout",
   limit: "limit",
+  view: "view",
+  lang: "lang",
   "discovery-id": "discoveryId",
   params: "params",
   "max-size": "maxSize",
+  "respond-with": "respondWith",
   codegen: "codegen",
   token: "token",
   query: "query",
@@ -312,6 +315,12 @@ function extractGlobalFlags(args) {
       case "--limit":
         flags.limit = takeNext(args, i++, arg);
         break;
+      case "--view":
+        flags.view = takeNext(args, i++, arg);
+        break;
+      case "--lang":
+        flags.lang = takeNext(args, i++, arg);
+        break;
       case "--discovery-id":
         flags.discoveryId = takeNext(args, i++, arg);
         break;
@@ -320,6 +329,9 @@ function extractGlobalFlags(args) {
         break;
       case "--max-size":
         flags.maxSize = takeNext(args, i++, arg);
+        break;
+      case "--respond-with":
+        flags.respondWith = takeNext(args, i++, arg);
         break;
       case "--codegen":
         flags.codegen = takeNext(args, i++, arg);
@@ -440,6 +452,9 @@ function printUsage(flags = {}) {
     --allow-unencrypted-storage
                            Persist OAuth tokens in the user-only config file when no keyring is available
     --timeout <seconds>    Request timeout
+    --view <routing|full>  Discover response projection
+    --lang <zh|en>         Discover response language
+    --respond-with <mode>  Call projection: full | summary | fields:<JSONPath,...>
     --target <target>      MCP target: cursor | claude-desktop | claude-code | opencode | openclaw | generic
     --output <path>        MCP config output path
     --write                Write MCP config to disk
@@ -467,8 +482,10 @@ function printUsage(flags = {}) {
     qveris init --query "weather forecast API"
     qveris init --resume --params '{"city": "London"}'
     qveris discover "weather forecast API"
+    qveris discover "weather forecast API" --view routing --lang en
     qveris inspect 1
     qveris call 1 --params '{"city": "London"}'
+    qveris call 1 --params '{"city": "London"}' --respond-with summary
     qveris call 1 --params @params.json --codegen curl
     qveris mcp configure --target cursor --write --include-key
     qveris mcp validate --target cursor

--- a/packages/cli/src/output/codegen.mjs
+++ b/packages/cli/src/output/codegen.mjs
@@ -2,30 +2,31 @@ import { resolveBaseUrl } from "../config/endpoint.mjs";
 
 export function generateSnippet(
   lang,
-  { baseUrl: baseUrlFlag, toolId, discoveryId, parameters, maxResponseSize = 20480 },
+  { baseUrl: baseUrlFlag, toolId, discoveryId, parameters, maxResponseSize = 20480, respondWith },
 ) {
   const { baseUrl } = resolveBaseUrl({ baseUrlFlag });
 
   switch (lang) {
     case "curl":
-      return generateCurl({ baseUrl, toolId, discoveryId, parameters, maxResponseSize });
+      return generateCurl({ baseUrl, toolId, discoveryId, parameters, maxResponseSize, respondWith });
     case "js":
     case "javascript":
-      return generateJs({ baseUrl, toolId, discoveryId, parameters, maxResponseSize });
+      return generateJs({ baseUrl, toolId, discoveryId, parameters, maxResponseSize, respondWith });
     case "python":
     case "py":
-      return generatePython({ baseUrl, toolId, discoveryId, parameters, maxResponseSize });
+      return generatePython({ baseUrl, toolId, discoveryId, parameters, maxResponseSize, respondWith });
     default:
       return `Unsupported language: ${lang}. Use: curl, js, python`;
   }
 }
 
-function generateCurl({ baseUrl, toolId, discoveryId, parameters, maxResponseSize }) {
+function generateCurl({ baseUrl, toolId, discoveryId, parameters, maxResponseSize, respondWith }) {
   const body = JSON.stringify(
     {
       search_id: discoveryId,
       parameters,
       max_response_size: maxResponseSize,
+      ...(respondWith !== undefined && { respond_with: respondWith }),
     },
     null,
     2,
@@ -40,7 +41,7 @@ ${body}
 EOF`;
 }
 
-function generateJs({ baseUrl, toolId, discoveryId, parameters, maxResponseSize }) {
+function generateJs({ baseUrl, toolId, discoveryId, parameters, maxResponseSize, respondWith }) {
   const paramsStr = JSON.stringify(parameters, null, 4);
   return `const resp = await fetch(
   "${baseUrl}/tools/execute?tool_id=${toolId}",
@@ -54,6 +55,7 @@ function generateJs({ baseUrl, toolId, discoveryId, parameters, maxResponseSize 
       search_id: "${discoveryId}",
       parameters: ${paramsStr},
       max_response_size: ${maxResponseSize},
+      ${respondWith === undefined ? "" : `respond_with: ${JSON.stringify(respondWith)},`}
     }),
   }
 );
@@ -61,7 +63,7 @@ const data = await resp.json();
 console.log(data);`;
 }
 
-function generatePython({ baseUrl, toolId, discoveryId, parameters, maxResponseSize }) {
+function generatePython({ baseUrl, toolId, discoveryId, parameters, maxResponseSize, respondWith }) {
   const paramsStr = JSON.stringify(parameters, null, 8);
   return `import os
 import requests
@@ -74,6 +76,7 @@ resp = requests.post(
         "search_id": "${discoveryId}",
         "parameters": ${paramsStr},
         "max_response_size": ${maxResponseSize},
+        ${respondWith === undefined ? "" : `"respond_with": ${JSON.stringify(respondWith)},`}
     },
     timeout=60,
 )

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -129,6 +129,92 @@ test("API client maps discover, inspect, call, credits, usage, and ledger endpoi
   ]);
 });
 
+test("API client passes projections and retries once when a legacy service rejects optional fields", async () => {
+  const discoverBodies = [];
+  await withMockFetch(
+    (_url, options) => {
+      const body = JSON.parse(options.body);
+      discoverBodies.push(body);
+      if (discoverBodies.length === 1) {
+        return jsonResponse(
+          {
+            detail: [
+              { type: "extra_forbidden", loc: ["body", "view"] },
+              { type: "extra_forbidden", loc: ["body", "lang"] },
+            ],
+          },
+          { status: 422 },
+        );
+      }
+      return jsonResponse({ search_id: "search-1", results: [] });
+    },
+    () =>
+      discoverTools({
+        apiKey: "sk-test",
+        baseUrl: "https://unit.test/api/v1",
+        query: "weather",
+        view: "routing",
+        lang: "en",
+      }),
+  );
+  assert.deepEqual(discoverBodies, [
+    { query: "weather", limit: 5, view: "routing", lang: "en" },
+    { query: "weather", limit: 5 },
+  ]);
+
+  const callBodies = [];
+  await withMockFetch(
+    (_url, options) => {
+      const body = JSON.parse(options.body);
+      callBodies.push(body);
+      if (callBodies.length === 1) {
+        return jsonResponse({ detail: [{ type: "extra_forbidden", loc: ["body", "respond_with"] }] }, { status: 422 });
+      }
+      return jsonResponse({ execution_id: "exec-1", success: true, result: { data: {} } });
+    },
+    () =>
+      callTool({
+        apiKey: "sk-test",
+        baseUrl: "https://unit.test/api/v1",
+        toolId: "weather-tool",
+        discoveryId: "search-1",
+        parameters: {},
+        respondWith: "summary",
+      }),
+  );
+  assert.deepEqual(callBodies, [
+    {
+      search_id: "search-1",
+      parameters: {},
+      max_response_size: 102400,
+      respond_with: "summary",
+    },
+    { search_id: "search-1", parameters: {}, max_response_size: 102400 },
+  ]);
+});
+
+test("API client does not downgrade invalid projections", async () => {
+  let requests = 0;
+  await assert.rejects(
+    withMockFetch(
+      () => {
+        requests += 1;
+        return jsonResponse({ details: [{ type: "value_error", loc: ["body", "respond_with"] }] }, { status: 422 });
+      },
+      () =>
+        callTool({
+          apiKey: "sk-test",
+          baseUrl: "https://unit.test/api/v1",
+          toolId: "weather-tool",
+          parameters: {},
+          respondWith: "fields:",
+        }),
+    ),
+    (error) => error instanceof CliError && error.status === 422,
+  );
+  assert.equal(requests, 1);
+});
+
 test("API client gets async credentials for the configured resource", async () => {
   const contexts = [];
   const credentialProvider = {

--- a/packages/cli/test/core.test.mjs
+++ b/packages/cli/test/core.test.mjs
@@ -222,5 +222,10 @@ test("code generation covers curl, JavaScript, Python, and unsupported languages
     assert.match(generateSnippet("js", input), /https:\/\/flag\.test\/api\/v1\/tools\/execute/);
     assert.match(generateSnippet("python", input), /https:\/\/flag\.test\/api\/v1\/tools\/execute/);
     assert.match(generateSnippet("ruby", input), /Unsupported language/);
+
+    const projectedInput = { ...input, respondWith: "summary" };
+    assert.match(generateSnippet("curl", projectedInput), /"respond_with": "summary"/);
+    assert.match(generateSnippet("js", projectedInput), /respond_with: "summary"/);
+    assert.match(generateSnippet("python", projectedInput), /"respond_with": "summary"/);
   });
 });

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added `view` / `lang` discover options and `respondWith` call projection support, including typed routing cards and summary/field result shapes. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field.
+
 ## [0.5.0] - 2026-07-18
 
 ### Added

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -82,9 +82,9 @@ never pass through the SDK.
 
 | Method | Billed | Returns | Notes |
 | --- | --- | --- | --- |
-| `discover(query, options?)` | Free | `SearchResponse` | `options`: `limit`, `sessionId`, `timeoutMs`. Results carry `why_recommended`, `expected_cost`, `stats`. |
+| `discover(query, options?)` | Free | `SearchResponse` | `options`: `limit`, `sessionId`, `view`, `lang`, `timeoutMs`. `view: 'routing'` returns compact routing cards; omitted/default is full. |
 | `inspect(toolIds, options?)` | Free | `SearchResponse` | `toolIds` is one id or an array; `options`: `searchId`, `sessionId`, `timeoutMs`. An empty array resolves locally with no request. |
-| `call(toolId, options)` | Credits | `ExecuteResponse` | `options`: `parameters` (required), `searchId`, `maxResponseSize`, `sessionId`, `timeoutMs`. |
+| `call(toolId, options)` | Credits | `ExecuteResponse` | `options`: `parameters` (required), `searchId`, `maxResponseSize`, `respondWith`, `sessionId`, `timeoutMs`. `respondWith` accepts `full`, `summary`, or `fields:<JSONPath,...>`. |
 | `credits()` | Free | `CreditsResponse` | Current balance and bucket details. |
 | `usage(filters?)` | Free | `UsageEventsResponse` | Request-level audit; filter by `execution_id`, `search_id`, dates, `summary`, `limit`. |
 | `ledger(filters?)` | Free | `CreditsLedgerResponse` | Settled credit movements; filter by `direction`, dates, `summary`, `limit`. |
@@ -95,6 +95,8 @@ Key response fields:
 
 - **`SearchResponse`** — `search_id`, `total`, `results: ToolInfo[]` (`tool_id`, `name`, `description`, `params`, `examples.sample_parameters`, `stats.success_rate`, `stats.avg_execution_time_ms`, `expected_cost`, `why_recommended`).
 - **`ExecuteResponse`** — `execution_id`, `success`, `result`, `billing` (pre-settlement estimate; the final charge is in `usage()` / `ledger()`).
+
+Projection options are never sent unless explicitly configured. If a legacy service returns `422 extra_forbidden` for an optional projection field, the SDK retries once without that field; validation errors for an invalid projection are returned unchanged.
 
 All types are exported from the package root (`import type { SearchResponse, ExecuteResponse, ToolInfo } from '@qverisai/sdk'`).
 

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -239,6 +239,58 @@ describe('Qveris client', () => {
     expect(tool.why_recommended).toContain('semantic and keyword');
   });
 
+  it('discover passes routing projection and language', async () => {
+    const fetchMock = mockFetch({
+      search_id: 'search-routing',
+      total: 1,
+      results: [
+        {
+          tool_id: 'weather.forecast.v1',
+          capability: 'Current weather by location',
+          cost_class: 'low',
+          reliability: 'A',
+          as_of_support: false,
+        },
+      ],
+    });
+    globalThis.fetch = fetchMock;
+
+    const response = await new Qveris({ apiKey: API_KEY }).discover('weather', {
+      view: 'routing',
+      lang: 'en',
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      query: 'weather',
+      view: 'routing',
+      lang: 'en',
+    });
+    expect(response.results[0].capability).toBe('Current weather by location');
+  });
+
+  it('discover retries once without projection fields rejected by a legacy service', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            detail: [
+              { type: 'extra_forbidden', loc: ['body', 'view'], msg: 'Extra inputs are not permitted' },
+              { type: 'extra_forbidden', loc: ['body', 'lang'], msg: 'Extra inputs are not permitted' },
+            ],
+          },
+          422,
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse(SAMPLE_DISCOVER_RESPONSE));
+    globalThis.fetch = fetchMock;
+
+    await new Qveris({ apiKey: API_KEY }).discover('weather', { view: 'routing', lang: 'en' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ query: 'weather' });
+  });
+
   it('inspect posts tool_ids and search_id, coercing a single string id', async () => {
     const fetchMock = mockFetch({
       search_id: 'search-123',
@@ -304,6 +356,81 @@ describe('Qveris client', () => {
     expect(response.execution_id).toBe('exec-123');
     expect(response.billing?.list_amount_credits).toBe(3);
     expect(response.billing?.charge_lines?.[0].component_key).toBe('request');
+  });
+
+  it('call passes summary projection and accepts its compact response shape', async () => {
+    const fetchMock = mockFetch({
+      execution_id: 'exec-summary',
+      success: true,
+      result: {
+        respond_with: 'summary',
+        content_schema: { type: 'object' },
+        summary: { size_bytes: 4096, row_count: 1, fields: ['temperature'] },
+        full_content_file_url: 'https://oss.qveris.ai/result.json',
+      },
+    });
+    globalThis.fetch = fetchMock;
+
+    const response = await new Qveris({ apiKey: API_KEY }).call('weather.forecast.v1', {
+      parameters: { city: 'London' },
+      respondWith: 'summary',
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      parameters: { city: 'London' },
+      search_id: null,
+      respond_with: 'summary',
+    });
+    expect(response.result).toMatchObject({ respond_with: 'summary' });
+  });
+
+  it('call retries without respond_with only when a legacy service rejects the extra field', async () => {
+    const success = {
+      execution_id: 'exec-full',
+      success: true,
+      result: { data: { temperature: 18 } },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'], msg: 'Extra input' }],
+          },
+          422,
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse(success));
+    globalThis.fetch = fetchMock;
+
+    await new Qveris({ apiKey: API_KEY }).call('weather.forecast.v1', {
+      parameters: { city: 'London' },
+      respondWith: 'summary',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      parameters: { city: 'London' },
+      search_id: null,
+    });
+  });
+
+  it('call does not downgrade an invalid projection response', async () => {
+    const fetchMock = mockFetch(
+      {
+        details: [{ type: 'value_error', loc: ['body', 'respond_with'], msg: 'Invalid projection' }],
+      },
+      422,
+    );
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      new Qveris({ apiKey: API_KEY }).call('weather.forecast.v1', {
+        parameters: {},
+        respondWith: 'fields:',
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('unwraps {status: "success", data: ...} envelopes', async () => {

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -96,12 +96,33 @@ function normalizeBaseUrl(value: string): string {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const EXECUTE_TIMEOUT_MS = 120_000;
 
+function unsupportedOptionalFields(error: unknown, allowedFields: ReadonlySet<string>): string[] {
+  if (!(error instanceof QverisApiError) || error.status !== 422 || !error.details) return [];
+  const body = error.details as Record<string, unknown>;
+  const candidates = Array.isArray(body.detail) ? body.detail : Array.isArray(body.details) ? body.details : [];
+  const fields = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const item = candidate as Record<string, unknown>;
+    const loc = Array.isArray(item.loc) ? item.loc : [];
+    const field = loc.at(-1);
+    if (item.type === 'extra_forbidden' && typeof field === 'string' && allowedFields.has(field)) {
+      fields.add(field);
+    }
+  }
+  return [...fields];
+}
+
 /** Options for {@link Qveris.discover}. */
 export interface DiscoverOptions {
   /** Maximum number of results (1-100, server default 20) */
   limit?: number;
   /** Session identifier for tracking */
   sessionId?: string;
+  /** Response projection. Omit for the legacy/full response shape. */
+  view?: 'routing' | 'full';
+  /** Response language. Omit to use server-side language negotiation. */
+  lang?: 'zh' | 'en';
   /** Per-request timeout override in milliseconds */
   timeoutMs?: number;
 }
@@ -126,6 +147,8 @@ export interface CallOptions {
   sessionId?: string;
   /** Max response bytes before truncation (-1 for no limit, server default 20480) */
   maxResponseSize?: number;
+  /** Server-side result projection. Omit for the legacy/full response. */
+  respondWith?: 'full' | 'summary' | `fields:${string}`;
   /** Per-request timeout override in milliseconds (default 120s) */
   timeoutMs?: number;
 }
@@ -207,17 +230,21 @@ export class Qveris {
    * Discover capabilities from a natural-language query. Free.
    */
   async discover(query: string, options: DiscoverOptions = {}): Promise<SearchResponse> {
-    return this.request<SearchResponse>(
-      'discover',
-      'POST',
-      '/search',
-      {
-        query,
-        ...(options.limit !== undefined && { limit: options.limit }),
-        ...(options.sessionId !== undefined && { session_id: options.sessionId }),
-      },
-      options.timeoutMs,
-    );
+    const body: Record<string, unknown> = {
+      query,
+      ...(options.limit !== undefined && { limit: options.limit }),
+      ...(options.sessionId !== undefined && { session_id: options.sessionId }),
+      ...(options.view !== undefined && { view: options.view }),
+      ...(options.lang !== undefined && { lang: options.lang }),
+    };
+    try {
+      return await this.request<SearchResponse>('discover', 'POST', '/search', body, options.timeoutMs);
+    } catch (error) {
+      const unsupported = unsupportedOptionalFields(error, new Set(['view', 'lang']));
+      if (unsupported.length === 0) throw error;
+      for (const field of unsupported) delete body[field];
+      return this.request<SearchResponse>('discover', 'POST', '/search', body, options.timeoutMs);
+    }
   }
 
   /**
@@ -247,20 +274,25 @@ export class Qveris {
    * final charges are reflected in usage() and ledger().
    */
   async call(toolId: string, options: CallOptions): Promise<ExecuteResponse> {
-    return this.request<ExecuteResponse>(
-      'call',
-      'POST',
-      `/tools/execute?tool_id=${encodeURIComponent(toolId)}`,
-      {
-        parameters: options.parameters,
-        search_id: options.searchId ?? null,
-        ...(options.sessionId !== undefined && { session_id: options.sessionId }),
-        ...(options.maxResponseSize !== undefined && {
-          max_response_size: options.maxResponseSize,
-        }),
-      },
-      options.timeoutMs ?? EXECUTE_TIMEOUT_MS,
-    );
+    const endpoint = `/tools/execute?tool_id=${encodeURIComponent(toolId)}`;
+    const body: Record<string, unknown> = {
+      parameters: options.parameters,
+      search_id: options.searchId ?? null,
+      ...(options.sessionId !== undefined && { session_id: options.sessionId }),
+      ...(options.maxResponseSize !== undefined && {
+        max_response_size: options.maxResponseSize,
+      }),
+      ...(options.respondWith !== undefined && { respond_with: options.respondWith }),
+    };
+    const timeoutMs = options.timeoutMs ?? EXECUTE_TIMEOUT_MS;
+    try {
+      return await this.request<ExecuteResponse>('call', 'POST', endpoint, body, timeoutMs);
+    } catch (error) {
+      const unsupported = unsupportedOptionalFields(error, new Set(['respond_with']));
+      if (unsupported.length === 0) throw error;
+      delete body.respond_with;
+      return this.request<ExecuteResponse>('call', 'POST', endpoint, body, timeoutMs);
+    }
   }
 
   /** Get current credit balance and bucket details. */

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -29,6 +29,12 @@ export interface SearchRequest {
 
   /** Session identifier for tracking user sessions. */
   session_id?: string;
+
+  /** Response projection. Omit for the legacy/full response shape. */
+  view?: 'routing' | 'full';
+
+  /** Response language. Omit to use server-side language negotiation. */
+  lang?: 'zh' | 'en';
 }
 
 /**
@@ -155,10 +161,22 @@ export interface ToolInfo {
   tool_id: string;
 
   /** Human-readable display name */
-  name: string;
+  name?: string;
 
   /** Detailed description of what the tool does */
-  description: string;
+  description?: string;
+
+  /** Compact capability label returned by the routing projection. */
+  capability?: string;
+
+  /** Compact cost class returned by the routing projection. */
+  cost_class?: string;
+
+  /** Compact reliability grade returned by the routing projection. */
+  reliability?: string;
+
+  /** Whether the capability supports point-in-time requests. */
+  as_of_support?: boolean;
 
   /** Tool categories/tags: category objects, or plain strings in legacy responses */
   categories?: Array<string | ToolCategory>;
@@ -312,6 +330,9 @@ export interface ExecuteRequest {
    * @default 20480 (20KB)
    */
   max_response_size?: number;
+
+  /** Server-side result projection. Omit for the legacy/full response. */
+  respond_with?: 'full' | 'summary' | `fields:${string}`;
 }
 
 /**
@@ -349,10 +370,39 @@ export interface ExecuteResultTruncated {
   content_schema?: Record<string, unknown>;
 }
 
+/** Compact result returned by `respond_with: "summary"`. */
+export interface ExecuteResultSummary {
+  respond_with: 'summary';
+  content_schema?: Record<string, unknown>;
+  summary?: {
+    size_bytes?: number;
+    row_count?: number;
+    fields?: string[];
+    [key: string]: unknown;
+  };
+  full_content_file_url?: string;
+  message?: string;
+}
+
+/** Selected result fields returned by a `fields:<JSONPath,...>` projection. */
+export interface ExecuteResultFields {
+  respond_with: `fields:${string}`;
+  data?: unknown;
+}
+
 /**
  * Union type for execution results (either full data or truncated).
  */
-export type ExecuteResult = ExecuteResultData | ExecuteResultTruncated;
+export type ExecuteResult =
+  | ExecuteResultData
+  | ExecuteResultTruncated
+  | ExecuteResultSummary
+  | ExecuteResultFields
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
 
 /**
  * Response from the Execute Tool API.
@@ -362,10 +412,10 @@ export interface ExecuteResponse {
   execution_id: string;
 
   /** The tool that was executed */
-  tool_id: string;
+  tool_id?: string;
 
   /** The parameters that were passed to the tool */
-  parameters: Record<string, unknown>;
+  parameters?: Record<string, unknown>;
 
   /**
    * The execution result.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added optional `view` / `lang` inputs to `discover` and `respond_with` to `call`, with typed routing/summary response support. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field.
+
 ## [0.11.0] - 2026-07-18
 
 ### Added

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -101,13 +101,17 @@ Discover available tools based on natural language queries.
 | `query` | string | ✓ | Natural language description of the capability you need |
 | `limit` | number | | Max results to return (1-100, default: 20) |
 | `session_id` | string | | Session identifier for tracking (auto-generated if omitted) |
+| `view` | string | | `routing` for compact routing cards; `full` or omitted for complete results |
+| `lang` | string | | Response language: `zh` or `en`; omitted uses server negotiation |
 
 **Example:**
 
 ```json
 {
   "query": "send email notification",
-  "limit": 10
+  "limit": 10,
+  "view": "routing",
+  "lang": "en"
 }
 ```
 
@@ -141,6 +145,7 @@ Call a discovered tool with specific parameters.
 | `params_to_tool` | object | ✓ | A dictionary of parameters to pass to the tool |
 | `session_id` | string | | Session identifier (auto-generated if omitted) |
 | `max_response_size` | number | | Max response size in bytes (default: 20480) |
+| `respond_with` | string | | `full`, `summary`, or `fields:<JSONPath,...>`; omitted defaults to full |
 
 **Example:**
 
@@ -148,11 +153,14 @@ Call a discovered tool with specific parameters.
 {
   "tool_id": "openweathermap.weather.execute.v1",
   "search_id": "abcd1234-ab12-ab12-ab12-abcdef123456",
-  "params_to_tool": {"city": "London", "units": "metric"}
+  "params_to_tool": {"city": "London", "units": "metric"},
+  "respond_with": "summary"
 }
 ```
 
 The `call` response may include compact pre-settlement `billing`. Final charge status should be checked with `usage_history` or `credits_ledger`.
+
+Projection inputs are opt-in. If an older service explicitly rejects one as an unknown field, the MCP server retries once without only that field. Invalid projection errors remain errors and are never silently downgraded.
 
 ### `usage_history`
 

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -160,6 +160,47 @@ describe('QverisClient', () => {
       );
     });
 
+    it('should pass routing projection and language', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ search_id: 'search-routing', results: [] }),
+      });
+
+      await client.searchTools({ query: 'weather', view: 'routing', lang: 'en' });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({ query: 'weather', view: 'routing', lang: 'en' }),
+        }),
+      );
+    });
+
+    it('should retry once without projection fields rejected by a legacy service', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          headers: new Headers(),
+          json: async () => ({
+            detail: [
+              { type: 'extra_forbidden', loc: ['body', 'view'] },
+              { type: 'extra_forbidden', loc: ['body', 'lang'] },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ search_id: 'search-full', results: [] }),
+        });
+
+      await client.searchTools({ query: 'weather', view: 'routing', lang: 'en' });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][1].body).toBe(JSON.stringify({ query: 'weather' }));
+    });
+
     it('should throw ApiError on non-OK response', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: false,
@@ -406,6 +447,78 @@ describe('QverisClient', () => {
       );
 
       expect(result).toEqual(mockResponse);
+    });
+
+    it('should pass summary projection', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          execution_id: 'exec-summary',
+          success: true,
+          result: { respond_with: 'summary' },
+        }),
+      });
+
+      await client.executeTool('weather-tool', {
+        search_id: 'search-123',
+        parameters: { city: 'London' },
+        respond_with: 'summary',
+      });
+
+      expect(fetchMock.mock.calls[0][1].body).toBe(
+        JSON.stringify({
+          search_id: 'search-123',
+          parameters: { city: 'London' },
+          respond_with: 'summary',
+        }),
+      );
+    });
+
+    it('should retry without respond_with only for a legacy extra-field rejection', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          headers: new Headers(),
+          json: async () => ({
+            detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'] }],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ execution_id: 'exec-full', success: true, result: { data: {} } }),
+        });
+
+      await client.executeTool('weather-tool', {
+        search_id: 'search-123',
+        parameters: {},
+        respond_with: 'summary',
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][1].body).toBe(JSON.stringify({ search_id: 'search-123', parameters: {} }));
+    });
+
+    it('should not downgrade an invalid projection', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: new Headers(),
+        json: async () => ({
+          details: [{ type: 'value_error', loc: ['body', 'respond_with'] }],
+        }),
+      });
+
+      await expect(
+        client.executeTool('weather-tool', {
+          search_id: 'search-123',
+          parameters: {},
+          respond_with: 'fields:',
+        }),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('should URL-encode tool_id', async () => {

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -278,7 +278,15 @@ export class QverisClient {
    * This is the Discover action and is free.
    */
   async searchTools(request: SearchRequest): Promise<SearchResponse> {
-    return this.request<SearchResponse>('discover', 'POST', '/search', request);
+    const body: Record<string, unknown> = { ...request };
+    try {
+      return await this.request<SearchResponse>('discover', 'POST', '/search', body);
+    } catch (error) {
+      const unsupported = unsupportedOptionalFields(error, new Set(['view', 'lang']));
+      if (unsupported.length === 0) throw error;
+      for (const field of unsupported) delete body[field];
+      return this.request<SearchResponse>('discover', 'POST', '/search', body);
+    }
   }
 
   /**
@@ -296,7 +304,15 @@ export class QverisClient {
    */
   async executeTool(toolId: string, request: ExecuteRequest): Promise<ExecuteResponse> {
     const endpoint = `/tools/execute?tool_id=${encodeURIComponent(toolId)}`;
-    return this.request<ExecuteResponse>('call', 'POST', endpoint, request, EXECUTE_TIMEOUT_MS);
+    const body: Record<string, unknown> = { ...request };
+    try {
+      return await this.request<ExecuteResponse>('call', 'POST', endpoint, body, EXECUTE_TIMEOUT_MS);
+    } catch (error) {
+      const unsupported = unsupportedOptionalFields(error, new Set(['respond_with']));
+      if (unsupported.length === 0) throw error;
+      delete body.respond_with;
+      return this.request<ExecuteResponse>('call', 'POST', endpoint, body, EXECUTE_TIMEOUT_MS);
+    }
   }
 
   /**
@@ -380,6 +396,23 @@ function extractRequestId(response: Response): string | undefined {
 
 function isApiError(error: unknown): error is ApiError {
   return typeof error === 'object' && error !== null && 'status' in error && 'message' in error;
+}
+
+function unsupportedOptionalFields(error: unknown, allowedFields: ReadonlySet<string>): string[] {
+  if (!isApiError(error) || error.status !== 422 || !error.details) return [];
+  const body = error.details as Record<string, unknown>;
+  const candidates = Array.isArray(body.detail) ? body.detail : Array.isArray(body.details) ? body.details : [];
+  const fields = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const item = candidate as Record<string, unknown>;
+    const loc = Array.isArray(item.loc) ? item.loc : [];
+    const field = loc.at(-1);
+    if (item.type === 'extra_forbidden' && typeof field === 'string' && allowedFields.has(field)) {
+      fields.add(field);
+    }
+  }
+  return [...fields];
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {

--- a/packages/mcp/src/tools/execute.test.ts
+++ b/packages/mcp/src/tools/execute.test.ts
@@ -36,6 +36,11 @@ describe('call (execute_tool)', () => {
       expect(executeToolSchema.properties.session_id.type).toBe('string');
       expect(executeToolSchema.required).not.toContain('session_id');
     });
+
+    it('should define respond_with as an optional projection', () => {
+      expect(executeToolSchema.properties.respond_with.pattern).toBe('^(full|summary|fields:.+)$');
+      expect(executeToolSchema.required).not.toContain('respond_with');
+    });
   });
 
   describe('executeExecuteTool', () => {
@@ -138,6 +143,33 @@ describe('call (execute_tool)', () => {
         session_id: 'default-session',
         parameters: {},
         max_response_size: 102400,
+      });
+    });
+
+    it('should pass respond_with when provided', async () => {
+      executeToolMock.mockResolvedValueOnce({
+        execution_id: 'exec-summary',
+        success: true,
+        result: { respond_with: 'summary' },
+      });
+
+      await executeExecuteTool(
+        mockClient,
+        {
+          tool_id: 'tool-1',
+          search_id: 'search-123',
+          params_to_tool: {},
+          respond_with: 'summary',
+        },
+        'default-session',
+      );
+
+      expect(executeToolMock).toHaveBeenCalledWith('tool-1', {
+        search_id: 'search-123',
+        session_id: 'default-session',
+        parameters: {},
+        max_response_size: undefined,
+        respond_with: 'summary',
       });
     });
 

--- a/packages/mcp/src/tools/execute.ts
+++ b/packages/mcp/src/tools/execute.ts
@@ -50,6 +50,9 @@ export interface ExecuteToolInput {
    * @minimum -1 (-1 means no limit)
    */
   max_response_size?: number;
+
+  /** Server-side result projection. Omit for the legacy/full response. */
+  respond_with?: 'full' | 'summary' | `fields:${string}`;
 }
 
 /**
@@ -90,6 +93,11 @@ export const executeToolSchema = {
         'Use -1 for no limit. Default is 20480 (20KB).',
       default: 20480,
     },
+    respond_with: {
+      type: 'string',
+      pattern: '^(full|summary|fields:.+)$',
+      description: 'Server-side result projection: "full", "summary", or "fields:<JSONPath,...>". Omit for full.',
+    },
   },
   required: ['tool_id', 'search_id', 'params_to_tool'],
 };
@@ -117,6 +125,7 @@ export async function executeExecuteTool(
     session_id: input.session_id ?? defaultSessionId,
     parameters: input.params_to_tool,
     max_response_size: input.max_response_size,
+    ...(input.respond_with !== undefined && { respond_with: input.respond_with }),
   });
 
   return response;

--- a/packages/mcp/src/tools/search.test.ts
+++ b/packages/mcp/src/tools/search.test.ts
@@ -28,6 +28,13 @@ describe('discover (search_tools)', () => {
       expect(searchToolsSchema.properties.session_id.type).toBe('string');
       expect(searchToolsSchema.required).not.toContain('session_id');
     });
+
+    it('should define optional routing projection and response language', () => {
+      expect(searchToolsSchema.properties.view.enum).toEqual(['routing', 'full']);
+      expect(searchToolsSchema.properties.lang.enum).toEqual(['zh', 'en']);
+      expect(searchToolsSchema.required).not.toContain('view');
+      expect(searchToolsSchema.required).not.toContain('lang');
+    });
   });
 
   describe('executeSearchTools', () => {
@@ -98,6 +105,20 @@ describe('discover (search_tools)', () => {
         query: 'test',
         limit: 20,
         session_id: 'custom-session',
+      });
+    });
+
+    it('should pass routing projection and response language when provided', async () => {
+      searchToolsMock.mockResolvedValueOnce({ search_id: 'search-routing', results: [] });
+
+      await executeSearchTools(mockClient, { query: 'weather', view: 'routing', lang: 'en' }, 'default-session');
+
+      expect(searchToolsMock).toHaveBeenCalledWith({
+        query: 'weather',
+        limit: 20,
+        session_id: 'default-session',
+        view: 'routing',
+        lang: 'en',
       });
     });
 

--- a/packages/mcp/src/tools/search.ts
+++ b/packages/mcp/src/tools/search.ts
@@ -37,6 +37,12 @@ export interface SearchToolsInput {
    * If not provided, the server will use an auto-generated session ID.
    */
   session_id?: string;
+
+  /** Compact routing cards or the complete result shape. Omit for full. */
+  view?: 'routing' | 'full';
+
+  /** Response language. Omit to use server-side negotiation. */
+  lang?: 'zh' | 'en';
 }
 
 /**
@@ -66,6 +72,17 @@ export const searchToolsSchema = {
         'Session identifier for tracking user sessions. ' +
         'If not provided, an auto-generated session ID will be used.',
     },
+    view: {
+      type: 'string',
+      enum: ['routing', 'full'],
+      description:
+        'Response projection. "routing" returns compact routing cards; "full" or omitted returns complete results.',
+    },
+    lang: {
+      type: 'string',
+      enum: ['zh', 'en'],
+      description: 'Response language. Omit to use server-side language negotiation.',
+    },
   },
   required: ['query'],
 };
@@ -87,6 +104,8 @@ export async function executeSearchTools(
     query: input.query,
     limit: input.limit ?? 20,
     session_id: input.session_id ?? defaultSessionId,
+    ...(input.view !== undefined && { view: input.view }),
+    ...(input.lang !== undefined && { lang: input.lang }),
   });
 
   return response;

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -29,6 +29,12 @@ export interface SearchRequest {
 
   /** Session identifier for tracking user sessions. */
   session_id?: string;
+
+  /** Response projection. Omit for the legacy/full response shape. */
+  view?: 'routing' | 'full';
+
+  /** Response language. Omit to use server-side language negotiation. */
+  lang?: 'zh' | 'en';
 }
 
 /**
@@ -155,10 +161,22 @@ export interface ToolInfo {
   tool_id: string;
 
   /** Human-readable display name */
-  name: string;
+  name?: string;
 
   /** Detailed description of what the tool does */
-  description: string;
+  description?: string;
+
+  /** Compact capability label returned by the routing projection. */
+  capability?: string;
+
+  /** Compact cost class returned by the routing projection. */
+  cost_class?: string;
+
+  /** Compact reliability grade returned by the routing projection. */
+  reliability?: string;
+
+  /** Whether the capability supports point-in-time requests. */
+  as_of_support?: boolean;
 
   /** Tool categories/tags: category objects, or plain strings in legacy responses */
   categories?: Array<string | ToolCategory>;
@@ -312,6 +330,9 @@ export interface ExecuteRequest {
    * @default 20480 (20KB)
    */
   max_response_size?: number;
+
+  /** Server-side result projection. Omit for the legacy/full response. */
+  respond_with?: 'full' | 'summary' | `fields:${string}`;
 }
 
 /**
@@ -349,10 +370,39 @@ export interface ExecuteResultTruncated {
   content_schema?: Record<string, unknown>;
 }
 
+/** Compact result returned by `respond_with: "summary"`. */
+export interface ExecuteResultSummary {
+  respond_with: 'summary';
+  content_schema?: Record<string, unknown>;
+  summary?: {
+    size_bytes?: number;
+    row_count?: number;
+    fields?: string[];
+    [key: string]: unknown;
+  };
+  full_content_file_url?: string;
+  message?: string;
+}
+
+/** Selected result fields returned by a `fields:<JSONPath,...>` projection. */
+export interface ExecuteResultFields {
+  respond_with: `fields:${string}`;
+  data?: unknown;
+}
+
 /**
  * Union type for execution results (either full data or truncated).
  */
-export type ExecuteResult = ExecuteResultData | ExecuteResultTruncated;
+export type ExecuteResult =
+  | ExecuteResultData
+  | ExecuteResultTruncated
+  | ExecuteResultSummary
+  | ExecuteResultFields
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
 
 /**
  * Response from the Execute Tool API.
@@ -362,10 +412,10 @@ export interface ExecuteResponse {
   execution_id: string;
 
   /** The tool that was executed */
-  tool_id: string;
+  tool_id?: string;
 
   /** The parameters that were passed to the tool */
-  parameters: Record<string, unknown>;
+  parameters?: Record<string, unknown>;
 
   /**
    * The execution result.

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added `view` / `lang` discover arguments and `respond_with` call projection support, including compact routing-card model fields. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field.
+
 ## [0.4.0] - 2026-07-18
 
 ### Added

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -94,13 +94,15 @@ First-class typed APIs:
 
 | Method | REST endpoint | Purpose |
 |--------|---------------|---------|
-| `discover(query, ...)` | `POST /search` | Find capabilities with natural language |
+| `discover(query, ..., view=None, lang=None)` | `POST /search` | Find capabilities; `view="routing"` returns compact routing cards |
 | `inspect(tool_ids, ...)` | `POST /tools/by-ids` | Fetch full capability metadata |
-| `call(tool_id, parameters, ...)` | `POST /tools/execute` | Execute a selected capability |
+| `call(tool_id, parameters, ..., respond_with=None)` | `POST /tools/execute` | Execute a selected capability; request `full`, `summary`, or selected JSONPath fields |
 | `usage(...)` | `GET /auth/usage/history/v2` | Audit request status and charge outcome |
 | `ledger(...)` | `GET /auth/credits/ledger` | Inspect final credit balance movements |
 
 Backward-compatible aliases remain available: `search_tools`, `get_tools_by_ids`, and `execute_tool`.
+
+Projection arguments are never sent unless explicitly configured. If a legacy service returns `422 extra_forbidden` for an optional projection field, the SDK retries once without that field; invalid projection errors are returned unchanged.
 
 ## Typed Models
 

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -25,7 +25,7 @@ Debug logs redact the token value.
 """
 
 import json
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Literal, Optional, Set, Tuple, Union
 
 import httpx
 
@@ -55,6 +55,30 @@ def _pre_settlement_credits(response: ToolExecutionResponse) -> Optional[float]:
     if response.billing is not None and response.billing.list_amount_credits is not None:
         return response.billing.list_amount_credits
     return response.cost
+
+
+def _unsupported_optional_fields(response: httpx.Response, allowed_fields: Set[str]) -> Set[str]:
+    """Return optional fields rejected by a legacy service as extra inputs."""
+    if response.status_code != 422:
+        return set()
+    try:
+        body = response.json()
+    except json.JSONDecodeError:
+        return set()
+    if not isinstance(body, dict):
+        return set()
+    candidates = body.get("detail") if isinstance(body.get("detail"), list) else body.get("details")
+    if not isinstance(candidates, list):
+        return set()
+    unsupported: Set[str] = set()
+    for item in candidates:
+        if not isinstance(item, dict) or item.get("type") != "extra_forbidden":
+            continue
+        loc = item.get("loc")
+        field = loc[-1] if isinstance(loc, list) and loc else None
+        if isinstance(field, str) and field in allowed_fields:
+            unsupported.add(field)
+    return unsupported
 
 
 class QverisClient:
@@ -109,6 +133,22 @@ class QverisClient:
             return {"headers": headers}
 
         return await self._retry.send(self.client, method, endpoint, prepare_attempt=prepare_attempt, **kwargs)
+
+    async def _send_with_optional_field_fallback(
+        self,
+        method: str,
+        endpoint: str,
+        payload: Dict[str, Any],
+        allowed_fields: Set[str],
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Retry once without optional fields rejected by a legacy service."""
+        response = await self._send(method, endpoint, json=payload, **kwargs)
+        unsupported = _unsupported_optional_fields(response, allowed_fields)
+        if not unsupported:
+            return response
+        fallback_payload = {key: value for key, value in payload.items() if key not in unsupported}
+        return await self._send(method, endpoint, json=fallback_payload, **kwargs)
 
     @property
     def rate_limit_retries(self) -> int:
@@ -180,7 +220,14 @@ class QverisClient:
         """
         await self.client.aclose()
 
-    async def discover(self, query: str, limit: int = 20, session_id: Optional[str] = None) -> SearchResponse:
+    async def discover(
+        self,
+        query: str,
+        limit: int = 20,
+        session_id: Optional[str] = None,
+        view: Optional[Literal["routing", "full"]] = None,
+        lang: Optional[Literal["zh", "en"]] = None,
+    ) -> SearchResponse:
         """
         Discover capabilities using natural language.
 
@@ -189,6 +236,8 @@ class QverisClient:
                    Example: "weather forecast API" or "search recent news".
             limit: Maximum number of tools to return (server may cap this).
             session_id: Optional correlation id.
+            view: Optional response projection. Omit for the legacy/full response.
+            lang: Optional response language; omit for server-side negotiation.
 
         Returns:
             `SearchResponse` containing `results` (tools) and `search_id` used for execution.
@@ -201,6 +250,10 @@ class QverisClient:
 
         if session_id:
             payload["session_id"] = session_id
+        if view is not None:
+            payload["view"] = view
+        if lang is not None:
+            payload["lang"] = lang
 
         with start_span(
             "qveris.discover",
@@ -210,7 +263,7 @@ class QverisClient:
             self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
             self._debug_headers()
 
-            response = await self._send("POST", "search", json=payload)
+            response = await self._send_with_optional_field_fallback("POST", "search", payload, {"view", "lang"})
 
             self._debug(f"[Qveris API] Response status: {response.status_code}")
             data = self._unwrap_envelope(self._parse_response_json(response))
@@ -296,6 +349,7 @@ class QverisClient:
         search_id: Optional[str] = None,
         session_id: Optional[str] = None,
         max_response_size: Optional[int] = None,
+        respond_with: Optional[str] = None,
     ) -> ToolExecutionResponse:
         """
         Call a specific capability.
@@ -306,6 +360,7 @@ class QverisClient:
             search_id: Search ID returned by `discover(...)` (recommended for traceability).
             session_id: Optional correlation id.
             max_response_size: Optional max response size in bytes. Large responses may be truncated.
+            respond_with: Optional server-side projection (`full`, `summary`, or `fields:<JSONPath,...>`).
 
         Returns:
             `ToolExecutionResponse` with `success`, `result`, and metadata.
@@ -324,6 +379,9 @@ class QverisClient:
         if max_response_size is not None:
             payload["max_response_size"] = max_response_size
 
+        if respond_with is not None:
+            payload["respond_with"] = respond_with
+
         with start_span(
             "qveris.call",
             {
@@ -337,11 +395,12 @@ class QverisClient:
             self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
             self._debug_headers()
 
-            response = await self._send(
+            response = await self._send_with_optional_field_fallback(
                 "POST",
                 "tools/execute",
+                payload,
+                {"respond_with"},
                 params={"tool_id": tool_id},
-                json=payload,
             )
 
             self._debug(f"[Qveris API] Response status: {response.status_code}")

--- a/packages/python-sdk/qveris/types.py
+++ b/packages/python-sdk/qveris/types.py
@@ -108,6 +108,10 @@ class ToolInfo(QverisModel):
     tool_id: str
     name: Optional[str] = None
     description: Optional[Any] = None
+    capability: Optional[str] = None
+    cost_class: Optional[str] = None
+    reliability: Optional[str] = None
+    as_of_support: Optional[bool] = None
     categories: Optional[List[Union[str, ToolCategory]]] = None
     category: Optional[str] = None
     capabilities: Optional[List[ToolCapability]] = None

--- a/packages/python-sdk/tests/test_client_contracts.py
+++ b/packages/python-sdk/tests/test_client_contracts.py
@@ -325,6 +325,36 @@ async def test_discover_contract_parses_tool_quality_and_billing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_discover_projection_passes_through_and_retries_legacy_rejection_once() -> None:
+    payloads = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payloads.append(json.loads(request.content))
+        if len(payloads) == 1:
+            return httpx.Response(
+                422,
+                json={
+                    "detail": [
+                        {"type": "extra_forbidden", "loc": ["body", "view"]},
+                        {"type": "extra_forbidden", "loc": ["body", "lang"]},
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"search_id": "search-full", "results": []})
+
+    client = make_client(handler)
+    try:
+        await client.discover("weather", view="routing", lang="en")
+    finally:
+        await client.close()
+
+    assert payloads == [
+        {"query": "weather", "limit": 20, "view": "routing", "lang": "en"},
+        {"query": "weather", "limit": 20},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_inspect_contract_posts_tool_ids() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
@@ -414,6 +444,91 @@ async def test_call_contract_parses_execution_outcome_and_billing() -> None:
     assert response.billing.list_amount_credits == 3
     assert response.billing.charge_lines is not None
     assert response.billing.charge_lines[0].component_key == "request"
+
+
+@pytest.mark.asyncio
+async def test_call_summary_projection_passes_through_and_parses_compact_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content) == {
+            "parameters": {"city": "London"},
+            "search_id": "search-123",
+            "respond_with": "summary",
+        }
+        return httpx.Response(
+            200,
+            json={
+                "execution_id": "exec-summary",
+                "success": True,
+                "result": {
+                    "respond_with": "summary",
+                    "content_schema": {"type": "object"},
+                    "summary": {"size_bytes": 4096, "row_count": 1, "fields": ["temperature"]},
+                    "full_content_file_url": "https://oss.qveris.ai/result.json",
+                },
+            },
+        )
+
+    client = make_client(handler)
+    try:
+        response = await client.call(
+            "weather.forecast.v1",
+            {"city": "London"},
+            search_id="search-123",
+            respond_with="summary",
+        )
+    finally:
+        await client.close()
+
+    assert response.result["respond_with"] == "summary"
+    assert response.tool_id is None
+    assert response.parameters is None
+
+
+@pytest.mark.asyncio
+async def test_call_projection_retries_only_legacy_extra_field_rejection() -> None:
+    payloads = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payloads.append(json.loads(request.content))
+        if len(payloads) == 1:
+            return httpx.Response(
+                422,
+                json={"detail": [{"type": "extra_forbidden", "loc": ["body", "respond_with"]}]},
+            )
+        return httpx.Response(200, json={"execution_id": "exec-full", "success": True, "result": {"data": {}}})
+
+    client = make_client(handler)
+    try:
+        await client.call("weather.forecast.v1", {}, respond_with="summary")
+    finally:
+        await client.close()
+
+    assert payloads == [
+        {"parameters": {}, "respond_with": "summary"},
+        {"parameters": {}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_call_invalid_projection_is_not_downgraded() -> None:
+    requests = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(
+            422,
+            json={"details": [{"type": "value_error", "loc": ["body", "respond_with"]}]},
+        )
+
+    client = make_client(handler)
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.call("weather.forecast.v1", {}, respond_with="fields:")
+    finally:
+        await client.close()
+
+    assert requests == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add opt-in `view` and `lang` projections to discovery across CLI, MCP, JavaScript, and Python clients
- add opt-in `respond_with` projections to tool calls with typed summary and fields response shapes
- retry once without only legacy-server-rejected optional projection fields
- keep invalid projection requests as errors and preserve existing defaults
- update package guides, changelogs, localized docs, and generated API references

## Validation

- full repository test suite: CLI 130, MCP 176, JavaScript SDK 63, OpenClaw 78, Python SDK 146 passed and 1 skipped
- lint, typecheck, and build
- locale consistency and generated docs checks
- production smoke for routing discovery and summarized weather execution

Relates to #120
