### PR TITLE
chore(release): prepare coordinated client releases

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,10 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-23
+
 ### Added
 
-- Added `qveris auth login/status/logout` using OAuth Device Authorization Grant, refresh-token rotation, revocation, and operating-system credential storage. Trusted headless hosts can explicitly opt into a user-only unencrypted config fallback. API key authentication remains fully compatible and takes precedence when configured.
-- Added opt-in server-side projections: `qveris discover --view routing [--lang zh|en]` and `qveris call --respond-with full|summary|fields:<JSONPath,...>`. Defaults remain unchanged; clients retry once without a projection only when a legacy service explicitly rejects that optional field as unknown.
+- Added `qveris auth login/status/logout` using OAuth Device Authorization Grant, refresh-token rotation, revocation, and operating-system credential storage. Trusted headless hosts can explicitly opt into a user-only unencrypted config fallback. API key authentication remains fully compatible and takes precedence when configured. ([#250])
+- Added opt-in server-side projections: `qveris discover --view routing [--lang zh|en]` and `qveris call --respond-with full|summary|fields:<JSONPath,...>`. Defaults remain unchanged; clients retry once without a projection only when a legacy service explicitly rejects that optional field as unknown. ([#256])
 - Added `qveris probe` for zero-cost parameter validation and quotes without executing a capability. ([#259])
 
 ## [0.8.2] - 2026-07-18
@@ -88,7 +90,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Initial release: `discover` / `inspect` / `call` from the terminal against the QVeris API.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.2...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.9.0...HEAD
+[0.9.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.2...cli-v0.9.0
 [0.8.2]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.1...cli-v0.8.2
 [0.8.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.0...cli-v0.8.1
 [0.8.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.7.0...cli-v0.8.0
@@ -102,6 +105,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#221]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/221
 [#226]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/226
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
+[#250]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/250
+[#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256
 [#204]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/204
 [#161]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/161
 [#144]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/144

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/cli",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "MIT",
       "bin": {
         "qveris": "bin/qveris.mjs"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "QVeris CLI for agent capability discovery, inspection, calling, and audit",
   "type": "module",
   "bin": {

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -6,9 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-23
+
 ### Added
 
-- Added `view` / `lang` discover options and `respondWith` call projection support, including typed routing cards and summary/field result shapes. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field.
+- Added `view` / `lang` discover options and `respondWith` call projection support, including typed routing cards and summary/field result shapes. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field. ([#256])
 - Added `Qveris.probe()` with typed schema, quote, coverage, and sample results. ([#259])
 
 ## [0.5.0] - 2026-07-18
@@ -48,7 +50,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - `0.1.x` under this npm name was an early MCP-focused SDK, superseded by `@qverisai/mcp`.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.5.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.6.0...HEAD
+[0.6.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.5.0...js-sdk-v0.6.0
 [0.5.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.4.0...js-sdk-v0.5.0
 [0.4.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.3.0...js-sdk-v0.4.0
 [0.3.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.2.0...js-sdk-v0.3.0
@@ -62,3 +65,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#134]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/134
 [#106]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/106
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
+[#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/sdk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "QVeris TypeScript SDK for agent capability discovery, inspection, calling, and audit",
   "keywords": [
     "qveris",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,9 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-23
+
 ### Added
 
-- Added optional `view` / `lang` inputs to `discover` and `respond_with` to `call`, with typed routing/summary response support. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field.
+- Added optional `view` / `lang` inputs to `discover` and `respond_with` to `call`, with typed routing/summary response support. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field. ([#256])
 - Added the canonical `probe` tool with typed zero-cost schema/quote results and an MCP `outputSchema`. ([#259])
 
 ## [0.11.0] - 2026-07-18
@@ -127,7 +129,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Handle empty/non-JSON success responses gracefully; `params_to_tool` documented as an object.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.11.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.12.0...HEAD
+[0.12.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.11.0...mcp-v0.12.0
 [0.11.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.10.0...mcp-v0.11.0
 [0.10.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.9.0...mcp-v0.10.0
 [0.9.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.8.0...mcp-v0.9.0
@@ -169,3 +172,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#9]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/9
 [#8]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/8
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
+[#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.QVerisAI/mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "subfolder": "packages/mcp"
   },
   "websiteUrl": "https://qveris.ai",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "transport": {
         "type": "stdio"
       },

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,9 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-23
+
 ### Added
 
-- Added `view` / `lang` discover arguments and `respond_with` call projection support, including compact routing-card model fields. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field.
+- Added `view` / `lang` discover arguments and `respond_with` call projection support, including compact routing-card model fields. Defaults remain full; an explicit legacy `422 extra_forbidden` response triggers one retry without only the rejected optional field. ([#256])
 - Added `QverisClient.probe()` with typed zero-cost schema, quote, coverage, and sample results. ([#259])
 
 ## [0.4.0] - 2026-07-18
@@ -73,7 +75,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Generated OpenAPI contract models with drift CI. ([#48])
 - `Agent` runtime: LLM tool loop over the QVeris workflow with streaming events.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.4.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.5.0...HEAD
+[0.5.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.4.0...python-sdk-v0.5.0
 [0.4.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.2...python-sdk-v0.4.0
 [0.3.2]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.1...python-sdk-v0.3.2
 [0.3.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.3.0...python-sdk-v0.3.1
@@ -100,3 +103,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#48]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/48
 [#34]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/34
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
+[#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qveris"
-version = "0.4.0"
+version = "0.5.0"
 description = "QVeris Python SDK for agent capability discovery, calling, and audit"
 requires-python = ">=3.8"
 license = "MIT"

--- a/packages/python-sdk/uv.lock
+++ b/packages/python-sdk/uv.lock
@@ -6025,7 +6025,7 @@ wheels = [
 
 [[package]]
 name = "qveris"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- prepare `@qverisai/cli` 0.9.0
- prepare `@qverisai/mcp` 0.12.0 and align `server.json`
- prepare `@qverisai/sdk` 0.6.0
- prepare the `qveris` Python SDK 0.5.0
- include device authorization, response projections, and zero-cost probe support in the coordinated release

## Stack

- base: #260
- merge after #256 and #260
- merge #261 before the release stack

## Validation

- full repository tests: 601 passed, 1 skipped
- lint, typecheck, and build
- `npm pack --dry-run` for CLI, MCP, and JavaScript SDK
- `uv lock --check` and Python wheel/sdist build
- public documentation boundary scans
