### PR TITLE
feat: add benchmark model adapter

### DIFF
--- a/benchmarks/discover-call/README.md
+++ b/benchmarks/discover-call/README.md
@@ -127,6 +127,30 @@ print prompts, keys, tokens, or provider error bodies to stdout. A first-result
 heuristic adapter is included only as a transport example; it does not construct
 parameters and is not an official model result.
 
+### Claude CLI adapter
+
+`adapters/claude-cli.mjs` is the reference adapter for authenticated Claude CLI
+installations. It passes the canonical system message as `--system-prompt`, the
+canonical user message on stdin, and the unchanged response schema through
+`--json-schema`. Safe mode disables project customizations, tools are disabled,
+and sessions are not persisted, so the run measures only the supplied benchmark
+messages. Use a full model identifier rather than an alias:
+
+```bash
+node src/run.mjs \
+  --model claude-sonnet-5 \
+  --adapter node \
+  --adapter-arg "$PWD/adapters/claude-cli.mjs" \
+  --adapter-revision adapter-git-sha \
+  --tasks tasks/v2.jsonl \
+  --trials 3 \
+  --execute \
+  --output runs/claude-sonnet-5.jsonl
+```
+
+The adapter uses the CLI's existing authentication and never receives
+`QVERIS_API_KEY` (the harness strips it from the adapter environment).
+
 ## Publication rules
 
 An official result must include:

--- a/benchmarks/discover-call/adapters/claude-cli.mjs
+++ b/benchmarks/discover-call/adapters/claude-cli.mjs
@@ -51,6 +51,11 @@ export function parseClaudeEnvelope(stdout) {
     throw new Error('Claude CLI returned invalid JSON');
   }
 
+  if (!isObject(envelope)) throw new Error('Claude CLI returned an invalid result envelope');
+  if (envelope.is_error === true || (typeof envelope.subtype === 'string' && envelope.subtype.startsWith('error'))) {
+    throw new Error('Claude CLI reported an unsuccessful result');
+  }
+
   if (isObject(envelope.structured_output)) return envelope.structured_output;
   if (isObject(envelope.structuredOutput)) return envelope.structuredOutput;
   if (typeof envelope.result === 'string') {
@@ -73,14 +78,47 @@ export async function invokeClaude(payload) {
       env: process.env,
     });
     let output = '';
+    let outputExceeded = false;
+    let forwardedSignal;
+    let forceKillTimer;
+
+    const cleanup = () => {
+      process.off('SIGINT', forwardSigint);
+      process.off('SIGTERM', forwardSigterm);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+    };
+    const forwardSignal = (signal) => {
+      if (forwardedSignal) return;
+      forwardedSignal = signal;
+      child.kill(signal);
+      forceKillTimer = setTimeout(() => child.kill('SIGKILL'), 1_000);
+      forceKillTimer.unref();
+    };
+    const forwardSigint = () => forwardSignal('SIGINT');
+    const forwardSigterm = () => forwardSignal('SIGTERM');
+    process.once('SIGINT', forwardSigint);
+    process.once('SIGTERM', forwardSigterm);
+
     child.stdin.on('error', () => {});
     child.stdout.on('data', (chunk) => {
       output += chunk;
-      if (output.length > 1_000_000) child.kill('SIGTERM');
+      if (output.length > 1_000_000 && !outputExceeded) {
+        outputExceeded = true;
+        child.kill('SIGTERM');
+      }
     });
     child.stderr.resume();
-    child.on('error', () => reject(new Error('Claude CLI could not be started')));
+    child.on('error', () => {
+      cleanup();
+      reject(new Error('Claude CLI could not be started'));
+    });
     child.on('close', (code) => {
+      cleanup();
+      if (forwardedSignal) {
+        process.kill(process.pid, forwardedSignal);
+        return;
+      }
+      if (outputExceeded) return reject(new Error('Claude CLI output exceeded the adapter limit'));
       if (code === 0) resolve(output);
       else reject(new Error('Claude CLI invocation failed'));
     });

