### PR TITLE
build: coordinate client package releases

### DIFF
--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -1,0 +1,42 @@
+name: Coordinated release tools
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/release-tools.yml"
+      - "RELEASING.md"
+      - "package.json"
+      - "scripts/release-client-packages.mjs"
+      - "scripts/release-client-packages.test.mjs"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/release-tools.yml"
+      - "RELEASING.md"
+      - "package.json"
+      - "scripts/release-client-packages.mjs"
+      - "scripts/release-client-packages.test.mjs"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Test coordinated release tooling
+        run: npm run test:release-clients

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - ".github/workflows/release-tools.yml"
+      - ".github/workflows/cli-publish.yml"
+      - ".github/workflows/js-sdk-publish.yml"
+      - ".github/workflows/mcp-publish.yml"
+      - ".github/workflows/python-sdk-publish.yml"
       - "RELEASING.md"
       - "package.json"
       - "scripts/release-client-packages.mjs"
@@ -12,6 +16,10 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/release-tools.yml"
+      - ".github/workflows/cli-publish.yml"
+      - ".github/workflows/js-sdk-publish.yml"
+      - ".github/workflows/mcp-publish.yml"
+      - ".github/workflows/python-sdk-publish.yml"
       - "RELEASING.md"
       - "package.json"
       - "scripts/release-client-packages.mjs"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,12 +23,13 @@ Each package releases independently via an annotated git tag; the matching GitHu
    ```
 
    The coordinator validates package versions, npm/Python lockfiles, MCP
-   `server.json`, and each versioned Changelog section. It creates annotated
-   tags from those sections, pushes exactly one tag at a time, confirms the
-   matching Actions run is registered before pushing the next tag, and then
-   waits for all four publish workflows. If a run is interrupted, rerun the
-   command: tags already present at the release commit are verified and
-   resumed instead of recreated. Use `-- --no-watch` only when another
+   `server.json`, each versioned Changelog section, and that every configured
+   publish workflow exists and listens for the matching tag prefix. It creates
+   annotated tags from those sections, pushes exactly one tag at a time,
+   confirms the matching Actions run is registered before pushing the next
+   tag, and then waits for all four publish workflows. If a run is interrupted,
+   rerun the command: tags already present at the release commit are verified
+   and resumed instead of recreated. Use `-- --no-watch` only when another
    operator will monitor the registered runs.
 
    For an individual package release, **tag the release commit with an

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,26 @@ Each package releases independently via an annotated git tag; the matching GitHu
 1. **Bump the version** in the package's `package.json` / `pyproject.toml`.
 2. **Update `CHANGELOG.md`** (Keep a Changelog format): move the `## [Unreleased]` notes into a new `## [<version>] - <YYYY-MM-DD>` section, and update the compare links at the bottom. The publish workflow **fails if `CHANGELOG.md` has no `## [<version>]` section** for the tagged version.
 3. Open a PR with the bump + changelog; merge it.