--- a/benchmarks/discover-call/adapters/claude-cli.mjs
+++ b/benchmarks/discover-call/adapters/claude-cli.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export function buildClaudeInvocation(payload) {
+  if (!payload || typeof payload !== 'object') throw new Error('Invalid adapter payload');
+  if (typeof payload.model !== 'string' || !payload.model.trim()) throw new Error('Missing model');
+  if (!Array.isArray(payload.messages) || payload.messages.length !== 2) {
+    throw new Error('Expected exactly two canonical messages');
+  }
+  const [systemMessage, userMessage] = payload.messages;
+  if (systemMessage?.role !== 'system' || typeof systemMessage.content !== 'string') {
+    throw new Error('Missing canonical system message');
+  }
+  if (userMessage?.role !== 'user' || typeof userMessage.content !== 'string') {
+    throw new Error('Missing canonical user message');
+  }
+  if (!payload.response_schema || typeof payload.response_schema !== 'object') {
+    throw new Error('Missing response schema');
+  }
+
+  return {
+    command: process.env.CLAUDE_BIN || 'claude',
+    args: [
+      '--print',
+      '--model',
+      payload.model,
+      '--system-prompt',
+      systemMessage.content,
+      '--json-schema',
+      JSON.stringify(payload.response_schema),
+      '--output-format',
+      'json',
+      '--tools',
+      '',
+      '--safe-mode',
+      '--no-session-persistence',
+      '--permission-mode',
+      'dontAsk',
+    ],
+    stdin: userMessage.content,
+  };
+}
+
+export function parseClaudeEnvelope(stdout) {
+  let envelope;
+  try {
+    envelope = JSON.parse(stdout.trim());
+  } catch {
+    throw new Error('Claude CLI returned invalid JSON');
+  }
+
+  if (isObject(envelope.structured_output)) return envelope.structured_output;
+  if (isObject(envelope.structuredOutput)) return envelope.structuredOutput;
+  if (typeof envelope.result === 'string') {
+    try {
+      const result = JSON.parse(envelope.result);
+      if (isObject(result)) return result;
+    } catch {
+      // Fall through to the generic, non-sensitive error below.
+    }
+  }
+  throw new Error('Claude CLI returned no structured output');
+}
+
+export async function invokeClaude(payload) {
+  const invocation = buildClaudeInvocation(payload);
+  const stdout = await new Promise((resolve, reject) => {
+    const child = spawn(invocation.command, invocation.args, {
+      shell: false,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: process.env,
+    });
+    let output = '';
+    child.stdin.on('error', () => {});
+    child.stdout.on('data', (chunk) => {
+      output += chunk;
+      if (output.length > 1_000_000) child.kill('SIGTERM');
+    });
+    child.stderr.resume();
+    child.on('error', () => reject(new Error('Claude CLI could not be started')));
+    child.on('close', (code) => {
+      if (code === 0) resolve(output);
+      else reject(new Error('Claude CLI invocation failed'));
+    });
+    child.stdin.end(invocation.stdin);
+  });
+  return parseClaudeEnvelope(stdout);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+  const result = await invokeClaude(JSON.parse(input));
+  process.stdout.write(JSON.stringify(result));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/discover-call/test/adapter.test.mjs
+++ b/benchmarks/discover-call/test/adapter.test.mjs
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { createProcessAdapter, main } from '../src/run.mjs';
+import { buildClaudeInvocation, parseClaudeEnvelope } from '../adapters/claude-cli.mjs';
 
 const adapterPath = resolve(fileURLToPath(new URL('../adapters/first-result.mjs', import.meta.url)));
 
@@ -51,4 +52,39 @@ test('process adapter reports startup failures without an unhandled stdin error'
     timeoutMs: 5_000,
   });
   await assert.rejects(invoke({ stage: 'select' }), /could not be started/);
+});
+
+test('Claude adapter preserves canonical messages and response schema', () => {
+  const payload = {
+    model: 'claude-sonnet-5',
+    messages: [
+      { role: 'system', content: 'Return one grounded tool.' },
+      { role: 'user', content: '{"input":"unchanged"}' },
+    ],
+    response_schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['tool_id'],
+      properties: { tool_id: { type: 'string' } },
+    },
+  };
+
+  const invocation = buildClaudeInvocation(payload);
+  assert.equal(invocation.stdin, payload.messages[1].content);
+  assert.equal(invocation.args[invocation.args.indexOf('--system-prompt') + 1], payload.messages[0].content);
+  assert.deepEqual(JSON.parse(invocation.args[invocation.args.indexOf('--json-schema') + 1]), payload.response_schema);
+  assert.equal(invocation.args[invocation.args.indexOf('--model') + 1], payload.model);
+  assert.equal(invocation.args.includes('--safe-mode'), true);
+  assert.equal(invocation.args[invocation.args.indexOf('--tools') + 1], '');
+});
+
+test('Claude adapter extracts only structured model output', () => {
+  assert.deepEqual(
+    parseClaudeEnvelope(JSON.stringify({ type: 'result', structured_output: { tool_id: 'weather.forecast' } })),
+    { tool_id: 'weather.forecast' },
+  );
+  assert.deepEqual(parseClaudeEnvelope(JSON.stringify({ result: '{"parameters":{"city":"London"}}' })), {
+    parameters: { city: 'London' },
+  });
+  assert.throws(() => parseClaudeEnvelope(JSON.stringify({ result: 'not-json' })), /no structured output/);
 });

--- a/benchmarks/discover-call/test/adapter.test.mjs
+++ b/benchmarks/discover-call/test/adapter.test.mjs
@@ -86,5 +86,13 @@ test('Claude adapter extracts only structured model output', () => {
   assert.deepEqual(parseClaudeEnvelope(JSON.stringify({ result: '{"parameters":{"city":"London"}}' })), {
     parameters: { city: 'London' },
   });
+  assert.throws(
+    () => parseClaudeEnvelope(JSON.stringify({ type: 'result', subtype: 'error_during_execution', is_error: true })),
+    /unsuccessful result/,
+  );
+  assert.throws(
+    () => parseClaudeEnvelope(JSON.stringify({ type: 'result', is_error: true, result: '{"tool_id":"wrong"}' })),
+    /unsuccessful result/,
+  );
   assert.throws(() => parseClaudeEnvelope(JSON.stringify({ result: 'not-json' })), /no structured output/);
 });


### PR DESCRIPTION
## Summary

- add a Claude CLI adapter for the public discover-to-call benchmark
- preserve the canonical benchmark messages and JSON response schema
- disable tools, project customizations, and session persistence during model decisions
- document a reproducible v2 task-set invocation with an immutable model identifier

## Validation

- benchmark tests: 22 passed
- task and fixture validation passed for v1 and v2
- v2 online preflight completed 18 of 18 discover and inspect workflows with the transport-only adapter

This PR prepares the formal run. Raw model results are intentionally not included until an authenticated model session can execute all 18 tasks with three trials and real calls.

Relates to #163