-4. **Tag the release commit with an annotated tag**, using the new CHANGELOG section as the tag message — this is what powers the release Highlights (#101), so the changelog and the tag stay one source of truth:
+4. For a coordinated CLI, MCP, JavaScript SDK, and Python SDK release, check the merged metadata and publish all four tags from an up-to-date, clean `main`:
+
+   ```bash
+   npm run release:clients:check
+   npm run release:clients:publish
+   ```
+
+   The coordinator validates package versions, npm/Python lockfiles, MCP
+   `server.json`, and each versioned Changelog section. It creates annotated
+   tags from those sections, pushes exactly one tag at a time, confirms the
+   matching Actions run is registered before pushing the next tag, and then
+   waits for all four publish workflows. If a run is interrupted, rerun the
+   command: tags already present at the release commit are verified and
+   resumed instead of recreated. Use `-- --no-watch` only when another
+   operator will monitor the registered runs.
+
+   For an individual package release, **tag the release commit with an
+   annotated tag**, using the new Changelog section as the tag message — this
+   is what powers the release Highlights (#101), so the Changelog and the tag
+   stay one source of truth:
 
    ```bash
    # Example for the MCP server (stops at the next heading or the link
@@ -26,11 +45,10 @@ Each package releases independently via an annotated git tag; the matching GitHu
    git push origin mcp-v0.8.0
    ```
 
-   > **Releasing several packages at once? Push each tag separately.** GitHub
-   > does not create push events when more than three tags are pushed in a
-   > single `git push`, so a combined push silently triggers **zero** publish
-   > workflows (observed in the 2026-07-09 release wave). One `git push origin
-   > <tag>` per package is the reliable form.
+   > **Never batch release tags in one push.** GitHub does not create push
+   > events when more than three tags are pushed in a single `git push`, so a
+   > combined push can trigger **zero** publish workflows. The coordinated
+   > command above enforces one push event per tag.
 
 5. The publish workflow verifies **version == tag** and **CHANGELOG has the section**, runs the full test matrix (ubuntu + windows), publishes, and creates the GitHub Release. Python releases also require a current `uv.lock`. MCP releases verify `server.json` uses the same version and publish its metadata to the official MCP Registry with GitHub OIDC.
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
     "install:all": "npm --prefix packages/cli ci && npm --prefix packages/mcp ci && npm --prefix packages/js-sdk ci && npm --prefix packages/openclaw-qveris-plugin ci && npm run install:py",
     "install:py": "cd packages/python-sdk && uv sync --frozen --extra dev",
     "build": "npm --prefix packages/mcp run build && npm --prefix packages/js-sdk run build && npm --prefix packages/openclaw-qveris-plugin run build",
+    "release:clients:check": "node scripts/release-client-packages.mjs check",
+    "release:clients:publish": "node scripts/release-client-packages.mjs publish",
+    "test:release-clients": "node --test scripts/release-client-packages.test.mjs",
     "typecheck": "npm --prefix packages/mcp run typecheck && npm --prefix packages/js-sdk run typecheck && npm --prefix packages/openclaw-qveris-plugin run typecheck",
-    "test": "npm --prefix packages/cli test && npm --prefix packages/mcp test && npm --prefix packages/js-sdk test && npm --prefix packages/openclaw-qveris-plugin test && npm run test:py",
+    "test": "npm --prefix packages/cli test && npm --prefix packages/mcp test && npm --prefix packages/js-sdk test && npm --prefix packages/openclaw-qveris-plugin test && npm run test:py && npm run test:release-clients",
     "test:py": "cd packages/python-sdk && uv run --frozen --extra dev pytest -q",
     "lint": "npm --prefix packages/cli run lint && npm --prefix packages/mcp run lint && npm --prefix packages/js-sdk run lint && npm --prefix packages/openclaw-qveris-plugin run lint && npm run lint:py",
     "lint:py": "cd packages/python-sdk && uv run --frozen --extra dev ruff check qveris tests examples docs-api && uv run --frozen --extra dev ruff format --check qveris tests examples docs-api"

--- a/scripts/release-client-packages.mjs
+++ b/scripts/release-client-packages.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -50,6 +50,70 @@ function read(root, path) {
 
 function readJson(root, path) {
   return JSON.parse(read(root, path));
+}
+
+export function workflowTagPatterns(content) {
+  const patterns = [];
+  let section = null;
+  let onIndent = -1;
+  let pushIndent = -1;
+  let tagsIndent = -1;
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+#.*$/, "");
+    if (!line.trim()) continue;
+    const indent = line.match(/^\s*/)[0].length;
+    const value = line.trim();
+
+    if (indent === 0) {
+      section = value === "on:" ? "on" : null;
+      onIndent = section ? indent : -1;
+      pushIndent = -1;
+      tagsIndent = -1;
+      continue;
+    }
+    if (section === "on" && indent > onIndent && value === "push:") {
+      section = "push";
+      pushIndent = indent;
+      tagsIndent = -1;
+      continue;
+    }
+    if (section === "push" && indent <= pushIndent) {
+      section = indent > onIndent && value === "push:" ? "push" : "on";
+      tagsIndent = -1;
+    }
+    if (section === "push" && indent > pushIndent && value === "tags:") {
+      section = "tags";
+      tagsIndent = indent;
+      continue;
+    }
+    if (section === "tags") {
+      if (indent <= tagsIndent) {
+        section = indent > pushIndent ? "push" : indent > onIndent ? "on" : null;
+        continue;
+      }
+      const match = value.match(/^-\s*["']?([^"'#]+?)["']?\s*$/);
+      if (match) patterns.push(match[1]);
+    }
+  }
+  return patterns;
+}
+
+function validateWorkflow(root, client, errors) {
+  const workflowPath = `.github/workflows/${client.workflow}`;
+  if (!existsSync(resolve(root, workflowPath))) {
+    errors.push(`${client.label}: publish workflow is missing: ${workflowPath}`);
+    return;
+  }
+  const expected = `${client.tagPrefix}*`;
+  const patterns = workflowTagPatterns(read(root, workflowPath));
+  if (!patterns.includes(expected)) {
+    errors.push(
+      `${client.label}: ${workflowPath} must listen for push.tags pattern ${JSON.stringify(expected)} (found: ${
+        patterns.length ? patterns.map(JSON.stringify).join(", ") : "none"
+      })`,
+    );
+  }
 }
 
 function packageVersionFromUvLock(content) {
@@ -112,6 +176,7 @@ function validatePythonMetadata(root, client, errors) {
 export function readReleasePlan(root = ROOT) {
   const errors = [];
   const releases = CLIENTS.map((client) => {
+    validateWorkflow(root, client, errors);
     const version =
       client.manifest === "npm"
         ? validateNpmMetadata(root, client, errors)

--- a/scripts/release-client-packages.mjs
+++ b/scripts/release-client-packages.mjs
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export const CLIENTS = [
+  {
+    key: "cli",
+    label: "CLI",
+    directory: "packages/cli",
+    tagPrefix: "cli-v",
+    workflow: "cli-publish.yml",
+    manifest: "npm",
+  },
+  {
+    key: "mcp",
+    label: "MCP",
+    directory: "packages/mcp",
+    tagPrefix: "mcp-v",
+    workflow: "mcp-publish.yml",
+    manifest: "npm",
+    serverManifest: true,
+  },
+  {
+    key: "js-sdk",
+    label: "JavaScript SDK",
+    directory: "packages/js-sdk",
+    tagPrefix: "js-sdk-v",
+    workflow: "js-sdk-publish.yml",
+    manifest: "npm",
+  },
+  {
+    key: "python-sdk",
+    label: "Python SDK",
+    directory: "packages/python-sdk",
+    tagPrefix: "python-sdk-v",
+    workflow: "python-sdk-publish.yml",
+    manifest: "python",
+  },
+];
+
+function read(root, path) {
+  return readFileSync(resolve(root, path), "utf8");
+}
+
+function readJson(root, path) {
+  return JSON.parse(read(root, path));
+}
+
+function packageVersionFromUvLock(content) {
+  const section = content
+    .split(/^\[\[package\]\]\s*$/m)
+    .find((candidate) => /^name = "qveris"\s*$/m.test(candidate));
+  return section?.match(/^version = "([^"]+)"\s*$/m)?.[1];
+}
+
+export function extractChangelogRelease(content, version) {
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const lines = content.split(/\r?\n/);
+  const start = lines.findIndex((line) => new RegExp(`^## \\[${escaped}\\](?:\\s+-\\s+\\d{4}-\\d{2}-\\d{2})?\\s*$`).test(line));
+  if (start < 0) return null;
+
+  const next = lines.findIndex((line, index) => index > start && /^## \[/.test(line));
+  const end = next < 0 ? lines.length : next;
+  const notes = lines.slice(start + 1, end).join("\n").trim();
+  return notes || null;
+}
+
+function validateNpmMetadata(root, client, errors) {
+  const packageJson = readJson(root, `${client.directory}/package.json`);
+  const lock = readJson(root, `${client.directory}/package-lock.json`);
+  const version = packageJson.version;
+
+  for (const [label, actual] of [
+    ["package-lock.json version", lock.version],
+    ['package-lock.json packages[""] version', lock.packages?.[""]?.version],
+  ]) {
+    if (actual !== version) errors.push(`${client.label}: ${label} (${actual ?? "missing"}) must equal ${version}`);
+  }
+
+  if (client.serverManifest) {
+    const server = readJson(root, `${client.directory}/server.json`);
+    if (server.version !== version) {
+      errors.push(`${client.label}: server.json version (${server.version ?? "missing"}) must equal ${version}`);
+    }
+    const packageVersions = (server.packages || []).map((entry) => entry.version);
+    if (packageVersions.length === 0 || packageVersions.some((candidate) => candidate !== version)) {
+      errors.push(`${client.label}: every server.json package version must equal ${version}`);
+    }
+  }
+
+  return version;
+}
+
+function validatePythonMetadata(root, client, errors) {
+  const pyproject = read(root, `${client.directory}/pyproject.toml`);
+  const version = pyproject.match(/^version = "([^"]+)"\s*$/m)?.[1];
+  const lockVersion = packageVersionFromUvLock(read(root, `${client.directory}/uv.lock`));
+
+  if (!version) errors.push(`${client.label}: pyproject.toml project version is missing`);
+  if (lockVersion !== version) {
+    errors.push(`${client.label}: uv.lock qveris version (${lockVersion ?? "missing"}) must equal ${version ?? "missing"}`);
+  }
+  return version;
+}
+
+export function readReleasePlan(root = ROOT) {
+  const errors = [];
+  const releases = CLIENTS.map((client) => {
+    const version =
+      client.manifest === "npm"
+        ? validateNpmMetadata(root, client, errors)
+        : validatePythonMetadata(root, client, errors);
+
+    if (!VERSION_RE.test(version || "")) {
+      errors.push(`${client.label}: invalid release version ${JSON.stringify(version)}`);
+    }
+
+    const changelogPath = `${client.directory}/CHANGELOG.md`;
+    const notes = version ? extractChangelogRelease(read(root, changelogPath), version) : null;
+    if (!notes) errors.push(`${client.label}: ${changelogPath} has no non-empty ## [${version}] release section`);
+
+    return {
+      ...client,
+      version,
+      tag: `${client.tagPrefix}${version}`,
+      changelogPath,
+      notes,
+    };
+  });
+
+  if (errors.length) {
+    throw new Error(`Coordinated release preflight failed:\n- ${errors.join("\n- ")}`);
+  }
+  return releases;
+}
+
+function execute(command, args, { cwd = ROOT, allowFailure = false, input, stdio = "pipe" } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    input,
+    stdio,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 && !allowFailure) {
+    const detail = String(result.stderr || result.stdout || "").trim();
+    throw new Error(`${command} ${args.join(" ")} failed${detail ? `:\n${detail}` : ""}`);
+  }
+  return result;
+}
+
+function output(command, args, options) {
+  const result = execute(command, args, options);
+  return result.status === 0 ? String(result.stdout).trim() : null;
+}
+
+function git(args, options) {
+  return output("git", args, options);
+}
+
+function localTagStatus(tag) {
+  const ref = `refs/tags/${tag}`;
+  const commit = git(["rev-list", "-n", "1", ref], { allowFailure: true });
+  if (!commit) return null;
+  return {
+    commit,
+    annotated: git(["cat-file", "-t", ref]) === "tag",
+  };
+}
+
+function remoteTagStatus(remote, tag) {
+  const directRef = `refs/tags/${tag}`;
+  const peeledRef = `${directRef}^{}`;
+  const rows = git(["ls-remote", "--tags", remote, directRef, peeledRef])
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split(/\s+/, 2));
+  if (rows.length === 0) return null;
+
+  const direct = rows.find(([, ref]) => ref === directRef)?.[0];
+  const peeled = rows.find(([, ref]) => ref === peeledRef)?.[0];
+  return {
+    commit: peeled || direct,
+    annotated: Boolean(peeled),
+  };
+}
+
+function inspectTag(remote, tag) {
+  return {
+    local: localTagStatus(tag),
+    remote: remoteTagStatus(remote, tag),
+  };
+}
+
+function assertMatchingTags(release, status) {
+  if (status.local && status.remote && status.local.commit !== status.remote.commit) {
+    throw new Error(
+      `${release.tag}: local tag points to ${status.local.commit}, but the remote tag points to ${status.remote.commit}`,
+    );
+  }
+  if (status.local && !status.local.annotated) throw new Error(`${release.tag}: local tag is not annotated`);
+  if (status.remote && !status.remote.annotated) throw new Error(`${release.tag}: remote tag is not annotated`);
+}
+
+function printPlan(releases, remote) {
+  console.log("Coordinated client release plan:\n");
+  for (const release of releases) {
+    const status = inspectTag(remote, release.tag);
+    assertMatchingTags(release, status);
+    const state = status.remote ? `released (${status.remote.commit.slice(0, 12)})` : status.local ? "local only" : "pending";
+    console.log(`- ${release.label.padEnd(14)} ${release.tag.padEnd(22)} ${state}`);
+  }
+}
+
+function assertPublishableRepository(remote) {
+  const branch = git(["symbolic-ref", "--short", "HEAD"], { allowFailure: true });
+  if (branch !== "main") throw new Error(`Publishing requires the main branch; current branch is ${branch || "detached HEAD"}`);
+
+  if (git(["status", "--porcelain"])) throw new Error("Publishing requires a clean working tree");
+
+  execute("git", ["fetch", "--quiet", remote, "main"]);
+  const head = git(["rev-parse", "HEAD"]);
+  const remoteMain = git(["rev-parse", `refs/remotes/${remote}/main`]);
+  if (head !== remoteMain) throw new Error(`HEAD (${head}) must equal ${remote}/main (${remoteMain})`);
+  return head;
+}
+
+function createAnnotatedTag(release) {
+  execute("git", ["tag", "-a", "--cleanup=verbatim", release.tag, "-F", "-"], {
+    input: `${release.notes}\n`,
+  });
+}
+
+function pushSingleTag(remote, release) {
+  execute("git", ["push", remote, `refs/tags/${release.tag}`], { stdio: "inherit" });
+}
+
+function workflowRuns(release, head) {
+  const raw = output("gh", [
+    "run",
+    "list",
+    "--workflow",
+    release.workflow,
+    "--event",
+    "push",
+    "--branch",
+    release.tag,
+    "--commit",
+    head,
+    "--limit",
+    "10",
+    "--json",
+    "databaseId,url,status,conclusion,headBranch,headSha",
+  ]);
+  return JSON.parse(raw || "[]");
+}
+
+async function waitForWorkflowRun(release, head, { attempts = 18, intervalMs = 5_000 } = {}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const run = workflowRuns(release, head).find(
+      (candidate) => candidate.headSha === head && candidate.headBranch === release.tag,
+    );
+    if (run) {
+      console.log(`  workflow registered: ${run.url}`);
+      return run;
+    }
+    if (attempt < attempts) await new Promise((resolvePromise) => setTimeout(resolvePromise, intervalMs));
+  }
+  throw new Error(`${release.tag}: ${release.workflow} did not register a push run within ${attempts * intervalMs}ms`);
+}
+
+function watchWorkflowRun(run) {
+  execute("gh", ["run", "watch", String(run.databaseId), "--exit-status"], { stdio: "inherit" });
+}
+
+export async function publishReleasePlan(releases, operations) {
+  const log = operations.log || console.log;
+  const runs = [];
+  for (const release of releases) {
+    const status = await operations.inspectTag(release);
+    operations.validateTag(release, status);
+
+    if (status.remote) {
+      if (status.remote.commit !== operations.head) {
+        throw new Error(`${release.tag}: remote tag already points to ${status.remote.commit}, not ${operations.head}`);
+      }
+      log(`\n${release.tag}: remote tag already exists; resuming workflow verification`);
+    } else {
+      if (status.local && status.local.commit !== operations.head) {
+        throw new Error(`${release.tag}: local tag already points to ${status.local.commit}, not ${operations.head}`);
+      }
+      if (!status.local) {
+        log(`\n${release.tag}: creating annotated tag`);
+        await operations.createTag(release);
+      }
+      log(`${release.tag}: pushing one tag event`);
+      await operations.pushTag(release);
+    }
+
+    // Confirm this event exists before sending the next tag push. This makes
+    // the four-package release immune to GitHub's >3-tags-per-push limit.
+    runs.push({ release, run: await operations.waitForRun(release) });
+  }
+
+  if (operations.watch) {
+    for (const { release, run } of runs) {
+      log(`\n${release.tag}: waiting for ${release.workflow}`);
+      await operations.watchRun(run);
+    }
+  }
+  return runs;
+}
+
+function usage() {
+  console.error(`Usage:
+  node scripts/release-client-packages.mjs check [--remote <name>]
+  node scripts/release-client-packages.mjs publish [--remote <name>] [--no-watch]`);
+}
+
+function parseArgs(argv) {
+  const [command, ...args] = argv;
+  let remote = "origin";
+  let watch = true;
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--remote") {
+      remote = args[++index];
+      if (!remote) throw new Error("--remote requires a value");
+    } else if (args[index] === "--no-watch") {
+      watch = false;
+    } else {
+      throw new Error(`Unknown option: ${args[index]}`);
+    }
+  }
+  if (!["check", "publish"].includes(command)) throw new Error(`Unknown command: ${command || "(missing)"}`);
+  if (command === "check" && !watch) throw new Error("--no-watch is only valid with publish");
+  return { command, remote, watch };
+}
+
+async function main() {
+  const { command, remote, watch } = parseArgs(process.argv.slice(2));
+  const releases = readReleasePlan();
+
+  if (command === "check") {
+    printPlan(releases, remote);
+    return;
+  }
+
+  const head = assertPublishableRepository(remote);
+  await publishReleasePlan(releases, {
+    head,
+    watch,
+    inspectTag: (release) => inspectTag(remote, release.tag),
+    validateTag: assertMatchingTags,
+    createTag: createAnnotatedTag,
+    pushTag: (release) => pushSingleTag(remote, release),
+    waitForRun: (release) => waitForWorkflowRun(release, head),
+    watchRun: watchWorkflowRun,
+  });
+  console.log("\nAll four client release workflows completed successfully.");
+}
+
+if (resolve(process.argv[1] || "") === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    usage();
+    console.error(`\nError: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-client-packages.test.mjs
+++ b/scripts/release-client-packages.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { CLIENTS, extractChangelogRelease, publishReleasePlan, readReleasePlan } from "./release-client-packages.mjs";
+
+function fixtureRoot(overrides = {}) {
+  const root = mkdtempSync(join(tmpdir(), "qveris-client-release-"));
+  const versions = {
+    cli: "1.2.3",
+    mcp: "2.3.4",
+    "js-sdk": "3.4.5",
+    "python-sdk": "4.5.6",
+    ...overrides,
+  };
+
+  for (const client of CLIENTS) {
+    const directory = join(root, client.directory);
+    mkdirSync(directory, { recursive: true });
+    const version = versions[client.key];
+    writeFileSync(
+      join(directory, "CHANGELOG.md"),
+      `# Changelog\n\n## [Unreleased]\n\n## [${version}] - 2026-07-23\n\n### Added\n\n- ${client.label} release\n\n## [0.0.1] - 2026-01-01\n`,
+    );
+
+    if (client.manifest === "npm") {
+      writeFileSync(join(directory, "package.json"), JSON.stringify({ version }));
+      writeFileSync(join(directory, "package-lock.json"), JSON.stringify({ version, packages: { "": { version } } }));
+      if (client.serverManifest) {
+        writeFileSync(join(directory, "server.json"), JSON.stringify({ version, packages: [{ version }] }));
+      }
+    } else {
+      writeFileSync(join(directory, "pyproject.toml"), `[project]\nname = "qveris"\nversion = "${version}"\n`);
+      writeFileSync(join(directory, "uv.lock"), `version = 1\n\n[[package]]\nname = "qveris"\nversion = "${version}"\n`);
+    }
+  }
+  return root;
+}
+
+test("extractChangelogRelease returns only the requested release notes", () => {
+  const notes = extractChangelogRelease(
+    "# Changelog\n\n## [1.2.0] - 2026-07-23\n\n### Added\n\n- new\n\n## [1.1.0] - 2026-07-01\n\n- old\n",
+    "1.2.0",
+  );
+  assert.equal(notes, "### Added\n\n- new");
+});
+
+test("readReleasePlan validates and coordinates all four package tags", () => {
+  const releases = readReleasePlan(fixtureRoot());
+  assert.deepEqual(
+    releases.map(({ key, tag }) => [key, tag]),
+    [
+      ["cli", "cli-v1.2.3"],
+      ["mcp", "mcp-v2.3.4"],
+      ["js-sdk", "js-sdk-v3.4.5"],
+      ["python-sdk", "python-sdk-v4.5.6"],
+    ],
+  );
+  assert.ok(releases.every((release) => release.notes.includes(`${release.label} release`)));
+});
+
+test("readReleasePlan rejects drift between package and release metadata", () => {
+  const root = fixtureRoot();
+  writeFileSync(
+    join(root, "packages/mcp/server.json"),
+    JSON.stringify({ version: "2.3.3", packages: [{ version: "2.3.3" }] }),
+  );
+  writeFileSync(join(root, "packages/python-sdk/uv.lock"), 'version = 1\n\n[[package]]\nname = "qveris"\nversion = "4.5.5"\n');
+
+  assert.throws(
+    () => readReleasePlan(root),
+    (error) =>
+      error.message.includes("MCP: server.json version (2.3.3) must equal 2.3.4") &&
+      error.message.includes("Python SDK: uv.lock qveris version (4.5.5) must equal 4.5.6"),
+  );
+});
+
+test("publishReleasePlan pushes one tag at a time and confirms each run before the next push", async () => {
+  const releases = readReleasePlan(fixtureRoot());
+  const events = [];
+
+  const runs = await publishReleasePlan(releases, {
+    head: "release-head",
+    watch: true,
+    log: () => {},
+    inspectTag: async (release) => {
+      events.push(`inspect:${release.tag}`);
+      return { local: null, remote: null };
+    },
+    validateTag: () => {},
+    createTag: async (release) => events.push(`create:${release.tag}`),
+    pushTag: async (release) => events.push(`push:${release.tag}`),
+    waitForRun: async (release) => {
+      events.push(`registered:${release.tag}`);
+      return { databaseId: release.tag };
+    },
+    watchRun: async (run) => events.push(`watch:${run.databaseId}`),
+  });
+
+  assert.equal(runs.length, 4);
+  for (let index = 0; index < releases.length - 1; index += 1) {
+    assert.ok(
+      events.indexOf(`registered:${releases[index].tag}`) < events.indexOf(`push:${releases[index + 1].tag}`),
+      `${releases[index].tag} must register before the next tag push`,
+    );
+  }
+  assert.deepEqual(
+    events.filter((event) => event.startsWith("push:")),
+    releases.map((release) => `push:${release.tag}`),
+  );
+});
+
+test("publishReleasePlan resumes an existing tag without pushing it again", async () => {
+  const [release] = readReleasePlan(fixtureRoot());
+  const events = [];
+
+  await publishReleasePlan([release], {
+    head: "release-head",
+    watch: false,
+    log: () => {},
+    inspectTag: async () => ({
+      local: { commit: "release-head", annotated: true },
+      remote: { commit: "release-head", annotated: true },
+    }),
+    validateTag: () => {},
+    createTag: async () => events.push("create"),
+    pushTag: async () => events.push("push"),
+    waitForRun: async () => {
+      events.push("registered");
+      return { databaseId: 1 };
+    },
+    watchRun: async () => events.push("watch"),
+  });
+
+  assert.deepEqual(events, ["registered"]);
+});

--- a/scripts/release-client-packages.test.mjs
+++ b/scripts/release-client-packages.test.mjs
@@ -1,10 +1,19 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-import { CLIENTS, extractChangelogRelease, publishReleasePlan, readReleasePlan } from "./release-client-packages.mjs";
+import {
+  CLIENTS,
+  extractChangelogRelease,
+  publishReleasePlan,
+  readReleasePlan,
+  workflowTagPatterns,
+} from "./release-client-packages.mjs";
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 function fixtureRoot(overrides = {}) {
   const root = mkdtempSync(join(tmpdir(), "qveris-client-release-"));
@@ -35,6 +44,13 @@ function fixtureRoot(overrides = {}) {
       writeFileSync(join(directory, "pyproject.toml"), `[project]\nname = "qveris"\nversion = "${version}"\n`);
       writeFileSync(join(directory, "uv.lock"), `version = 1\n\n[[package]]\nname = "qveris"\nversion = "${version}"\n`);
     }
+
+    const workflowDirectory = join(root, ".github/workflows");
+    mkdirSync(workflowDirectory, { recursive: true });
+    writeFileSync(
+      join(workflowDirectory, client.workflow),
+      `name: Publish ${client.label}\n\non:\n  workflow_dispatch:\n  push:\n    tags:\n      - "${client.tagPrefix}*"\n\njobs: {}\n`,
+    );
   }
   return root;
 }
@@ -45,6 +61,15 @@ test("extractChangelogRelease returns only the requested release notes", () => {
     "1.2.0",
   );
   assert.equal(notes, "### Added\n\n- new");
+});
+
+test("workflowTagPatterns reads only push tag triggers", () => {
+  assert.deepEqual(
+    workflowTagPatterns(
+      'name: Test\n\non:\n  pull_request:\n    paths:\n      - "js-sdk-v*"\n  push:\n    branches: [main]\n    tags:\n      - "js-sdk-v*"\n',
+    ),
+    ["js-sdk-v*"],
+  );
 });
 
 test("readReleasePlan validates and coordinates all four package tags", () => {
@@ -61,6 +86,19 @@ test("readReleasePlan validates and coordinates all four package tags", () => {
   assert.ok(releases.every((release) => release.notes.includes(`${release.label} release`)));
 });
 
+test("repository publish workflows exist and listen for every coordinated tag", () => {
+  const releases = readReleasePlan(REPOSITORY_ROOT);
+  assert.deepEqual(
+    releases.map(({ workflow, tagPrefix }) => [workflow, `${tagPrefix}*`]),
+    [
+      ["cli-publish.yml", "cli-v*"],
+      ["mcp-publish.yml", "mcp-v*"],
+      ["js-sdk-publish.yml", "js-sdk-v*"],
+      ["python-sdk-publish.yml", "python-sdk-v*"],
+    ],
+  );
+});
+
 test("readReleasePlan rejects drift between package and release metadata", () => {
   const root = fixtureRoot();
   writeFileSync(
@@ -74,6 +112,25 @@ test("readReleasePlan rejects drift between package and release metadata", () =>
     (error) =>
       error.message.includes("MCP: server.json version (2.3.3) must equal 2.3.4") &&
       error.message.includes("Python SDK: uv.lock qveris version (4.5.5) must equal 4.5.6"),
+  );
+});
+
+test("readReleasePlan rejects a missing or mismatched publish workflow before tagging", () => {
+  const missingRoot = fixtureRoot();
+  rmSync(join(missingRoot, ".github/workflows/js-sdk-publish.yml"));
+  assert.throws(
+    () => readReleasePlan(missingRoot),
+    /JavaScript SDK: publish workflow is missing: \.github\/workflows\/js-sdk-publish\.yml/,
+  );
+
+  const mismatchedRoot = fixtureRoot();
+  writeFileSync(
+    join(mismatchedRoot, ".github/workflows/js-sdk-publish.yml"),
+    'name: Publish JavaScript SDK\n\non:\n  push:\n    tags:\n      - "javascript-v*"\n',
+  );
+  assert.throws(
+    () => readReleasePlan(mismatchedRoot),
+    /JavaScript SDK: \.github\/workflows\/js-sdk-publish\.yml must listen for push\.tags pattern "js-sdk-v\*"/,
   );
 });
 


### PR DESCRIPTION
## Summary

- add a four-package release coordinator for CLI, MCP, JavaScript SDK, and Python SDK
- validate package, lockfile, MCP registry metadata, and versioned Changelog alignment before tagging
- push one annotated tag at a time and confirm its publish run is registered before sending the next tag event
- support interrupted-run recovery and optional workflow watching
- test release planning and sequencing on Linux and Windows

## Why

GitHub does not create push events when more than three tags are sent in one push. A coordinated four-package release therefore needs a checked, resumable path that cannot accidentally batch the tags or silently miss publish workflows.

## Validation

- `npm run test:release-clients`
- `npm run release:clients:check`
- `node --check scripts/release-client-packages.mjs`
- verified the workflow-run query against all four completed coordinated release runs
- verified `publish` refuses to run outside a clean, current `main`
- `git diff --check`
