### PR TITLE
fix: make paid calls single-submit and credential-safe

### DIFF
--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -208,7 +208,7 @@ qveris call 1 --params '{"city": "London"}' --respond-with summary
 qveris call 1 --params '{"city": "London"}' --respond-with 'fields:$.temperature,$.humidity'
 ```
 
-Projection flags are opt-in. If an older service explicitly rejects a projection field as unknown, the CLI retries once without only that field. Invalid projections remain `422` errors.
+Projection flags are opt-in. Paid calls are strict single-submit: the CLI does not retry `429`/`503`, refresh OAuth after `401` and replay, or remove a rejected projection field and resubmit. Projection rejections and invalid projections remain `422` errors. `QVERIS_MAX_RETRIES` continues to apply to read and audit commands only.
 
 **Dry run (no credits consumed):**
 

--- a/docs/en-US/js-sdk-api.md
+++ b/docs/en-US/js-sdk-api.md
@@ -710,6 +710,19 @@ Options for [Qveris.call](#call).
 
 #### Properties
 
+##### compatibilityMode?
+
+> `optional` **compatibilityMode?**: `"strict"` \| `"legacyOptionalFields"`
+
+Strict mode never resubmits a paid call. The deprecated legacy mode may
+replay once without an optional field rejected by an older service.
+
+###### Default
+
+```ts
+'strict'
+```
+
 ##### maxResponseSize?
 
 > `optional` **maxResponseSize?**: `number`

--- a/docs/en-US/js-sdk.md
+++ b/docs/en-US/js-sdk.md
@@ -110,9 +110,9 @@ Option shapes:
 
 - `discover(query, { limit?, sessionId?, view?, lang?, timeoutMs? })`
 - `inspect(toolIds, { searchId?, sessionId?, timeoutMs? })` — `toolIds` accepts a single string or an array; an **empty array short-circuits** and returns an empty response without a network request.
-- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs? })`
+- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs?, compatibilityMode? })`
 
-Projection options are opt-in. A legacy `422 extra_forbidden` response causes one retry without only the rejected optional field; invalid projections remain errors.
+Projection options are opt-in. Paid calls are strict single-submit: `429`/`503` and projection errors are returned without replay. The deprecated `compatibilityMode: 'legacyOptionalFields'` opt-in permits exactly one replay without an optional field rejected by an older service; invalid projections remain errors.
 
 `usage(...)` and `ledger(...)` take filter objects such as `start_date`, `end_date`, `summary`, `bucket`, `charge_outcome`, `execution_id`, `search_id`, `direction`, `entry_type`, `min_credits`, `max_credits`, `limit`, `page`, `page_size`.
 

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -288,7 +288,7 @@ Example:
 }
 ```
 
-Projection inputs are opt-in. A legacy `422 extra_forbidden` response causes one retry without only the rejected optional field; invalid projections remain errors.
+Projection inputs are opt-in. Paid `call` / `execute_tool` requests are strict single-submit: the MCP server does not retry `429`/`503` or remove a rejected projection field and resubmit. Projection errors remain errors; `QVERIS_MAX_RETRIES` applies only to read and audit tools.
 
 Typical successful response fields:
 

--- a/docs/en-US/python-sdk-api.md
+++ b/docs/en-US/python-sdk-api.md
@@ -10,7 +10,7 @@ This reference is generated from the public Python objects and docstrings. See t
 
 <a id="qveris.QverisClient"></a>
 
-### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None, \*, credential_provider: CredentialProvider | None = None)
+### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None, \*, credential_provider: CredentialProvider | None = None, http_client: AsyncClient | None = None, transport: AsyncBaseTransport | None = None, limits: Limits | None = None)
 
 Async client for Qveris API.
 
@@ -32,7 +32,7 @@ Call this if you create QverisClient directly and want to free network resources
 
 <a id="qveris.QverisClient.discover"></a>
 
-#### *async* discover(query: str, limit: int = 20, session_id: str | None = None, view: Literal['routing', 'full'] | None = None, lang: Literal['zh', 'en'] | None = None) → [SearchResponse](#qveris.SearchResponse)
+#### *async* discover(query: str, limit: int = 20, session_id: str | None = None, view: Literal['routing', 'full'] | None = None, lang: Literal['zh', 'en'] | None = None, timeout: float | None = None, correlation_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
 
 Discover capabilities using natural language.
 
@@ -53,7 +53,7 @@ Deprecated alias for discover(…).
 
 <a id="qveris.QverisClient.inspect"></a>
 
-#### *async* inspect(tool_ids: Iterable[str] | str, search_id: str | None = None, session_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
+#### *async* inspect(tool_ids: Iterable[str] | str, search_id: str | None = None, session_id: str | None = None, timeout: float | None = None, correlation_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
 
 Inspect one or more capabilities by tool ID.
 
@@ -72,13 +72,13 @@ Deprecated alias for inspect(…).
 
 <a id="qveris.QverisClient.probe"></a>
 
-#### *async* probe(tool_id: str, parameters: Dict[str, Any] | None = None, checks: List[Literal['schema', 'quote', 'coverage', 'sample']] | None = None, live_budget: Literal['none', 'metadata', 'sampled'] = 'none') → ToolProbeResponse
+#### *async* probe(tool_id: str, parameters: Dict[str, Any] | None = None, checks: List[Literal['schema', 'quote', 'coverage', 'sample']] | None = None, live_budget: Literal['none', 'metadata', 'sampled'] = 'none', timeout: float | None = None, correlation_id: str | None = None) → ToolProbeResponse
 
 Validate candidate parameters and obtain a zero-cost quote without execution.
 
 <a id="qveris.QverisClient.call"></a>
 
-#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None, respond_with: str | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
+#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None, respond_with: str | None = None, compatibility_mode: Literal['strict', 'legacy_optional_fields'] = 'strict', timeout: float | None = None, correlation_id: str | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
 
 Call a specific capability.
 
@@ -89,6 +89,9 @@ Call a specific capability.
   * **session_id** – Optional correlation id.
   * **max_response_size** – Optional max response size in bytes. Large responses may be truncated.
   * **respond_with** – Optional server-side projection (full, summary, or fields:<JSONPath,…>).
+  * **compatibility_mode** – Strict mode never resubmits a paid call. The deprecated legacy mode may replay once without an unsupported optional field.
+  * **timeout** – HTTP request timeout in seconds; credential acquisition is separate.
+  * **correlation_id** – Non-sensitive reference forwarded only to the credential provider.
 * **Returns:**
   ToolExecutionResponse with success, result, and metadata.
 
@@ -100,7 +103,7 @@ Deprecated alias for call(…).
 
 <a id="qveris.QverisClient.usage"></a>
 
-#### *async* usage(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, event_type: str | None = None, kind: str | None = None, success: bool | None = None, charge_outcome: str | None = None, search_id: str | None = None, execution_id: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None) → [UsageHistoryResponse](#qveris.UsageHistoryResponse)
+#### *async* usage(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, event_type: str | None = None, kind: str | None = None, success: bool | None = None, charge_outcome: str | None = None, search_id: str | None = None, execution_id: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None, timeout: float | None = None, correlation_id: str | None = None) → [UsageHistoryResponse](#qveris.UsageHistoryResponse)
 
 Query request-level usage audit history.
 
@@ -108,7 +111,7 @@ Use this to verify success, failure, charge outcome, and final settlement contex
 
 <a id="qveris.QverisClient.ledger"></a>
 
-#### *async* ledger(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, entry_type: str | None = None, direction: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None) → [CreditsLedgerResponse](#qveris.CreditsLedgerResponse)
+#### *async* ledger(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, entry_type: str | None = None, direction: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None, timeout: float | None = None, correlation_id: str | None = None) → [CreditsLedgerResponse](#qveris.CreditsLedgerResponse)
 
 Query final credits ledger entries.
 
@@ -308,25 +311,97 @@ Configuration for LLM behavior used by Agent.
 
 ### *class* qveris.CompactBillingStatement(\*, price: BillingPrice | None = None, quantity: float | None = None, charge_lines: List[BillingChargeLine] | None = None, minimum_charge_credits: float | None = None, list_amount_credits: float | None = None, requested_amount_credits: float | None = None, summary: str | None = None, \*\*extra_data: Any)
 
+<a id="qveris.CompactBillingStatement.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
+
 <a id="qveris.CreditsLedgerItem"></a>
 
 ### *class* qveris.CreditsLedgerItem(\*, id: str, entry_type: str, amount_credits: float, source_system: str, created_at: str, source_ref_type: str | None = None, source_ref_id: str | None = None, pre_settlement_bill: Dict[str, Any] | None = None, settlement_result: Dict[str, Any] | None = None, balance_before: Dict[str, Any] | None = None, balance_after: Dict[str, Any] | None = None, ledger_metadata: Dict[str, Any] | None = None, description: str | None = None, \*\*extra_data: Any)
+
+<a id="qveris.CreditsLedgerItem.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
 
 <a id="qveris.CreditsLedgerResponse"></a>
 
 ### *class* qveris.CreditsLedgerResponse(\*, items: ~typing.List[~qveris.types.CreditsLedgerItem] = <factory>, total: int = 0, page: int = 1, page_size: int = 0, summary: ~typing.Dict[str, ~typing.Any] | None = None, \*\*extra_data: ~typing.Any)
 
+<a id="qveris.CreditsLedgerResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
+
 <a id="qveris.Message"></a>
 
 ### *class* qveris.Message(\*, role: str, content: str | None = None, tool_calls: List[Dict[str, Any]] | None = None, tool_call_id: str | None = None, name: str | None = None, reasoning_details: Any | None = None, \*\*extra_data: Any)
+
+<a id="qveris.Message.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
 
 <a id="qveris.SearchResponse"></a>
 
 ### *class* qveris.SearchResponse(\*, query: str | None = None, search_id: str | None = None, total: int | None = None, results: ~typing.List[~qveris.types.ToolInfo] = <factory>, stats: ~qveris.types.SearchStats | None = None, remaining_credits: float | None = None, elapsed_time_ms: float | None = None, \*\*extra_data: ~typing.Any)
 
+<a id="qveris.SearchResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
+
 <a id="qveris.StreamEvent"></a>
 
 ### *class* qveris.StreamEvent(\*, type: Literal['content', 'reasoning', 'tool_call', 'tool_result', 'metrics', 'error', 'reasoning_details', 'budget_warning', 'budget_exceeded'], content: str | None = None, tool_call: Dict[str, Any] | None = None, tool_result: Dict[str, Any] | None = None, metrics: Dict[str, Any] | None = None, error: str | None = None, details: Any | None = None, budget: Dict[str, Any] | None = None, \*\*extra_data: Any)
+
+<a id="qveris.StreamEvent.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
 
 <a id="qveris.ToolCapability"></a>
 
@@ -336,11 +411,35 @@ Standardized capability descriptor attached to a tool.
 
 Example: `MKT.BARS.ADJUSTED` with market coverage tags.
 
+<a id="qveris.ToolCapability.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
+
 <a id="qveris.ToolCapabilityTag"></a>
 
 ### *class* qveris.ToolCapabilityTag(\*, id: str | None = None, name: str | None = None, type: str | None = None, description: str | None = None, \*\*extra_data: Any)
 
 Coverage tag attached to a capability (e.g. market coverage).
+
+<a id="qveris.ToolCapabilityTag.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
 
 <a id="qveris.ToolCategory"></a>
 
@@ -350,22 +449,94 @@ Category/tag attached to a tool.
 
 Current API responses return category objects; legacy responses returned plain strings, so `ToolInfo.categories` accepts both.
 
+<a id="qveris.ToolCategory.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
+
 <a id="qveris.ToolExecutionResponse"></a>
 
 ### *class* qveris.ToolExecutionResponse(\*, execution_id: str, success: bool, result: Any | None = None, error_message: str | None = None, elapsed_time_ms: float | None = None, execution_time: float | None = None, tool_id: str | None = None, parameters: Dict[str, Any] | None = None, cost: float | None = None, billing: [CompactBillingStatement](#qveris.CompactBillingStatement) | None = None, pre_settlement_bill: Dict[str, Any] | None = None, remaining_credits: float | None = None, created_at: str | None = None, \*\*extra_data: Any)
+
+<a id="qveris.ToolExecutionResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
 
 <a id="qveris.ToolInfo"></a>
 
 ### *class* qveris.ToolInfo(\*, tool_id: str, name: str | None = None, description: Any | None = None, capability: str | None = None, cost_class: str | None = None, reliability: str | None = None, as_of_support: bool | None = None, categories: List[str | [ToolCategory](#qveris.ToolCategory)] | None = None, category: str | None = None, capabilities: List[[ToolCapability](#qveris.ToolCapability)] | None = None, provider_id: str | None = None, provider_name: str | None = None, provider_description: Any | None = None, provider_website_url: str | None = None, region: str | None = None, params: List[[ToolParameter](#qveris.ToolParameter)] | None = None, examples: ToolExamples | None = None, stats: ToolStats | None = None, billing_rule: BillingRule | None = None, expected_cost: str | float | None = None, final_score: float | None = None, score: float | None = None, why_recommended: str | None = None, has_last_execution: bool | None = None, last_execution_record: Dict[str, Any] | None = None, docs_url: str | None = None, protocol: str | None = None, \*\*extra_data: Any)
 
+<a id="qveris.ToolInfo.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
+
 <a id="qveris.ToolParameter"></a>
 
 ### *class* qveris.ToolParameter(\*, name: str, type: Any, required: bool = False, description: Any | None = None, enum: List[Any] | None = None, \*\*extra_data: Any)
+
+<a id="qveris.ToolParameter.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
 
 <a id="qveris.UsageEventItem"></a>
 
 ### *class* qveris.UsageEventItem(\*, id: str, event_type: str, source_system: str, success: bool, created_at: str, kind: str | None = None, source_ref_type: str | None = None, source_ref_id: str | None = None, session_id: str | None = None, search_id: str | None = None, execution_id: str | None = None, tool_id: str | None = None, model: str | None = None, query: str | None = None, charge_outcome: str | None = None, error_message: str | None = None, billing_snapshot_status: str | None = None, pre_settlement_bill: Dict[str, Any] | None = None, settlement_result: Dict[str, Any] | None = None, requested_amount_credits: float | None = None, actual_amount_credits: float | None = None, credits_ledger_entry_id: str | None = None, display_target: str | None = None, billing_summary: str | None = None, pre_settlement_amount_credits: float | None = None, settled_amount_credits: float | None = None, \*\*extra_data: Any)
 
+<a id="qveris.UsageEventItem.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.
+
 <a id="qveris.UsageHistoryResponse"></a>
 
 ### *class* qveris.UsageHistoryResponse(\*, items: ~typing.List[~qveris.types.UsageEventItem] = <factory>, total: int = 0, page: int = 1, page_size: int = 0, summary: ~typing.Dict[str, ~typing.Any] | None = None, \*\*extra_data: ~typing.Any)
+
+<a id="qveris.UsageHistoryResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that’s what pydantic-core passes when calling it.
+
+* **Parameters:**
+  * **self** – The BaseModel instance.
+  * **context** – The context.

--- a/docs/en-US/python-sdk-api.md
+++ b/docs/en-US/python-sdk-api.md
@@ -24,7 +24,7 @@ Rate-limit backoff is retried pressure, not failure — surface this rather than
 
 <a id="qveris.QverisClient.close"></a>
 
-#### *async* close()
+#### *async* close() → None
 
 Close the underlying HTTP client.
 

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -164,6 +164,11 @@ status = agent.budget_status()   # {"limit": 25, "spent": 12.0, "remaining": 13.
 |-------|---------|---------|-------------|
 | `api_key` | `QVERIS_API_KEY` | `None` | API key, sent as `Authorization: Bearer ...` |
 | `base_url` | `QVERIS_BASE_URL` | `https://qveris.ai/api/v1` | API base URL |
+| `credential_audience` | `QVERIS_CREDENTIAL_AUDIENCE` | `None` | Optional audience forwarded to the credential provider |
+| `credential_scopes` | `QVERIS_CREDENTIAL_SCOPES` | `()` | Optional scopes forwarded to the credential provider |
+| `max_retries` | `QVERIS_MAX_RETRIES` | `3` | Bounded `429`/`503` retries for read/audit operations; never applies to paid calls |
+| `read_timeout` | `QVERIS_READ_TIMEOUT` | `30` | Default HTTP timeout in seconds for read/audit operations |
+| `call_timeout` | `QVERIS_CALL_TIMEOUT` | `120` | Default HTTP timeout in seconds for paid calls |
 | `enable_history_pruning` | — | `True` | Prune/compress old tool outputs to save tokens (agent loop) |
 | `max_iterations` | — | `50` | Max agent tool-loop iterations |
 
@@ -184,6 +189,36 @@ agent = Agent(
 )
 ```
 
+## Safe paid calls and transport ownership
+
+Paid `call()` requests are strict single-submit by default. The SDK does not automatically retry `429`/`503`, timeout, or transport failures, and it does not remove a rejected projection field and resubmit. A typed error reports `request_metadata.http_attempts == 1`. If an older service requires the former projection fallback, opt in explicitly:
+
+```python
+result = await client.call(
+    "tool.id",
+    {"symbol": "AAPL"},
+    respond_with="summary",
+    compatibility_mode="legacy_optional_fields",  # deprecated; may submit twice
+)
+```
+
+The opt-in emits `DeprecationWarning`; `request_metadata.compatibility_replays` records the replay. Read and audit operations continue to use bounded `max_retries`.
+
+`QverisClient` accepts either an injected shared `http_client` or SDK-owned `transport` / `limits` settings. These forms are mutually exclusive. `close()` waits for in-flight operations, is safe to call concurrently, closes only SDK-owned clients, and rejects new work with `QverisClientClosedError` after shutdown.
+
+Credential providers receive an immutable `CredentialContext` for every physical attempt, including resource, configured audience/scopes, operation, purpose, session ID, and an optional non-sensitive `correlation_id`. HTTP timeout starts after credential acquisition.
+
+Public failures use the `QverisError` hierarchy (`QverisApiError`, `QverisTransportError`, `QverisCredentialError`, `QverisContractError`, `QverisClientClosedError`). They retain safe machine fields and immutable `RequestMetadata`, but not raw HTTP requests/responses, bearer credentials, signed URLs, or underlying exception objects.
+
+### Migration from 0.5
+
+- `max_retries` now applies only to read and audit operations; it no longer controls paid calls.
+- `call(..., respond_with=...)` no longer performs a silent legacy replay. Use `compatibility_mode="legacy_optional_fields"` only during a short migration window.
+- Catch `QverisError` or its typed subclasses instead of `httpx.HTTPStatusError` / raw transport errors.
+- Response metadata is available as `response.request_metadata` and is excluded from wire serialization.
+
+Capability Resolve/Query methods, selection tokens, idempotency keys, and execution lookup will be added only after those fields and endpoints are published in the public OpenAPI contract; the client does not invent interim wire fields.
+
 ## API reference
 
 The [source-generated API reference](python-sdk-api.md) lists the current
@@ -195,11 +230,10 @@ drift.
 
 | Method | REST endpoint | Purpose |
 |--------|---------------|---------|
-| `discover(query, limit=20, session_id=None, view=None, lang=None)` | `POST /search` | Find capabilities; `view="routing"` returns compact routing cards (free) |
-| `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | Fetch full capability metadata (free) |
-| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None, respond_with=None)` | `POST /tools/execute` | Execute a capability; select full, summary, or JSONPath fields |
-
-Projection arguments are opt-in. A legacy `422 extra_forbidden` response causes one retry without only the rejected optional field; invalid projections remain errors.
+| `discover(query, limit=20, session_id=None, view=None, lang=None, timeout=None, correlation_id=None)` | `POST /search` | Find capabilities; `view="routing"` returns compact routing cards (free) |
+| `inspect(tool_ids, search_id=None, session_id=None, timeout=None, correlation_id=None)` | `POST /tools/by-ids` | Fetch full capability metadata (free) |
+| `probe(tool_id, parameters=None, checks=None, live_budget="none", timeout=None, correlation_id=None)` | `POST /tools/probe` | Validate parameters and request a zero-cost quote |
+| `call(tool_id, parameters, ..., compatibility_mode="strict", timeout=None, correlation_id=None)` | `POST /tools/execute` | Execute with strict single-submit semantics |
 | `usage(**filters)` | `GET /auth/usage/history/v2` | Audit request status and charge outcome |
 | `ledger(**filters)` | `GET /auth/credits/ledger` | Inspect final credit balance movements |
 | `handle_tool_call(func_name, func_args, session_id=None)` | — | Bridge an LLM tool call to the right QVeris method |
@@ -208,6 +242,8 @@ Projection arguments are opt-in. A legacy `422 extra_forbidden` response causes 
 `tool_ids` accepts a single string or an iterable. `usage(...)` and `ledger(...)` take keyword-only filters such as `start_date`, `end_date`, `summary` (default `True`), `bucket`, `charge_outcome`, `execution_id`, `search_id`, `direction`, `entry_type`, `min_credits`, `max_credits`, `limit`, `page`, `page_size`.
 
 Backward-compatible aliases remain available: `search_tools` → `discover`, `get_tools_by_ids` → `inspect`, `execute_tool` → `call`.
+
+Projection arguments are opt-in. Read-side discover projection compatibility remains bounded; paid calls never replay unless the deprecated compatibility mode is explicitly selected. Invalid projections remain errors.
 
 ### `Agent`
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -208,7 +208,7 @@ qveris call 1 --params '{"city": "London"}' --respond-with summary
 qveris call 1 --params '{"city": "London"}' --respond-with 'fields:$.temperature,$.humidity'
 ```
 
-投影参数仅在显式指定时发送。如果旧服务明确把投影字段判定为未知字段，CLI 只移除该字段并重试一次；无效投影仍按 `422` 错误返回。
+投影参数仅在显式指定时发送。付费调用严格 single-submit：CLI 不会重试 `429`/`503`，不会在 `401` 后刷新 OAuth 并重放，也不会删除被拒绝的投影字段后再次提交。投影拒绝和无效投影都按 `422` 错误返回。`QVERIS_MAX_RETRIES` 仅继续用于读和审计命令。
 
 **试运行（不消耗积分）：**
 

--- a/docs/zh-CN/js-sdk-api.md
+++ b/docs/zh-CN/js-sdk-api.md
@@ -708,6 +708,19 @@ Options for [Qveris.call](#call).
 
 #### 属性
 
+##### compatibilityMode?
+
+> `optional` **compatibilityMode?**: `"strict"` \| `"legacyOptionalFields"`
+
+Strict mode never resubmits a paid call. The deprecated legacy mode may
+replay once without an optional field rejected by an older service.
+
+###### 默认值
+
+```ts
+'strict'
+```
+
 ##### maxResponseSize?
 
 > `optional` **maxResponseSize?**: `number`

--- a/docs/zh-CN/js-sdk.md
+++ b/docs/zh-CN/js-sdk.md
@@ -108,9 +108,9 @@ AI SDK 集成。该页面直接根据 TypeScript 源码重新生成，并由 CI 
 
 - `discover(query, { limit?, sessionId?, view?, lang?, timeoutMs? })`
 - `inspect(toolIds, { searchId?, sessionId?, timeoutMs? })` —— `toolIds` 接受单个字符串或数组；**空数组会短路**，直接返回空响应而不发起网络请求。
-- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs? })`
+- `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs?, compatibilityMode? })`
 
-投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
+投影参数仅在显式指定时发送。付费调用严格 single-submit：`429`/`503` 和投影错误会直接返回，不会重放。已弃用的 `compatibilityMode: 'legacyOptionalFields'` 可显式允许一次删除旧服务拒绝的可选字段后重放；无效投影仍按错误返回。
 
 `usage(...)` 和 `ledger(...)` 接受过滤对象，如 `start_date`、`end_date`、`summary`、`bucket`、`charge_outcome`、`execution_id`、`search_id`、`direction`、`entry_type`、`min_credits`、`max_credits`、`limit`、`page`、`page_size`。
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -286,7 +286,7 @@ claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --
 }
 ```
 
-投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
+投影参数仅在显式指定时发送。付费 `call` / `execute_tool` 请求严格 single-submit：MCP server 不会重试 `429`/`503`，也不会删除被拒绝的投影字段后再次提交。投影错误仍按错误返回；`QVERIS_MAX_RETRIES` 仅用于读和审计工具。
 
 典型成功响应字段：
 

--- a/docs/zh-CN/python-sdk-api.md
+++ b/docs/zh-CN/python-sdk-api.md
@@ -24,7 +24,7 @@ Rate-limit backoff is retried pressure, not failure — surface this rather than
 
 <a id="qveris.QverisClient.close"></a>
 
-#### *async* close()
+#### *async* close() → None
 
 Close the underlying HTTP client.
 

--- a/docs/zh-CN/python-sdk-api.md
+++ b/docs/zh-CN/python-sdk-api.md
@@ -10,7 +10,7 @@
 
 <a id="qveris.QverisClient"></a>
 
-### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None, \*, credential_provider: CredentialProvider | None = None)
+### *class* qveris.QverisClient(config: [QverisConfig](#qveris.QverisConfig) | None = None, debug_callback: Callable[[str], None] | None = None, \*, credential_provider: CredentialProvider | None = None, http_client: AsyncClient | None = None, transport: AsyncBaseTransport | None = None, limits: Limits | None = None)
 
 Async client for Qveris API.
 
@@ -32,7 +32,7 @@ Call this if you create QverisClient directly and want to free network resources
 
 <a id="qveris.QverisClient.discover"></a>
 
-#### *async* discover(query: str, limit: int = 20, session_id: str | None = None, view: Literal['routing', 'full'] | None = None, lang: Literal['zh', 'en'] | None = None) → [SearchResponse](#qveris.SearchResponse)
+#### *async* discover(query: str, limit: int = 20, session_id: str | None = None, view: Literal['routing', 'full'] | None = None, lang: Literal['zh', 'en'] | None = None, timeout: float | None = None, correlation_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
 
 Discover capabilities using natural language.
 
@@ -53,7 +53,7 @@ Deprecated alias for discover(...).
 
 <a id="qveris.QverisClient.inspect"></a>
 
-#### *async* inspect(tool_ids: Iterable[str] | str, search_id: str | None = None, session_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
+#### *async* inspect(tool_ids: Iterable[str] | str, search_id: str | None = None, session_id: str | None = None, timeout: float | None = None, correlation_id: str | None = None) → [SearchResponse](#qveris.SearchResponse)
 
 Inspect one or more capabilities by tool ID.
 
@@ -72,13 +72,13 @@ Deprecated alias for inspect(...).
 
 <a id="qveris.QverisClient.probe"></a>
 
-#### *async* probe(tool_id: str, parameters: Dict[str, Any] | None = None, checks: List[Literal['schema', 'quote', 'coverage', 'sample']] | None = None, live_budget: Literal['none', 'metadata', 'sampled'] = 'none') → ToolProbeResponse
+#### *async* probe(tool_id: str, parameters: Dict[str, Any] | None = None, checks: List[Literal['schema', 'quote', 'coverage', 'sample']] | None = None, live_budget: Literal['none', 'metadata', 'sampled'] = 'none', timeout: float | None = None, correlation_id: str | None = None) → ToolProbeResponse
 
 Validate candidate parameters and obtain a zero-cost quote without execution.
 
 <a id="qveris.QverisClient.call"></a>
 
-#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None, respond_with: str | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
+#### *async* call(tool_id: str, parameters: Dict[str, Any], search_id: str | None = None, session_id: str | None = None, max_response_size: int | None = None, respond_with: str | None = None, compatibility_mode: Literal['strict', 'legacy_optional_fields'] = 'strict', timeout: float | None = None, correlation_id: str | None = None) → [ToolExecutionResponse](#qveris.ToolExecutionResponse)
 
 Call a specific capability.
 
@@ -89,6 +89,9 @@ Call a specific capability.
   * **session_id** -- Optional correlation id.
   * **max_response_size** -- Optional max response size in bytes. Large responses may be truncated.
   * **respond_with** -- Optional server-side projection (full, summary, or fields:<JSONPath,...>).
+  * **compatibility_mode** -- Strict mode never resubmits a paid call. The deprecated legacy mode may replay once without an unsupported optional field.
+  * **timeout** -- HTTP request timeout in seconds; credential acquisition is separate.
+  * **correlation_id** -- Non-sensitive reference forwarded only to the credential provider.
 * **返回:**
   ToolExecutionResponse with success, result, and metadata.
 
@@ -100,7 +103,7 @@ Deprecated alias for call(...).
 
 <a id="qveris.QverisClient.usage"></a>
 
-#### *async* usage(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, event_type: str | None = None, kind: str | None = None, success: bool | None = None, charge_outcome: str | None = None, search_id: str | None = None, execution_id: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None) → [UsageHistoryResponse](#qveris.UsageHistoryResponse)
+#### *async* usage(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, event_type: str | None = None, kind: str | None = None, success: bool | None = None, charge_outcome: str | None = None, search_id: str | None = None, execution_id: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None, timeout: float | None = None, correlation_id: str | None = None) → [UsageHistoryResponse](#qveris.UsageHistoryResponse)
 
 Query request-level usage audit history.
 
@@ -108,7 +111,7 @@ Use this to verify success, failure, charge outcome, and final settlement contex
 
 <a id="qveris.QverisClient.ledger"></a>
 
-#### *async* ledger(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, entry_type: str | None = None, direction: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None) → [CreditsLedgerResponse](#qveris.CreditsLedgerResponse)
+#### *async* ledger(\*, start_date: str | None = None, end_date: str | None = None, summary: bool | None = True, bucket: str | None = None, entry_type: str | None = None, direction: str | None = None, min_credits: float | None = None, max_credits: float | None = None, limit: int | None = None, page: int | None = None, page_size: int | None = None, timeout: float | None = None, correlation_id: str | None = None) → [CreditsLedgerResponse](#qveris.CreditsLedgerResponse)
 
 Query final credits ledger entries.
 
@@ -308,25 +311,97 @@ Configuration for LLM behavior used by Agent.
 
 ### *class* qveris.CompactBillingStatement(\*, price: BillingPrice | None = None, quantity: float | None = None, charge_lines: List[BillingChargeLine] | None = None, minimum_charge_credits: float | None = None, list_amount_credits: float | None = None, requested_amount_credits: float | None = None, summary: str | None = None, \*\*extra_data: Any)
 
+<a id="qveris.CompactBillingStatement.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
+
 <a id="qveris.CreditsLedgerItem"></a>
 
 ### *class* qveris.CreditsLedgerItem(\*, id: str, entry_type: str, amount_credits: float, source_system: str, created_at: str, source_ref_type: str | None = None, source_ref_id: str | None = None, pre_settlement_bill: Dict[str, Any] | None = None, settlement_result: Dict[str, Any] | None = None, balance_before: Dict[str, Any] | None = None, balance_after: Dict[str, Any] | None = None, ledger_metadata: Dict[str, Any] | None = None, description: str | None = None, \*\*extra_data: Any)
+
+<a id="qveris.CreditsLedgerItem.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
 
 <a id="qveris.CreditsLedgerResponse"></a>
 
 ### *class* qveris.CreditsLedgerResponse(\*, items: ~typing.List[~qveris.types.CreditsLedgerItem] = <factory>, total: int = 0, page: int = 1, page_size: int = 0, summary: ~typing.Dict[str, ~typing.Any] | None = None, \*\*extra_data: ~typing.Any)
 
+<a id="qveris.CreditsLedgerResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
+
 <a id="qveris.Message"></a>
 
 ### *class* qveris.Message(\*, role: str, content: str | None = None, tool_calls: List[Dict[str, Any]] | None = None, tool_call_id: str | None = None, name: str | None = None, reasoning_details: Any | None = None, \*\*extra_data: Any)
+
+<a id="qveris.Message.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
 
 <a id="qveris.SearchResponse"></a>
 
 ### *class* qveris.SearchResponse(\*, query: str | None = None, search_id: str | None = None, total: int | None = None, results: ~typing.List[~qveris.types.ToolInfo] = <factory>, stats: ~qveris.types.SearchStats | None = None, remaining_credits: float | None = None, elapsed_time_ms: float | None = None, \*\*extra_data: ~typing.Any)
 
+<a id="qveris.SearchResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
+
 <a id="qveris.StreamEvent"></a>
 
 ### *class* qveris.StreamEvent(\*, type: Literal['content', 'reasoning', 'tool_call', 'tool_result', 'metrics', 'error', 'reasoning_details', 'budget_warning', 'budget_exceeded'], content: str | None = None, tool_call: Dict[str, Any] | None = None, tool_result: Dict[str, Any] | None = None, metrics: Dict[str, Any] | None = None, error: str | None = None, details: Any | None = None, budget: Dict[str, Any] | None = None, \*\*extra_data: Any)
+
+<a id="qveris.StreamEvent.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
 
 <a id="qveris.ToolCapability"></a>
 
@@ -336,11 +411,35 @@ Standardized capability descriptor attached to a tool.
 
 Example: `MKT.BARS.ADJUSTED` with market coverage tags.
 
+<a id="qveris.ToolCapability.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
+
 <a id="qveris.ToolCapabilityTag"></a>
 
 ### *class* qveris.ToolCapabilityTag(\*, id: str | None = None, name: str | None = None, type: str | None = None, description: str | None = None, \*\*extra_data: Any)
 
 Coverage tag attached to a capability (e.g. market coverage).
+
+<a id="qveris.ToolCapabilityTag.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
 
 <a id="qveris.ToolCategory"></a>
 
@@ -350,22 +449,94 @@ Category/tag attached to a tool.
 
 Current API responses return category objects; legacy responses returned plain strings, so `ToolInfo.categories` accepts both.
 
+<a id="qveris.ToolCategory.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
+
 <a id="qveris.ToolExecutionResponse"></a>
 
 ### *class* qveris.ToolExecutionResponse(\*, execution_id: str, success: bool, result: Any | None = None, error_message: str | None = None, elapsed_time_ms: float | None = None, execution_time: float | None = None, tool_id: str | None = None, parameters: Dict[str, Any] | None = None, cost: float | None = None, billing: [CompactBillingStatement](#qveris.CompactBillingStatement) | None = None, pre_settlement_bill: Dict[str, Any] | None = None, remaining_credits: float | None = None, created_at: str | None = None, \*\*extra_data: Any)
+
+<a id="qveris.ToolExecutionResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
 
 <a id="qveris.ToolInfo"></a>
 
 ### *class* qveris.ToolInfo(\*, tool_id: str, name: str | None = None, description: Any | None = None, capability: str | None = None, cost_class: str | None = None, reliability: str | None = None, as_of_support: bool | None = None, categories: List[str | [ToolCategory](#qveris.ToolCategory)] | None = None, category: str | None = None, capabilities: List[[ToolCapability](#qveris.ToolCapability)] | None = None, provider_id: str | None = None, provider_name: str | None = None, provider_description: Any | None = None, provider_website_url: str | None = None, region: str | None = None, params: List[[ToolParameter](#qveris.ToolParameter)] | None = None, examples: ToolExamples | None = None, stats: ToolStats | None = None, billing_rule: BillingRule | None = None, expected_cost: str | float | None = None, final_score: float | None = None, score: float | None = None, why_recommended: str | None = None, has_last_execution: bool | None = None, last_execution_record: Dict[str, Any] | None = None, docs_url: str | None = None, protocol: str | None = None, \*\*extra_data: Any)
 
+<a id="qveris.ToolInfo.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
+
 <a id="qveris.ToolParameter"></a>
 
 ### *class* qveris.ToolParameter(\*, name: str, type: Any, required: bool = False, description: Any | None = None, enum: List[Any] | None = None, \*\*extra_data: Any)
+
+<a id="qveris.ToolParameter.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
 
 <a id="qveris.UsageEventItem"></a>
 
 ### *class* qveris.UsageEventItem(\*, id: str, event_type: str, source_system: str, success: bool, created_at: str, kind: str | None = None, source_ref_type: str | None = None, source_ref_id: str | None = None, session_id: str | None = None, search_id: str | None = None, execution_id: str | None = None, tool_id: str | None = None, model: str | None = None, query: str | None = None, charge_outcome: str | None = None, error_message: str | None = None, billing_snapshot_status: str | None = None, pre_settlement_bill: Dict[str, Any] | None = None, settlement_result: Dict[str, Any] | None = None, requested_amount_credits: float | None = None, actual_amount_credits: float | None = None, credits_ledger_entry_id: str | None = None, display_target: str | None = None, billing_summary: str | None = None, pre_settlement_amount_credits: float | None = None, settled_amount_credits: float | None = None, \*\*extra_data: Any)
 
+<a id="qveris.UsageEventItem.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.
+
 <a id="qveris.UsageHistoryResponse"></a>
 
 ### *class* qveris.UsageHistoryResponse(\*, items: ~typing.List[~qveris.types.UsageEventItem] = <factory>, total: int = 0, page: int = 1, page_size: int = 0, summary: ~typing.Dict[str, ~typing.Any] | None = None, \*\*extra_data: ~typing.Any)
+
+<a id="qveris.UsageHistoryResponse.model_post_init"></a>
+
+#### model_post_init(context: Any, /) → None
+
+This function is meant to behave like a BaseModel method to initialise private attributes.
+
+It takes context as an argument since that's what pydantic-core passes when calling it.
+
+* **参数:**
+  * **self** -- The BaseModel instance.
+  * **context** -- The context.

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -164,6 +164,11 @@ status = agent.budget_status()   # {"limit": 25, "spent": 12.0, "remaining": 13.
 |------|---------|--------|------|
 | `api_key` | `QVERIS_API_KEY` | `None` | API 密钥，以 `Authorization: Bearer ...` 发送 |
 | `base_url` | `QVERIS_BASE_URL` | `https://qveris.ai/api/v1` | API 基础地址 |
+| `credential_audience` | `QVERIS_CREDENTIAL_AUDIENCE` | `None` | 透传给凭据 provider 的可选 audience |
+| `credential_scopes` | `QVERIS_CREDENTIAL_SCOPES` | `()` | 透传给凭据 provider 的可选 scopes |
+| `max_retries` | `QVERIS_MAX_RETRIES` | `3` | 读/审计操作的有界 `429`/`503` 重试；不适用于付费调用 |
+| `read_timeout` | `QVERIS_READ_TIMEOUT` | `30` | 读/审计操作的默认 HTTP 超时（秒） |
+| `call_timeout` | `QVERIS_CALL_TIMEOUT` | `120` | 付费调用的默认 HTTP 超时（秒） |
 | `enable_history_pruning` | — | `True` | 裁剪/压缩旧的工具输出以节省 token（agent 循环） |
 | `max_iterations` | — | `50` | agent 工具循环的最大迭代次数 |
 
@@ -184,6 +189,36 @@ agent = Agent(
 )
 ```
 
+## 安全付费调用与 transport 所有权
+
+付费 `call()` 默认严格 single-submit。SDK 不会自动重试 `429`/`503`、超时或 transport 失败，也不会删除被拒绝的投影字段后再次提交；类型化错误会报告 `request_metadata.http_attempts == 1`。如果旧服务仍需要原来的投影降级，可显式选择：
+
+```python
+result = await client.call(
+    "tool.id",
+    {"symbol": "AAPL"},
+    respond_with="summary",
+    compatibility_mode="legacy_optional_fields",  # 已弃用；可能提交两次
+)
+```
+
+该模式会发出 `DeprecationWarning`，并用 `request_metadata.compatibility_replays` 记录重放。读和审计操作仍使用有界 `max_retries`。
+
+`QverisClient` 可以注入共享 `http_client`，或配置由 SDK 持有的 `transport` / `limits`；两种形式互斥。`close()` 会等待在途操作、支持并发幂等调用、只关闭 SDK 自己创建的 client；关闭后新请求会抛出 `QverisClientClosedError`。
+
+每次物理 attempt 都会给凭据 provider 传入不可变 `CredentialContext`，其中包含 resource、显式配置的 audience/scopes、operation、purpose、session ID 和可选的非敏感 `correlation_id`。HTTP 超时从凭据获取完成后开始计算。
+
+公开失败统一使用 `QverisError` 层级（`QverisApiError`、`QverisTransportError`、`QverisCredentialError`、`QverisContractError`、`QverisClientClosedError`）。错误会保留安全的机器字段和不可变 `RequestMetadata`，但不会保留原始 HTTP request/response、bearer credential、签名 URL 或底层异常对象。
+
+### 从 0.5 迁移
+
+- `max_retries` 仅用于读和审计操作，不再控制付费调用。
+- `call(..., respond_with=...)` 不再静默执行旧版重放；只应在短期迁移窗口使用 `compatibility_mode="legacy_optional_fields"`。
+- 捕获 `QverisError` 或其类型化子类，不再捕获 `httpx.HTTPStatusError` / 原始 transport 异常。
+- 响应元数据位于 `response.request_metadata`，不会进入 wire 序列化。
+
+Capability Resolve/Query、selection token、idempotency key 和 execution lookup 只会在对应端点及字段进入公开 OpenAPI 后提供；client 不会提前发明临时 wire 字段。
+
 ## API 参考
 
 [根据源码生成的 API 参考](python-sdk-api.md)列出当前公开 client、Agent、配置和响应模型的签名。
@@ -193,11 +228,10 @@ Sphinx 会根据 Python 对象与 docstring 重新生成该页面，CI 同时检
 
 | 方法 | REST 端点 | 用途 |
 |------|-----------|------|
-| `discover(query, limit=20, session_id=None, view=None, lang=None)` | `POST /search` | 发现能力；`view="routing"` 返回精简 routing card（免费） |
-| `inspect(tool_ids, search_id=None, session_id=None)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
-| `call(tool_id, parameters, search_id=None, session_id=None, max_response_size=None, respond_with=None)` | `POST /tools/execute` | 执行能力；可选择完整、摘要或 JSONPath 字段 |
-
-投影参数仅在显式指定时发送。旧服务返回 `422 extra_forbidden` 时仅移除对应可选字段并重试一次；无效投影仍按错误返回。
+| `discover(query, limit=20, session_id=None, view=None, lang=None, timeout=None, correlation_id=None)` | `POST /search` | 发现能力；`view="routing"` 返回精简 routing card（免费） |
+| `inspect(tool_ids, search_id=None, session_id=None, timeout=None, correlation_id=None)` | `POST /tools/by-ids` | 获取能力完整元数据（免费） |
+| `probe(tool_id, parameters=None, checks=None, live_budget="none", timeout=None, correlation_id=None)` | `POST /tools/probe` | 校验参数并请求零成本报价 |
+| `call(tool_id, parameters, ..., compatibility_mode="strict", timeout=None, correlation_id=None)` | `POST /tools/execute` | 使用严格 single-submit 语义执行能力 |
 | `usage(**filters)` | `GET /auth/usage/history/v2` | 审计请求状态与扣费结果 |
 | `ledger(**filters)` | `GET /auth/credits/ledger` | 查看最终积分余额变动 |
 | `handle_tool_call(func_name, func_args, session_id=None)` | — | 把 LLM 工具调用桥接到对应的 QVeris 方法 |
@@ -206,6 +240,8 @@ Sphinx 会根据 Python 对象与 docstring 重新生成该页面，CI 同时检
 `tool_ids` 接受单个字符串或可迭代对象。`usage(...)` 和 `ledger(...)` 接受仅关键字过滤参数，如 `start_date`、`end_date`、`summary`（默认 `True`）、`bucket`、`charge_outcome`、`execution_id`、`search_id`、`direction`、`entry_type`、`min_credits`、`max_credits`、`limit`、`page`、`page_size`。
 
 仍保留向后兼容别名：`search_tools` → `discover`，`get_tools_by_ids` → `inspect`，`execute_tool` → `call`。
+
+投影参数仅在显式指定时发送。Discover 的读侧投影兼容仍然有界；付费调用只有在显式选择已弃用兼容模式时才会重放。无效投影仍按错误返回。
 
 ### `Agent`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed
+
+- Paid `qveris call` requests are now strict single-submit: the CLI does not retry `429`/`503`, replay after OAuth refresh on `401`, or remove a rejected projection field and resubmit. Read commands retain bounded retry and OAuth refresh behavior. ([#273])
+
 ## [0.9.0] - 2026-07-23
 
 ### Added
@@ -124,3 +128,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#12]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/12
 [#10]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/10
 [#9]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/9
+[#273]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/273

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -248,7 +248,7 @@ qveris call 1 --params '{"symbol": "AAPL"}' --codegen python
 qveris call 1 --params '{"symbol": "AAPL"}' --codegen js
 ```
 
-Projection flags are opt-in. If an older service explicitly rejects a projection field as unknown, the CLI retries once without only that field. Invalid projections are not downgraded and remain `422` errors.
+Projection flags are opt-in. A paid call is always single-submit: the CLI does not retry `429`/`503`, replay after OAuth refresh on `401`, or remove a rejected projection field and resubmit. Projection rejections and invalid projections remain `422` errors.
 
 #### Response Truncation
 
@@ -419,6 +419,8 @@ Rate-limited (`429`) and transient (`503`) responses are retried automatically: 
 # Tune or disable via env
 export QVERIS_MAX_RETRIES=5   # default 3; 0 disables
 ```
+
+This setting applies to read and audit commands only. `qveris call` never retries automatically.
 
 ### Config File
 

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -43,6 +43,7 @@ async function requestJson(
     // Retry rate-limited (429) / transient (503) responses: honor Retry-After,
     // otherwise exponential backoff with jitter, bounded by maxRetries.
     maxRetries = resolveMaxRetries(process.env.QVERIS_MAX_RETRIES),
+    allowAuthReplay = true,
   },
 ) {
   const url = new URL(baseUrl.replace(/\/+$/, "") + path);
@@ -76,7 +77,12 @@ async function requestJson(
         redirect: "error",
       });
 
-      if (response.status === 401 && !authRetried && typeof credentialProvider.refreshCredential === "function") {
+      if (
+        allowAuthReplay &&
+        response.status === 401 &&
+        !authRetried &&
+        typeof credentialProvider.refreshCredential === "function"
+      ) {
         authRetried = true;
         await response.body?.cancel?.().catch(() => {});
         await credentialProvider.refreshCredential();
@@ -263,22 +269,20 @@ export async function callTool({
   timeoutMs = 120000,
 }) {
   const baseUrl = getBaseUrl(baseUrlFlag, apiKey === undefined && credentialProvider === undefined);
-  return requestWithOptionalFieldFallback(
-    "/tools/execute",
-    {
-      credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
-      baseUrl,
-      query: { tool_id: toolId },
-      body: {
-        search_id: discoveryId,
-        parameters,
-        max_response_size: maxResponseSize,
-        ...(respondWith !== undefined && { respond_with: respondWith }),
-      },
-      timeoutMs,
+  return requestJson("/tools/execute", {
+    credentialProvider: resolveCredentialProvider({ apiKey, credentialProvider }),
+    baseUrl,
+    query: { tool_id: toolId },
+    body: {
+      search_id: discoveryId,
+      parameters,
+      max_response_size: maxResponseSize,
+      ...(respondWith !== undefined && { respond_with: respondWith }),
     },
-    new Set(["respond_with"]),
-  );
+    timeoutMs,
+    maxRetries: 0,
+    allowAuthReplay: false,
+  });
 }
 
 export async function getCredits({ apiKey, credentialProvider, baseUrl: baseUrlFlag, timeoutMs = 30000 }) {

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -12,6 +13,10 @@ import {
   unwrapApiResponse,
 } from "../src/client/api.mjs";
 import { CliError } from "../src/errors/handler.mjs";
+
+const PAID_CALL_POLICY = JSON.parse(
+  readFileSync(new URL("../../../test-fixtures/paid-call-policy.json", import.meta.url), "utf8"),
+);
 
 function withMockFetch(handler, fn) {
   const original = globalThis.fetch;
@@ -179,11 +184,12 @@ test("API client preserves read projection fallback but never resubmits a paid c
   ]);
 
   const callBodies = [];
+  const previous = PAID_CALL_POLICY.contract_fixtures.n_minus_1;
   await assert.rejects(
     withMockFetch(
       (_url, options) => {
         callBodies.push(JSON.parse(options.body));
-        return jsonResponse({ detail: [{ type: "extra_forbidden", loc: ["body", "respond_with"] }] }, { status: 422 });
+        return jsonResponse(previous.body, { status: previous.status });
       },
       () =>
         callTool({

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -145,7 +145,7 @@ test("API client maps discover, inspect, probe, call, credits, usage, and ledger
   ]);
 });
 
-test("API client passes projections and retries once when a legacy service rejects optional fields", async () => {
+test("API client preserves read projection fallback but never resubmits a paid call", async () => {
   const discoverBodies = [];
   await withMockFetch(
     (_url, options) => {
@@ -179,24 +179,23 @@ test("API client passes projections and retries once when a legacy service rejec
   ]);
 
   const callBodies = [];
-  await withMockFetch(
-    (_url, options) => {
-      const body = JSON.parse(options.body);
-      callBodies.push(body);
-      if (callBodies.length === 1) {
+  await assert.rejects(
+    withMockFetch(
+      (_url, options) => {
+        callBodies.push(JSON.parse(options.body));
         return jsonResponse({ detail: [{ type: "extra_forbidden", loc: ["body", "respond_with"] }] }, { status: 422 });
-      }
-      return jsonResponse({ execution_id: "exec-1", success: true, result: { data: {} } });
-    },
-    () =>
-      callTool({
-        apiKey: "sk-test",
-        baseUrl: "https://unit.test/api/v1",
-        toolId: "weather-tool",
-        discoveryId: "search-1",
-        parameters: {},
-        respondWith: "summary",
-      }),
+      },
+      () =>
+        callTool({
+          apiKey: "sk-test",
+          baseUrl: "https://unit.test/api/v1",
+          toolId: "weather-tool",
+          discoveryId: "search-1",
+          parameters: {},
+          respondWith: "summary",
+        }),
+    ),
+    (error) => error instanceof CliError && error.status === 422,
   );
   assert.deepEqual(callBodies, [
     {
@@ -205,7 +204,6 @@ test("API client passes projections and retries once when a legacy service rejec
       max_response_size: 102400,
       respond_with: "summary",
     },
-    { search_id: "search-1", parameters: {}, max_response_size: 102400 },
   ]);
 });
 
@@ -315,6 +313,26 @@ test("OAuth credentials refresh once on 401 and business 403 is not retried", as
     /forbidden/,
   );
   assert.equal(requests, 1);
+  assert.equal(refreshes, 1);
+
+  let paidRequests = 0;
+  await assert.rejects(
+    withMockFetch(
+      () => {
+        paidRequests += 1;
+        return jsonResponse({ message: "expired" }, { status: 401 });
+      },
+      () =>
+        callTool({
+          credentialProvider: provider,
+          baseUrl: "https://unit.test/api/v1",
+          toolId: "paid-tool",
+          parameters: {},
+        }),
+    ),
+    (error) => error instanceof CliError && error.code === "AUTH_INVALID_KEY",
+  );
+  assert.equal(paidRequests, 1);
   assert.equal(refreshes, 1);
 
   const oauthProvider = {

--- a/packages/cli/test/retry.test.mjs
+++ b/packages/cli/test/retry.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { discoverTools } from "../src/client/api.mjs";
+import { callTool, discoverTools } from "../src/client/api.mjs";
 import { CliError } from "../src/errors/handler.mjs";
 import {
   computeRetryDelayMs,
@@ -9,6 +10,10 @@ import {
   parseRetryAfterMs,
   resolveMaxRetries,
 } from "../src/client/retry.mjs";
+
+const PAID_CALL_POLICY = JSON.parse(
+  readFileSync(new URL("../../../test-fixtures/paid-call-policy.json", import.meta.url), "utf8"),
+);
 
 // --- pure helpers ------------------------------------------------------------
 
@@ -140,3 +145,31 @@ test("QVERIS_MAX_RETRIES=0 disables retrying", async () => {
     ),
   );
 });
+
+for (const status of PAID_CALL_POLICY.read_operations.retryable_statuses) {
+  test(`paid call is single-submit on HTTP ${status}`, async () => {
+    let calls = 0;
+    await withEnv("QVERIS_MAX_RETRIES", "3", () =>
+      withMockFetch(
+        () => {
+          calls += 1;
+          return new Response(JSON.stringify({ message: "retry later" }), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        },
+        async () => {
+          await assert.rejects(
+            callTool({
+              apiKey: "sk-test",
+              baseUrl: "https://unit.test/api/v1",
+              toolId: "paid-tool",
+              parameters: {},
+            }),
+          );
+          assert.equal(calls, PAID_CALL_POLICY.paid_call.expected_http_attempts);
+        },
+      ),
+    );
+  });
+}

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed
+
+- Paid `call()` operations are strict single-submit by default and no longer retry `429`/`503` or automatically remove a rejected projection field and replay. The deprecated `compatibilityMode: "legacyOptionalFields"` opt-in preserves the legacy projection replay when explicitly required. ([#273])
+
 ## [0.6.0] - 2026-07-23
 
 ### Added
@@ -66,3 +70,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#106]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/106
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
 [#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256
+[#273]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/273

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -90,7 +90,7 @@ never pass through the SDK.
 | --- | --- | --- | --- |
 | `discover(query, options?)` | Free | `SearchResponse` | `options`: `limit`, `sessionId`, `view`, `lang`, `timeoutMs`. `view: 'routing'` returns compact routing cards; omitted/default is full. |
 | `inspect(toolIds, options?)` | Free | `SearchResponse` | `toolIds` is one id or an array; `options`: `searchId`, `sessionId`, `timeoutMs`. An empty array resolves locally with no request. |
-| `call(toolId, options)` | Credits | `ExecuteResponse` | `options`: `parameters` (required), `searchId`, `maxResponseSize`, `respondWith`, `sessionId`, `timeoutMs`. `respondWith` accepts `full`, `summary`, or `fields:<JSONPath,...>`. |
+| `call(toolId, options)` | Credits | `ExecuteResponse` | Strict single-submit by default. `respondWith` accepts `full`, `summary`, or `fields:<JSONPath,...>`; deprecated `compatibilityMode: 'legacyOptionalFields'` explicitly enables one projection replay. |
 | `credits()` | Free | `CreditsResponse` | Current balance and bucket details. |
 | `usage(filters?)` | Free | `UsageEventsResponse` | Request-level audit; filter by `execution_id`, `search_id`, dates, `summary`, `limit`. |
 | `ledger(filters?)` | Free | `CreditsLedgerResponse` | Settled credit movements; filter by `direction`, dates, `summary`, `limit`. |
@@ -102,7 +102,7 @@ Key response fields:
 - **`SearchResponse`** — `search_id`, `total`, `results: ToolInfo[]` (`tool_id`, `name`, `description`, `params`, `examples.sample_parameters`, `stats.success_rate`, `stats.avg_execution_time_ms`, `expected_cost`, `why_recommended`).
 - **`ExecuteResponse`** — `execution_id`, `success`, `result`, `billing` (pre-settlement estimate; the final charge is in `usage()` / `ledger()`).
 
-Projection options are never sent unless explicitly configured. If a legacy service returns `422 extra_forbidden` for an optional projection field, the SDK retries once without that field; validation errors for an invalid projection are returned unchanged.
+Projection options are never sent unless explicitly configured. Paid calls do not retry `429`/`503` or automatically replay a rejected optional field. The deprecated `compatibilityMode: 'legacyOptionalFields'` opt-in enables exactly one projection fallback when an older service returns `422 extra_forbidden`; invalid projections remain errors.
 
 All types are exported from the package root (`import type { SearchResponse, ExecuteResponse, ToolInfo } from '@qverisai/sdk'`).
 
@@ -114,13 +114,13 @@ All types are exported from the package root (`import type { SearchResponse, Exe
 | `credentialProvider` | Async-capable bearer credential source; mutually exclusive with `apiKey` |
 | `baseUrl` / `QVERIS_BASE_URL` | API endpoint: constructor option > environment variable > built-in default |
 | `timeoutMs` | Default request timeout (30s; `call` defaults to 120s) |
-| `maxRetries` | Retries for rate-limited (429) / transient (503) responses (default 3; `0` disables) |
+| `maxRetries` | Read-operation retries for rate-limited (429) / transient (503) responses (default 3; `0` disables); paid calls never inherit it |
 
 API keys never select the endpoint. Endpoint overrides must be HTTP(S) URLs without credentials, a query string, or a fragment.
 
 ## Rate limiting & retries
 
-The client transparently retries rate-limited (`429`) and transient (`503`) responses: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Each wait is capped and retries are bounded by `maxRetries`, so a call never hangs.
+The client transparently retries rate-limited (`429`) and transient (`503`) responses for read/audit operations: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Each wait is capped and retries are bounded by `maxRetries`; paid calls remain single-submit.
 
 ```ts
 const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY!, maxRetries: 5 });

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Qveris } from './client.js';
@@ -7,6 +8,12 @@ import { QverisApiError } from './errors.js';
 import type { ToolCategory, ToolCapability } from './types.js';
 
 const API_KEY = 'sk-test-key';
+const PAID_CALL_POLICY = JSON.parse(
+  readFileSync(new URL('../../../test-fixtures/paid-call-policy.json', import.meta.url), 'utf8'),
+) as {
+  paid_call: { expected_http_attempts: number };
+  read_operations: { retryable_statuses: number[] };
+};
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {
@@ -407,7 +414,26 @@ describe('Qveris client', () => {
     expect(response.result).toMatchObject({ respond_with: 'summary' });
   });
 
-  it('call retries without respond_with only when a legacy service rejects the extra field', async () => {
+  it('call strict mode does not resubmit when a legacy service rejects respond_with', async () => {
+    const fetchMock = mockFetch(
+      {
+        detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'], msg: 'Extra input' }],
+      },
+      422,
+    );
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      new Qveris({ apiKey: API_KEY }).call('weather.forecast.v1', {
+        parameters: { city: 'London' },
+        respondWith: 'summary',
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('call legacy compatibility replays once without rejected respond_with', async () => {
     const success = {
       execution_id: 'exec-full',
       success: true,
@@ -425,13 +451,16 @@ describe('Qveris client', () => {
       )
       .mockResolvedValueOnce(jsonResponse(success));
     globalThis.fetch = fetchMock;
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     await new Qveris({ apiKey: API_KEY }).call('weather.forecast.v1', {
       parameters: { city: 'London' },
       respondWith: 'summary',
+      compatibilityMode: 'legacyOptionalFields',
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('may resubmit a paid call'));
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
       parameters: { city: 'London' },
       search_id: null,
@@ -689,5 +718,21 @@ describe('Qveris client', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(client.rateLimitRetryCount).toBe(0);
     });
+
+    it.each(PAID_CALL_POLICY.read_operations.retryable_statuses)(
+      'paid call is single-submit on HTTP %s',
+      async (status) => {
+        const fetchMock = mockFetch({ message: 'retry later' }, status);
+        globalThis.fetch = fetchMock;
+
+        await expect(
+          new Qveris({ apiKey: API_KEY, maxRetries: 3 }).call('paid-tool', {
+            parameters: {},
+          }),
+        ).rejects.toMatchObject({ status });
+
+        expect(fetchMock).toHaveBeenCalledTimes(PAID_CALL_POLICY.paid_call.expected_http_attempts);
+      },
+    );
   });
 });

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -13,6 +13,10 @@ const PAID_CALL_POLICY = JSON.parse(
 ) as {
   paid_call: { expected_http_attempts: number };
   read_operations: { retryable_statuses: number[] };
+  contract_fixtures: {
+    n: { status: number; body: { execution_id: string; success: boolean; result: { ok: boolean } } };
+    n_minus_1: { status: number; body: Record<string, unknown> };
+  };
 };
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -415,12 +419,8 @@ describe('Qveris client', () => {
   });
 
   it('call strict mode does not resubmit when a legacy service rejects respond_with', async () => {
-    const fetchMock = mockFetch(
-      {
-        detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'], msg: 'Extra input' }],
-      },
-      422,
-    );
+    const previous = PAID_CALL_POLICY.contract_fixtures.n_minus_1;
+    const fetchMock = mockFetch(previous.body, previous.status);
     globalThis.fetch = fetchMock;
 
     await expect(
@@ -434,22 +434,12 @@ describe('Qveris client', () => {
   });
 
   it('call legacy compatibility replays once without rejected respond_with', async () => {
-    const success = {
-      execution_id: 'exec-full',
-      success: true,
-      result: { data: { temperature: 18 } },
-    };
+    const current = PAID_CALL_POLICY.contract_fixtures.n;
+    const previous = PAID_CALL_POLICY.contract_fixtures.n_minus_1;
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        jsonResponse(
-          {
-            detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'], msg: 'Extra input' }],
-          },
-          422,
-        ),
-      )
-      .mockResolvedValueOnce(jsonResponse(success));
+      .mockResolvedValueOnce(jsonResponse(previous.body, previous.status))
+      .mockResolvedValueOnce(jsonResponse(current.body, current.status));
     globalThis.fetch = fetchMock;
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -154,6 +154,12 @@ export interface CallOptions {
   respondWith?: 'full' | 'summary' | `fields:${string}`;
   /** Per-request timeout override in milliseconds (default 120s) */
   timeoutMs?: number;
+  /**
+   * Strict mode never resubmits a paid call. The deprecated legacy mode may
+   * replay once without an optional field rejected by an older service.
+   * @default 'strict'
+   */
+  compatibilityMode?: 'strict' | 'legacyOptionalFields';
 }
 
 /** Options for {@link Qveris.probe}. */
@@ -318,11 +324,14 @@ export class Qveris {
       ...(options.respondWith !== undefined && { respond_with: options.respondWith }),
     };
     const timeoutMs = options.timeoutMs ?? EXECUTE_TIMEOUT_MS;
+    const compatibilityMode = options.compatibilityMode ?? 'strict';
     try {
       return await this.request<ExecuteResponse>('call', 'POST', endpoint, body, timeoutMs);
     } catch (error) {
+      if (compatibilityMode !== 'legacyOptionalFields') throw error;
       const unsupported = unsupportedOptionalFields(error, new Set(['respond_with']));
       if (unsupported.length === 0) throw error;
+      globalThis.console?.warn('QVeris legacyOptionalFields compatibility may resubmit a paid call and is deprecated.');
       delete body.respond_with;
       return this.request<ExecuteResponse>('call', 'POST', endpoint, body, timeoutMs);
     }
@@ -391,6 +400,7 @@ export class Qveris {
     // Retry rate-limited (429) / transient (503) responses: honor Retry-After,
     // otherwise exponential backoff with jitter, bounded by maxRetries. Each
     // attempt is a fresh fetch with its own timeout.
+    const retryLimit = operation === 'call' ? 0 : this.maxRetries;
     for (let attempt = 0; ; attempt++) {
       // Credential acquisition is not part of the API request timeout. Resolve
       // it for every attempt so a retry can refresh a short-lived token, and
@@ -414,7 +424,7 @@ export class Qveris {
           signal: controller.signal,
         });
 
-        if (RETRYABLE_STATUS.has(response.status) && attempt < this.maxRetries) {
+        if (RETRYABLE_STATUS.has(response.status) && attempt < retryLimit) {
           retryDelayMs = computeRetryDelayMs({
             retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
             attempt,

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed
+
+- Paid `call` / `execute_tool` requests are now strict single-submit: the MCP client does not retry `429`/`503` or remove a rejected projection field and resubmit. Read tools retain bounded retry behavior. ([#273])
+
 ## [0.12.0] - 2026-07-23
 
 ### Added
@@ -158,6 +162,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#140]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/140
 [#139]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/139
 [#126]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/126
+[#273]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/273
 [#122]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/122
 [#117]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/117
 [#105]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/105

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -174,7 +174,7 @@ Call a discovered tool with specific parameters.
 
 The `call` response may include compact pre-settlement `billing`. Final charge status should be checked with `usage_history` or `credits_ledger`.
 
-Projection inputs are opt-in. If an older service explicitly rejects one as an unknown field, the MCP server retries once without only that field. Invalid projection errors remain errors and are never silently downgraded.
+Projection inputs are opt-in. Paid `call` / `execute_tool` requests are always single-submit: the MCP server does not retry `429`/`503` or remove a rejected projection field and resubmit. Projection errors remain errors.
 
 ### `usage_history`
 
@@ -339,7 +339,7 @@ npx -y @qverisai/mcp
 |----------|----------|-------------|
 | `QVERIS_API_KEY` | ✓ | Your QVeris API key |
 | `QVERIS_BASE_URL` | | Override the built-in API base URL |
-| `QVERIS_MAX_RETRIES` | | Retries for rate-limited (429) / transient (503) responses (default 3; `0` disables). Honors `Retry-After`, else backs off with jitter. |
+| `QVERIS_MAX_RETRIES` | | Read-operation retries for rate-limited (429) / transient (503) responses (default 3; `0` disables). Paid calls never inherit this setting. |
 | `QVERIS_MCP_TRANSPORT` | | `stdio` (default) or `http` |
 | `QVERIS_MCP_HTTP_PORT` | | HTTP port (default `3000`; setting it implies HTTP mode) |
 | `QVERIS_MCP_HTTP_HOST` | | HTTP bind host (default `127.0.0.1`) |

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -11,6 +11,9 @@ const PAID_CALL_POLICY = JSON.parse(
 ) as {
   paid_call: { expected_http_attempts: number };
   read_operations: { retryable_statuses: number[] };
+  contract_fixtures: {
+    n_minus_1: { status: number; body: Record<string, unknown> };
+  };
 };
 
 describe('QverisClient', () => {
@@ -511,14 +514,13 @@ describe('QverisClient', () => {
     });
 
     it('should not resubmit a paid call for a legacy extra-field rejection', async () => {
+      const previous = PAID_CALL_POLICY.contract_fixtures.n_minus_1;
       fetchMock.mockResolvedValueOnce({
         ok: false,
-        status: 422,
+        status: previous.status,
         statusText: 'Unprocessable Entity',
         headers: new Headers(),
-        json: async () => ({
-          detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'] }],
-        }),
+        json: async () => previous.body,
       });
 
       await expect(

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -2,8 +2,16 @@
  * Unit tests for the Qveris API Client
  */
 
+import { readFileSync } from 'node:fs';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QverisClient, createClientFromEnv } from './client.js';
+
+const PAID_CALL_POLICY = JSON.parse(
+  readFileSync(new URL('../../../../test-fixtures/paid-call-policy.json', import.meta.url), 'utf8'),
+) as {
+  paid_call: { expected_http_attempts: number };
+  read_operations: { retryable_statuses: number[] };
+};
 
 describe('QverisClient', () => {
   describe('constructor', () => {
@@ -502,30 +510,26 @@ describe('QverisClient', () => {
       );
     });
 
-    it('should retry without respond_with only for a legacy extra-field rejection', async () => {
-      fetchMock
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 422,
-          statusText: 'Unprocessable Entity',
-          headers: new Headers(),
-          json: async () => ({
-            detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'] }],
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ execution_id: 'exec-full', success: true, result: { data: {} } }),
-        });
-
-      await client.executeTool('weather-tool', {
-        search_id: 'search-123',
-        parameters: {},
-        respond_with: 'summary',
+    it('should not resubmit a paid call for a legacy extra-field rejection', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: new Headers(),
+        json: async () => ({
+          detail: [{ type: 'extra_forbidden', loc: ['body', 'respond_with'] }],
+        }),
       });
 
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(fetchMock.mock.calls[1][1].body).toBe(JSON.stringify({ search_id: 'search-123', parameters: {} }));
+      await expect(
+        client.executeTool('weather-tool', {
+          search_id: 'search-123',
+          parameters: {},
+          respond_with: 'summary',
+        }),
+      ).rejects.toMatchObject({ status: 422 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('should not downgrade an invalid projection', async () => {
@@ -548,6 +552,28 @@ describe('QverisClient', () => {
       ).rejects.toMatchObject({ status: 422 });
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
+
+    it.each(PAID_CALL_POLICY.read_operations.retryable_statuses)(
+      'should single-submit a paid call on HTTP %s',
+      async (status) => {
+        fetchMock.mockResolvedValue({
+          ok: false,
+          status,
+          statusText: 'Retry later',
+          headers: new Headers(),
+          json: async () => ({ message: 'retry later' }),
+        });
+
+        await expect(
+          client.executeTool('weather-tool', {
+            search_id: 'search-123',
+            parameters: {},
+          }),
+        ).rejects.toMatchObject({ status });
+
+        expect(fetchMock).toHaveBeenCalledTimes(PAID_CALL_POLICY.paid_call.expected_http_attempts);
+      },
+    );
 
     it('should URL-encode tool_id', async () => {
       fetchMock.mockResolvedValueOnce({

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -167,6 +167,7 @@ export class QverisClient {
     // Retry rate-limited (429) / transient (503) responses: honor Retry-After,
     // otherwise exponential backoff with jitter, bounded by maxRetries. Each
     // attempt is a fresh fetch with its own timeout.
+    const retryLimit = operation === 'call' ? 0 : this.maxRetries;
     for (let attempt = 0; ; attempt++) {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
@@ -184,7 +185,7 @@ export class QverisClient {
           signal: controller.signal,
         });
 
-        if (RETRYABLE_STATUS.has(response.status) && attempt < this.maxRetries) {
+        if (RETRYABLE_STATUS.has(response.status) && attempt < retryLimit) {
           retryDelayMs = computeRetryDelayMs({
             retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
             attempt,
@@ -319,15 +320,7 @@ export class QverisClient {
    */
   async executeTool(toolId: string, request: ExecuteRequest): Promise<ExecuteResponse> {
     const endpoint = `/tools/execute?tool_id=${encodeURIComponent(toolId)}`;
-    const body: Record<string, unknown> = { ...request };
-    try {
-      return await this.request<ExecuteResponse>('call', 'POST', endpoint, body, EXECUTE_TIMEOUT_MS);
-    } catch (error) {
-      const unsupported = unsupportedOptionalFields(error, new Set(['respond_with']));
-      if (unsupported.length === 0) throw error;
-      delete body.respond_with;
-      return this.request<ExecuteResponse>('call', 'POST', endpoint, body, EXECUTE_TIMEOUT_MS);
-    }
+    return this.request<ExecuteResponse>('call', 'POST', endpoint, request, EXECUTE_TIMEOUT_MS);
   }
 
   /**

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added credential-safe typed exceptions, immutable per-operation `RequestMetadata`, operation-aware `CredentialContext`, read/call timeout settings, and supported injection of a shared HTTP client or owned transport/connection limits. ([#273])
+
+### Changed
+
+- Paid `call()` operations are strict single-submit by default: they no longer retry `429`/`503` or automatically replay after a legacy projection rejection. The deprecated `compatibility_mode="legacy_optional_fields"` opt-in preserves the old projection fallback when explicitly required. Read operations continue to use bounded `max_retries`. ([#273])
+
+### Security
+
+- Removed raw `httpx` request, response, transport exception, credential-provider exception, signed URL, and unredacted response-body data from public error/debug paths. ([#273])
+
 ## [0.5.0] - 2026-07-23
 
 ### Added
@@ -104,3 +116,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#34]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/34
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
 [#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256
+[#273]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/273

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -97,13 +97,13 @@ First-class typed APIs:
 |--------|---------------|---------|
 | `discover(query, ..., view=None, lang=None)` | `POST /search` | Find capabilities; `view="routing"` returns compact routing cards |
 | `inspect(tool_ids, ...)` | `POST /tools/by-ids` | Fetch full capability metadata |
-| `call(tool_id, parameters, ..., respond_with=None)` | `POST /tools/execute` | Execute a selected capability; request `full`, `summary`, or selected JSONPath fields |
+| `call(tool_id, parameters, ..., respond_with=None)` | `POST /tools/execute` | Execute a selected capability with strict single-submit semantics |
 | `usage(...)` | `GET /auth/usage/history/v2` | Audit request status and charge outcome |
 | `ledger(...)` | `GET /auth/credits/ledger` | Inspect final credit balance movements |
 
 Backward-compatible aliases remain available: `search_tools`, `get_tools_by_ids`, and `execute_tool`.
 
-Projection arguments are never sent unless explicitly configured. If a legacy service returns `422 extra_forbidden` for an optional projection field, the SDK retries once without that field; invalid projection errors are returned unchanged.
+Projection arguments are never sent unless explicitly configured. A paid `call()` is strict single-submit by default: it does not retry `429`/`503`, transport/timeout failures, or a rejected optional field. If an older service requires projection fallback, `compatibility_mode="legacy_optional_fields"` explicitly opts into one deprecated replay and records it in `response.request_metadata`.
 
 ## Typed Models
 
@@ -152,7 +152,7 @@ Use the SDK at the level that matches your application:
 
 ## Rate limiting & retries
 
-The client transparently retries rate-limited (`429`) and transient (`503`) responses: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Each sleep is capped and the number of retries is bounded, so a call never hangs indefinitely.
+The client transparently retries rate-limited (`429`) and transient (`503`) responses for read and audit operations: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Paid `call()` requests never inherit this retry policy.
 
 ```python
 # Default is 3 retries; tune via config or QVERIS_MAX_RETRIES.
@@ -161,7 +161,7 @@ client = QverisClient(QverisConfig(max_retries=5))
 print(client.rate_limit_retries)  # how many times it backed off (pressure, not failures)
 ```
 
-Set `max_retries=0` to disable automatic retrying. Rate-limit backoff is retried pressure rather than failure — inspect `client.rate_limit_retries` to observe it instead of treating the retried `429`s as errors.
+Set `max_retries=0` to disable read-operation retrying. Rate-limit backoff is retried pressure rather than failure — inspect `client.rate_limit_retries` to observe it instead of treating the retried `429`s as errors. Every typed response and SDK error exposes immutable `request_metadata` with physical attempt, retry, compatibility replay, request ID, and elapsed-time counts.
 
 ## Custom LLM Providers
 

--- a/packages/python-sdk/qveris/__init__.py
+++ b/packages/python-sdk/qveris/__init__.py
@@ -3,6 +3,15 @@ from .agent.core import Agent
 from .client.api import QverisClient
 from .config import QverisConfig, AgentConfig
 from .credentials import ApiKeyCredentialProvider, CredentialContext, CredentialProvider
+from .errors import (
+    QverisApiError,
+    QverisClientClosedError,
+    QverisContractError,
+    QverisCredentialError,
+    QverisError,
+    QverisTransportError,
+    RequestMetadata,
+)
 from .types import (
     CompactBillingStatement,
     CreditsLedgerItem,
@@ -29,6 +38,13 @@ __all__ = [
     "CredentialContext",
     "CredentialProvider",
     "ApiKeyCredentialProvider",
+    "RequestMetadata",
+    "QverisError",
+    "QverisApiError",
+    "QverisTransportError",
+    "QverisCredentialError",
+    "QverisContractError",
+    "QverisClientClosedError",
     "AgentConfig",
     "Message",
     "StreamEvent",

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -93,6 +93,7 @@ _SENSITIVE_KEYS = frozenset(
 )
 _BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
 _API_KEY_PATTERN = re.compile(r"(?i)\bsk-[a-z0-9._-]{8,}")
+_URL_PATTERN = re.compile(r"(?i)https?://[^\s\"'<>]+")
 _SIGNED_URL_MARKERS = (
     "x-amz-signature=",
     "x-goog-signature=",
@@ -100,6 +101,7 @@ _SIGNED_URL_MARKERS = (
     "sig=",
     "token=",
 )
+_NORMALIZED_SENSITIVE_KEYS = frozenset(re.sub(r"[^a-z0-9]", "", key.lower()) for key in _SENSITIVE_KEYS)
 
 
 @dataclass
@@ -452,26 +454,32 @@ class QverisClient:
         if depth >= 8:
             return "<diagnostic value omitted>"
         if isinstance(value, dict):
-            safe: Dict[Any, Any] = {}
+            safe_dict: Dict[Any, Any] = {}
             for index, (key, item) in enumerate(value.items()):
                 if index >= 100:
-                    safe["__truncated__"] = True
+                    safe_dict["__truncated__"] = True
                     break
-                safe[key] = "***" if str(key).lower() in _SENSITIVE_KEYS else self._redact_sensitive(item, depth + 1)
-            return safe
+                normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+                safe_dict[key] = (
+                    "***" if normalized_key in _NORMALIZED_SENSITIVE_KEYS else self._redact_sensitive(item, depth + 1)
+                )
+            return safe_dict
         if isinstance(value, list):
             return [self._redact_sensitive(item, depth + 1) for item in value[:100]]
         if isinstance(value, tuple):
             return tuple(self._redact_sensitive(item, depth + 1) for item in value[:100])
         if isinstance(value, str):
-            safe = _BEARER_PATTERN.sub("Bearer ***", value)
-            safe = _API_KEY_PATTERN.sub("***", safe)
-            lower = safe.lower()
-            if safe.startswith(("http://", "https://")) and any(marker in lower for marker in _SIGNED_URL_MARKERS):
-                return "***"
-            if len(safe) > 8192:
-                return safe[:8192] + "..."
-            return safe
+            safe_text = _BEARER_PATTERN.sub("Bearer ***", value)
+            safe_text = _API_KEY_PATTERN.sub("***", safe_text)
+
+            def redact_signed_url(match: re.Match[str]) -> str:
+                url = match.group(0)
+                return "***" if any(marker in url.lower() for marker in _SIGNED_URL_MARKERS) else url
+
+            safe_text = _URL_PATTERN.sub(redact_signed_url, safe_text)
+            if len(safe_text) > 8192:
+                return safe_text[:8192] + "..."
+            return safe_text
         return value
 
     def _safe_message(self, value: Any, fallback: str) -> str:
@@ -575,7 +583,7 @@ class QverisClient:
             return status >= 400
         return False
 
-    async def close(self):
+    async def close(self) -> None:
         """
         Close the underlying HTTP client.
 
@@ -588,14 +596,37 @@ class QverisClient:
                 self._closing = True
             try:
                 await self._no_active_requests.wait()
-                if self._owns_http_client:
-                    await self.client.aclose()
             except asyncio.CancelledError:
-                async with self._lifecycle_lock:
+                # No transport close has started, so cancellation can safely
+                # return the wrapper to its open state.
+                self._closing = False
+                raise
+
+            if not self._owns_http_client:
+                self._closed = True
+                self._closing = False
+                return
+
+            # httpx marks AsyncClient closed before awaiting transport.aclose().
+            # Once that boundary is crossed, cancellation must not make this
+            # wrapper appear reusable while its transport is half-closed.
+            close_task = asyncio.create_task(self.client.aclose())
+            try:
+                await asyncio.shield(close_task)
+            except asyncio.CancelledError:
+                try:
+                    await close_task
+                finally:
+                    self._closed = True
                     self._closing = False
                 raise
-            async with self._lifecycle_lock:
+            except Exception:
                 self._closed = True
+                self._closing = False
+                raise
+
+            self._closed = True
+            self._closing = False
 
     async def discover(
         self,

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -25,13 +25,33 @@ If `QVERIS_API_KEY` is configured (via `QverisConfig.api_key`), it is sent as:
 Debug logs redact the token value.
 """
 
+import asyncio
 import json
+import re
+import time
+import warnings
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
 
 import httpx
 
 from ..config import QverisConfig
-from ..credentials import ApiKeyCredentialProvider, CredentialContext, CredentialProvider, resolve_credential
+from ..credentials import (
+    ApiKeyCredentialProvider,
+    CredentialContext,
+    CredentialProvider,
+    CredentialResolutionError,
+    resolve_credential,
+)
+from ..errors import (
+    QverisApiError,
+    QverisClientClosedError,
+    QverisContractError,
+    QverisCredentialError,
+    QverisError,
+    QverisTransportError,
+    RequestMetadata,
+)
 from ..observability import (
     ATTR_CREDITS,
     ATTR_ELAPSED_MS,
@@ -55,6 +75,46 @@ from ..types import (
     UsageHistoryResponse,
 )
 from .retry import RetryPolicy
+
+
+_SENSITIVE_KEYS = frozenset(
+    {
+        "authorization",
+        "api_key",
+        "apikey",
+        "access_token",
+        "refresh_token",
+        "token",
+        "selection_token",
+        "full_content_file_url",
+        "cookie",
+        "set-cookie",
+    }
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
+_API_KEY_PATTERN = re.compile(r"(?i)\bsk-[a-z0-9._-]{8,}")
+_SIGNED_URL_MARKERS = (
+    "x-amz-signature=",
+    "x-goog-signature=",
+    "signature=",
+    "sig=",
+    "token=",
+)
+
+
+@dataclass
+class _RequestState:
+    operation: str
+    started_at: float
+    http_attempts: int = 0
+    compatibility_replays: int = 0
+    request_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _SendFailure:
+    error_type: str
+    message: str
 
 
 def _pre_settlement_credits(response: ToolExecutionResponse) -> Optional[float]:
@@ -97,6 +157,9 @@ class QverisClient:
         debug_callback: Optional[Callable[[str], None]] = None,
         *,
         credential_provider: Optional[CredentialProvider] = None,
+        http_client: Optional[httpx.AsyncClient] = None,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+        limits: Optional[httpx.Limits] = None,
     ):
         self.config = config or QverisConfig()
         self.debug_callback = debug_callback
@@ -113,33 +176,226 @@ class QverisClient:
         self.headers = {
             "Content-Type": "application/json",
         }
+        if http_client is not None and (transport is not None or limits is not None):
+            raise ValueError("http_client cannot be combined with transport or limits")
 
         # httpx automatically respects HTTP_PROXY/HTTPS_PROXY env vars (kept by
         # using the default transport). Retries are layered on top at the client
         # level so rate-limited (429) / transient (503) responses back off
         # (Retry-After / jitter) instead of failing the caller.
         self.base_url = self.config.base_url.rstrip("/") + "/"
-        self.client = httpx.AsyncClient(
+        self._owns_http_client = http_client is None
+        self.client = http_client or httpx.AsyncClient(
             base_url=self.base_url,
             headers=self.headers,
-            timeout=60.0,
+            timeout=self.config.read_timeout,
+            transport=transport,
+            limits=limits or httpx.Limits(),
         )
         self._retry = RetryPolicy(max_retries=self.config.max_retries)
+        self._lifecycle_lock = asyncio.Lock()
+        self._close_lock = asyncio.Lock()
+        self._no_active_requests = asyncio.Event()
+        self._no_active_requests.set()
+        self._active_requests = 0
+        self._closing = False
+        self._closed = False
 
-    async def _send(self, method: str, endpoint: str, **kwargs: Any) -> httpx.Response:
-        """Send a request through the retry policy (429/503 backoff)."""
+    async def _begin_request(self, state: _RequestState) -> None:
+        async with self._lifecycle_lock:
+            if self._closing or self._closed:
+                metadata = self._request_metadata(state)
+                raise QverisClientClosedError(
+                    "QVeris client is closing or closed",
+                    operation=state.operation,
+                    request_metadata=metadata,
+                )
+            self._active_requests += 1
+            self._no_active_requests.clear()
+
+    async def _ensure_open(self, state: _RequestState) -> None:
+        async with self._lifecycle_lock:
+            if self._closing or self._closed:
+                raise QverisClientClosedError(
+                    "QVeris client is closing or closed",
+                    operation=state.operation,
+                    request_metadata=self._request_metadata(state),
+                )
+
+    async def _end_request(self) -> None:
+        async with self._lifecycle_lock:
+            self._active_requests -= 1
+            if self._active_requests == 0:
+                self._no_active_requests.set()
+
+    def _request_metadata(self, state: _RequestState) -> RequestMetadata:
+        retries = max(0, state.http_attempts - 1 - state.compatibility_replays)
+        return RequestMetadata(
+            operation=state.operation,
+            http_attempts=state.http_attempts,
+            retry_attempts=retries,
+            compatibility_replays=state.compatibility_replays,
+            request_id=state.request_id,
+            elapsed_ms=max(0.0, (time.monotonic() - state.started_at) * 1000),
+        )
+
+    def _credential_context(
+        self,
+        operation: str,
+        *,
+        session_id: Optional[str],
+        correlation_id: Optional[str],
+    ) -> CredentialContext:
+        purpose = {
+            "call": "paid_execution",
+            "usage": "usage_audit",
+            "ledger": "ledger_audit",
+        }.get(operation, "data_read")
+        return CredentialContext(
+            resource=self.config.base_url,
+            audience=self.config.credential_audience,
+            scopes=self.config.credential_scopes,
+            operation=operation,  # type: ignore[arg-type]
+            purpose=purpose,  # type: ignore[arg-type]
+            session_id=session_id,
+            correlation_id=correlation_id,
+        )
+
+    @staticmethod
+    def _scrub_request_authorization(request: Any) -> None:
+        headers = getattr(request, "headers", None)
+        if headers is None:
+            return
+        try:
+            if "Authorization" in headers:
+                headers["Authorization"] = "Bearer ***"
+        except Exception:
+            pass
+
+    @staticmethod
+    def _scrub_response_credential(response: httpx.Response, credential: Optional[str]) -> None:
+        """Remove the attempt credential before a response leaves the transport boundary."""
+        if not credential:
+            return
+        secret = credential.encode()
+        try:
+            response._content = response.content.replace(secret, b"***")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        try:
+            for key, value in list(response.headers.multi_items()):
+                if credential in value:
+                    response.headers[key] = value.replace(credential, "***")
+        except Exception:
+            pass
+
+    def _scrub_error_response(self, response: httpx.Response) -> None:
+        """Replace an error body with its bounded, recursively redacted form."""
+        if response.status_code < 400:
+            return
+        try:
+            safe_body = self._redact_sensitive(response.json())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            safe_body = {"body": "<non-JSON error body omitted>"}
+        content = json.dumps(safe_body, ensure_ascii=False).encode()
+        response._content = content  # type: ignore[attr-defined]
+        response.headers["content-length"] = str(len(content))
+
+    async def _send(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        operation: str,
+        state: _RequestState,
+        session_id: Optional[str] = None,
+        correlation_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Send a request with operation-specific retry and a safe error boundary."""
         request_headers = dict(kwargs.pop("headers", {}))
 
-        async def prepare_attempt() -> Dict[str, Any]:
-            credential = await resolve_credential(
-                self.credential_provider,
-                CredentialContext(resource=self.config.base_url, scopes=()),
-            )
-            headers = dict(request_headers)
-            headers["Authorization"] = f"Bearer {credential}"
-            return {"headers": headers}
+        def on_attempt() -> None:
+            state.http_attempts += 1
 
-        return await self._retry.send(self.client, method, endpoint, prepare_attempt=prepare_attempt, **kwargs)
+        request_timeout = timeout
+        if request_timeout is None:
+            request_timeout = self.config.call_timeout if operation == "call" else self.config.read_timeout
+        retry_limit = 0 if operation == "call" else self.config.max_retries
+        url = self.base_url + endpoint.lstrip("/")
+
+        async def perform() -> Union[httpx.Response, _SendFailure]:
+            credential: Optional[str] = None
+
+            async def prepare_attempt() -> Dict[str, Any]:
+                nonlocal credential
+                credential = await resolve_credential(
+                    self.credential_provider,
+                    self._credential_context(
+                        operation,
+                        session_id=session_id,
+                        correlation_id=correlation_id,
+                    ),
+                )
+                headers = dict(request_headers)
+                headers["Authorization"] = f"Bearer {credential}"
+                return {"headers": headers}
+
+            try:
+                response = await self._retry.send(
+                    self.client,
+                    method,
+                    url,
+                    prepare_attempt=prepare_attempt,
+                    max_retries=retry_limit,
+                    on_attempt=on_attempt,
+                    timeout=request_timeout,
+                    **kwargs,
+                )
+                self._scrub_request_authorization(getattr(response, "request", None))
+                self._scrub_response_credential(response, credential)
+                self._scrub_error_response(response)
+                return response
+            except asyncio.CancelledError:
+                return _SendFailure("cancelled", "QVeris request was cancelled")
+            except CredentialResolutionError as exc:
+                return _SendFailure("credential", str(exc))
+            except httpx.TimeoutException as exc:
+                self._scrub_request_authorization(getattr(exc, "request", None))
+                return _SendFailure("timeout", "QVeris request timed out")
+            except httpx.TransportError as exc:
+                self._scrub_request_authorization(getattr(exc, "request", None))
+                return _SendFailure(type(exc).__name__.lower(), "QVeris transport request failed")
+            except Exception as exc:
+                self._scrub_request_authorization(getattr(exc, "request", None))
+                return _SendFailure("transport_error", "QVeris transport request failed")
+
+        await self._begin_request(state)
+        try:
+            outcome = await perform()
+        finally:
+            await self._end_request()
+
+        if isinstance(outcome, _SendFailure):
+            metadata = self._request_metadata(state)
+            if outcome.error_type == "cancelled":
+                raise asyncio.CancelledError(outcome.message) from None
+            if outcome.error_type == "credential":
+                raise QverisCredentialError(
+                    outcome.message,
+                    operation=operation,
+                    request_metadata=metadata,
+                ) from None
+            raise QverisTransportError(
+                outcome.message,
+                error_type=outcome.error_type,
+                operation=operation,
+                request_metadata=metadata,
+            ) from None
+
+        state.request_id = self._extract_request_id(outcome)
+        return outcome
 
     async def _send_with_optional_field_fallback(
         self,
@@ -147,15 +403,34 @@ class QverisClient:
         endpoint: str,
         payload: Dict[str, Any],
         allowed_fields: Set[str],
+        *,
+        operation: str,
+        state: _RequestState,
+        allow_fallback: bool = True,
         **kwargs: Any,
     ) -> httpx.Response:
         """Retry once without optional fields rejected by a legacy service."""
-        response = await self._send(method, endpoint, json=payload, **kwargs)
+        response = await self._send(
+            method,
+            endpoint,
+            operation=operation,
+            state=state,
+            json=payload,
+            **kwargs,
+        )
         unsupported = _unsupported_optional_fields(response, allowed_fields)
-        if not unsupported:
+        if not unsupported or not allow_fallback:
             return response
+        state.compatibility_replays += 1
         fallback_payload = {key: value for key, value in payload.items() if key not in unsupported}
-        return await self._send(method, endpoint, json=fallback_payload, **kwargs)
+        return await self._send(
+            method,
+            endpoint,
+            operation=operation,
+            state=state,
+            json=fallback_payload,
+            **kwargs,
+        )
 
     @property
     def rate_limit_retries(self) -> int:
@@ -172,20 +447,53 @@ class QverisClient:
         if self.debug_callback:
             self.debug_callback(message)
 
+    def _redact_sensitive(self, value: Any, depth: int = 0) -> Any:
+        """Recursively redact credential-bearing and signed-URL fields."""
+        if depth >= 8:
+            return "<diagnostic value omitted>"
+        if isinstance(value, dict):
+            safe: Dict[Any, Any] = {}
+            for index, (key, item) in enumerate(value.items()):
+                if index >= 100:
+                    safe["__truncated__"] = True
+                    break
+                safe[key] = "***" if str(key).lower() in _SENSITIVE_KEYS else self._redact_sensitive(item, depth + 1)
+            return safe
+        if isinstance(value, list):
+            return [self._redact_sensitive(item, depth + 1) for item in value[:100]]
+        if isinstance(value, tuple):
+            return tuple(self._redact_sensitive(item, depth + 1) for item in value[:100])
+        if isinstance(value, str):
+            safe = _BEARER_PATTERN.sub("Bearer ***", value)
+            safe = _API_KEY_PATTERN.sub("***", safe)
+            lower = safe.lower()
+            if safe.startswith(("http://", "https://")) and any(marker in lower for marker in _SIGNED_URL_MARKERS):
+                return "***"
+            if len(safe) > 8192:
+                return safe[:8192] + "..."
+            return safe
+        return value
+
+    def _safe_message(self, value: Any, fallback: str) -> str:
+        safe = self._redact_sensitive(value)
+        if not isinstance(safe, str) or not safe.strip():
+            return fallback
+        return safe[:2048]
+
     def _parse_response_json(self, response: httpx.Response) -> Any:
         """Parse response JSON once while still logging non-JSON bodies for debugging."""
         try:
             data = response.json()
-            self._debug(f"[Qveris API] Response body: {json.dumps(data, indent=2)}")
+            safe_data = self._redact_sensitive(data)
+            self._debug(f"[Qveris API] Response body: {json.dumps(safe_data, indent=2)}")
             return data
         except json.JSONDecodeError:
-            self._debug(f"[Qveris API] Response body (raw): {response.text[:500]}")
-            response.raise_for_status()
+            self._debug("[Qveris API] Response body: <non-JSON body omitted>")
             raise
 
     def _url_for(self, method: str, path: str, params: Optional[Dict[str, Any]] = None) -> str:
         """Build the effective request URL using the same httpx client settings."""
-        return str(self.client.build_request(method, path, params=params).url)
+        return str(httpx.Request(method, self.base_url + path.lstrip("/"), params=params).url)
 
     def _debug_headers(self) -> None:
         """Log request headers with authorization redacted."""
@@ -198,7 +506,51 @@ class QverisClient:
         """Drop None-valued query params while preserving falsey filters like 0 and False."""
         return {key: value for key, value in kwargs.items() if value is not None}
 
-    def _unwrap_envelope(self, data: Any) -> Any:
+    @staticmethod
+    def _extract_request_id(response: httpx.Response) -> Optional[str]:
+        return (
+            response.headers.get("x-request-id")
+            or response.headers.get("x-qveris-request-id")
+            or response.headers.get("x-correlation-id")
+        )
+
+    def _api_error_from_response(
+        self,
+        response: httpx.Response,
+        *,
+        operation: str,
+        state: _RequestState,
+    ) -> Optional[QverisApiError]:
+        if response.status_code < 400:
+            return None
+        try:
+            raw_details = response.json()
+        except json.JSONDecodeError:
+            raw_details = {"body": "<non-JSON error body omitted>"}
+        details = self._redact_sensitive(raw_details)
+        message = response.reason_phrase or f"HTTP {response.status_code}"
+        code = None
+        category = None
+        if isinstance(details, dict):
+            message = self._safe_message(
+                details.get("error_message") or details.get("message") or details.get("error") or message,
+                f"HTTP {response.status_code}",
+            )
+            code_value = details.get("code") or details.get("error_code") or details.get("reason_code")
+            category_value = details.get("category") or details.get("error_category")
+            code = str(code_value) if code_value is not None else None
+            category = str(category_value) if category_value is not None else None
+        return QverisApiError(
+            message,
+            status=response.status_code,
+            operation=operation,
+            request_metadata=self._request_metadata(state),
+            code=code,
+            category=category,
+            details=details,
+        )
+
+    def _unwrap_envelope(self, data: Any, *, operation: str, state: _RequestState) -> Any:
         """Accept both raw payloads and standard {status, data} API envelopes."""
         if (
             isinstance(data, dict)
@@ -207,7 +559,11 @@ class QverisClient:
         ):
             status = data.get("status") or data.get("status_code")
             if self._is_failure_status(status):
-                raise RuntimeError(data.get("message") or "API returned failure status")
+                raise QverisContractError(
+                    self._safe_message(data.get("message"), "API returned failure status"),
+                    operation=operation,
+                    request_metadata=self._request_metadata(state),
+                )
             return data["data"]
         return data
 
@@ -225,7 +581,21 @@ class QverisClient:
 
         Call this if you create `QverisClient` directly and want to free network resources.
         """
-        await self.client.aclose()
+        async with self._close_lock:
+            async with self._lifecycle_lock:
+                if self._closed:
+                    return
+                self._closing = True
+            try:
+                await self._no_active_requests.wait()
+                if self._owns_http_client:
+                    await self.client.aclose()
+            except asyncio.CancelledError:
+                async with self._lifecycle_lock:
+                    self._closing = False
+                raise
+            async with self._lifecycle_lock:
+                self._closed = True
 
     async def discover(
         self,
@@ -234,6 +604,8 @@ class QverisClient:
         session_id: Optional[str] = None,
         view: Optional[Literal["routing", "full"]] = None,
         lang: Optional[Literal["zh", "en"]] = None,
+        timeout: Optional[float] = None,
+        correlation_id: Optional[str] = None,
     ) -> SearchResponse:
         """
         Discover capabilities using natural language.
@@ -262,20 +634,34 @@ class QverisClient:
         if lang is not None:
             payload["lang"] = lang
 
+        state = _RequestState("discover", time.monotonic())
         with start_span(
             "qveris.discover",
             {ATTR_OPERATION: "discover", ATTR_LIMIT: limit, ATTR_SESSION_ID: session_id},
         ) as span:
             self._debug(f"[Qveris API] POST {url}")
-            self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
+            self._debug(f"[Qveris API] Request body: {json.dumps(self._redact_sensitive(payload), indent=2)}")
             self._debug_headers()
 
-            response = await self._send_with_optional_field_fallback("POST", "search", payload, {"view", "lang"})
+            response = await self._send_with_optional_field_fallback(
+                "POST",
+                "search",
+                payload,
+                {"view", "lang"},
+                operation="discover",
+                state=state,
+                session_id=session_id,
+                correlation_id=correlation_id,
+                timeout=timeout,
+            )
 
             self._debug(f"[Qveris API] Response status: {response.status_code}")
-            data = self._unwrap_envelope(self._parse_response_json(response))
-            response.raise_for_status()
+            error = self._api_error_from_response(response, operation="discover", state=state)
+            if error is not None:
+                raise error from None
+            data = self._unwrap_envelope(self._parse_response_json(response), operation="discover", state=state)
             result = SearchResponse(**data)
+            result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(
                 span,
                 {
@@ -295,6 +681,8 @@ class QverisClient:
         tool_ids: Union[Iterable[str], str],
         search_id: Optional[str] = None,
         session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+        correlation_id: Optional[str] = None,
     ) -> SearchResponse:
         """
         Inspect one or more capabilities by tool ID.
@@ -308,8 +696,12 @@ class QverisClient:
             `SearchResponse` with full tool details for the requested IDs.
         """
         ids = [tool_ids] if isinstance(tool_ids, str) else list(tool_ids or [])
+        state = _RequestState("inspect", time.monotonic())
         if not ids:
-            return SearchResponse(search_id=search_id, total=0, results=[])
+            await self._ensure_open(state)
+            result = SearchResponse(search_id=search_id, total=0, results=[])
+            result._set_request_metadata(self._request_metadata(state))
+            return result
 
         url = self._url_for("POST", "tools/by-ids")
         payload: Dict[str, Any] = {"tool_ids": ids}
@@ -328,15 +720,27 @@ class QverisClient:
             },
         ) as span:
             self._debug(f"[Qveris API] POST {url}")
-            self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
+            self._debug(f"[Qveris API] Request body: {json.dumps(self._redact_sensitive(payload), indent=2)}")
             self._debug_headers()
 
-            response = await self._send("POST", "tools/by-ids", json=payload)
+            response = await self._send(
+                "POST",
+                "tools/by-ids",
+                operation="inspect",
+                state=state,
+                session_id=session_id,
+                correlation_id=correlation_id,
+                timeout=timeout,
+                json=payload,
+            )
 
             self._debug(f"[Qveris API] Response status: {response.status_code}")
-            data = self._unwrap_envelope(self._parse_response_json(response))
-            response.raise_for_status()
+            error = self._api_error_from_response(response, operation="inspect", state=state)
+            if error is not None:
+                raise error from None
+            data = self._unwrap_envelope(self._parse_response_json(response), operation="inspect", state=state)
             result = SearchResponse(**data)
+            result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(span, {ATTR_RESULT_COUNT: len(result.results or [])})
             return result
 
@@ -355,6 +759,8 @@ class QverisClient:
         parameters: Optional[Dict[str, Any]] = None,
         checks: Optional[List[Literal["schema", "quote", "coverage", "sample"]]] = None,
         live_budget: Literal["none", "metadata", "sampled"] = "none",
+        timeout: Optional[float] = None,
+        correlation_id: Optional[str] = None,
     ) -> ToolProbeResponse:
         """Validate candidate parameters and obtain a zero-cost quote without execution."""
         url = self._url_for("POST", "tools/probe", params={"tool_id": tool_id})
@@ -363,15 +769,28 @@ class QverisClient:
             "checks": checks if checks is not None else ["schema"],
             "live_budget": live_budget,
         }
+        state = _RequestState("probe", time.monotonic())
         with start_span("qveris.probe", {ATTR_OPERATION: "probe", ATTR_TOOL_ID: tool_id}) as span:
             self._debug(f"[Qveris API] POST {url}")
-            self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
+            self._debug(f"[Qveris API] Request body: {json.dumps(self._redact_sensitive(payload), indent=2)}")
             self._debug_headers()
-            response = await self._send("POST", "tools/probe", json=payload, params={"tool_id": tool_id})
+            response = await self._send(
+                "POST",
+                "tools/probe",
+                operation="probe",
+                state=state,
+                correlation_id=correlation_id,
+                timeout=timeout,
+                json=payload,
+                params={"tool_id": tool_id},
+            )
             self._debug(f"[Qveris API] Response status: {response.status_code}")
-            data = self._unwrap_envelope(self._parse_response_json(response))
-            response.raise_for_status()
+            error = self._api_error_from_response(response, operation="probe", state=state)
+            if error is not None:
+                raise error from None
+            data = self._unwrap_envelope(self._parse_response_json(response), operation="probe", state=state)
             result = ToolProbeResponse(**data)
+            result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(span, {ATTR_SUCCESS: result.schema_ is None or result.schema_.valid})
             return result
 
@@ -383,6 +802,9 @@ class QverisClient:
         session_id: Optional[str] = None,
         max_response_size: Optional[int] = None,
         respond_with: Optional[str] = None,
+        compatibility_mode: Literal["strict", "legacy_optional_fields"] = "strict",
+        timeout: Optional[float] = None,
+        correlation_id: Optional[str] = None,
     ) -> ToolExecutionResponse:
         """
         Call a specific capability.
@@ -394,6 +816,10 @@ class QverisClient:
             session_id: Optional correlation id.
             max_response_size: Optional max response size in bytes. Large responses may be truncated.
             respond_with: Optional server-side projection (`full`, `summary`, or `fields:<JSONPath,...>`).
+            compatibility_mode: Strict mode never resubmits a paid call. The deprecated
+                legacy mode may replay once without an unsupported optional field.
+            timeout: HTTP request timeout in seconds; credential acquisition is separate.
+            correlation_id: Non-sensitive reference forwarded only to the credential provider.
 
         Returns:
             `ToolExecutionResponse` with `success`, `result`, and metadata.
@@ -415,6 +841,16 @@ class QverisClient:
         if respond_with is not None:
             payload["respond_with"] = respond_with
 
+        if compatibility_mode not in {"strict", "legacy_optional_fields"}:
+            raise ValueError("compatibility_mode must be 'strict' or 'legacy_optional_fields'")
+        if compatibility_mode == "legacy_optional_fields":
+            warnings.warn(
+                "legacy_optional_fields may resubmit a paid call; prefer strict mode",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        state = _RequestState("call", time.monotonic())
         with start_span(
             "qveris.call",
             {
@@ -425,7 +861,7 @@ class QverisClient:
             },
         ) as span:
             self._debug(f"[Qveris API] POST {url}")
-            self._debug(f"[Qveris API] Request body: {json.dumps(payload, indent=2)}")
+            self._debug(f"[Qveris API] Request body: {json.dumps(self._redact_sensitive(payload), indent=2)}")
             self._debug_headers()
 
             response = await self._send_with_optional_field_fallback(
@@ -433,13 +869,22 @@ class QverisClient:
                 "tools/execute",
                 payload,
                 {"respond_with"},
+                operation="call",
+                state=state,
+                allow_fallback=compatibility_mode == "legacy_optional_fields",
+                session_id=session_id,
+                correlation_id=correlation_id,
+                timeout=timeout,
                 params={"tool_id": tool_id},
             )
 
             self._debug(f"[Qveris API] Response status: {response.status_code}")
-            data = self._unwrap_envelope(self._parse_response_json(response))
-            response.raise_for_status()
+            error = self._api_error_from_response(response, operation="call", state=state)
+            if error is not None:
+                raise error from None
+            data = self._unwrap_envelope(self._parse_response_json(response), operation="call", state=state)
             result = ToolExecutionResponse(**data)
+            result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(
                 span,
                 {
@@ -486,6 +931,8 @@ class QverisClient:
         limit: Optional[int] = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
+        timeout: Optional[float] = None,
+        correlation_id: Optional[str] = None,
     ) -> UsageHistoryResponse:
         """
         Query request-level usage audit history.
@@ -513,11 +960,24 @@ class QverisClient:
 
         self._debug(f"[Qveris API] GET {self._url_for('GET', 'auth/usage/history/v2', params=params)}")
         self._debug_headers()
-        response = await self._send("GET", "auth/usage/history/v2", params=params)
+        state = _RequestState("usage", time.monotonic())
+        response = await self._send(
+            "GET",
+            "auth/usage/history/v2",
+            operation="usage",
+            state=state,
+            correlation_id=correlation_id,
+            timeout=timeout,
+            params=params,
+        )
         self._debug(f"[Qveris API] Response status: {response.status_code}")
-        data = self._unwrap_envelope(self._parse_response_json(response))
-        response.raise_for_status()
-        return UsageHistoryResponse(**data)
+        error = self._api_error_from_response(response, operation="usage", state=state)
+        if error is not None:
+            raise error from None
+        data = self._unwrap_envelope(self._parse_response_json(response), operation="usage", state=state)
+        result = UsageHistoryResponse(**data)
+        result._set_request_metadata(self._request_metadata(state))
+        return result
 
     async def ledger(
         self,
@@ -533,6 +993,8 @@ class QverisClient:
         limit: Optional[int] = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
+        timeout: Optional[float] = None,
+        correlation_id: Optional[str] = None,
     ) -> CreditsLedgerResponse:
         """
         Query final credits ledger entries.
@@ -556,11 +1018,24 @@ class QverisClient:
 
         self._debug(f"[Qveris API] GET {self._url_for('GET', 'auth/credits/ledger', params=params)}")
         self._debug_headers()
-        response = await self._send("GET", "auth/credits/ledger", params=params)
+        state = _RequestState("ledger", time.monotonic())
+        response = await self._send(
+            "GET",
+            "auth/credits/ledger",
+            operation="ledger",
+            state=state,
+            correlation_id=correlation_id,
+            timeout=timeout,
+            params=params,
+        )
         self._debug(f"[Qveris API] Response status: {response.status_code}")
-        data = self._unwrap_envelope(self._parse_response_json(response))
-        response.raise_for_status()
-        return CreditsLedgerResponse(**data)
+        error = self._api_error_from_response(response, operation="ledger", state=state)
+        if error is not None:
+            raise error from None
+        data = self._unwrap_envelope(self._parse_response_json(response), operation="ledger", state=state)
+        result = CreditsLedgerResponse(**data)
+        result._set_request_metadata(self._request_metadata(state))
+        return result
 
     async def handle_tool_call(
         self,
@@ -626,7 +1101,27 @@ class QverisClient:
             # Not a Qveris tool.
             return None, False, False
 
-        except httpx.HTTPStatusError as e:
-            return {"error": f"HTTP {e.response.status_code}: {e.response.text[:500]}"}, True, True
-        except Exception as e:
-            return {"error": str(e)}, True, True
+        except QverisApiError as error:
+            return (
+                {
+                    "error": str(error),
+                    "status": error.status,
+                    "code": error.code,
+                    "operation": error.operation,
+                    "http_attempts": error.request_metadata.http_attempts,
+                },
+                True,
+                True,
+            )
+        except QverisError as error:
+            return (
+                {
+                    "error": str(error),
+                    "operation": error.operation,
+                    "http_attempts": error.request_metadata.http_attempts,
+                },
+                True,
+                True,
+            )
+        except Exception:
+            return {"error": "Unexpected QVeris client error"}, True, True

--- a/packages/python-sdk/qveris/client/retry.py
+++ b/packages/python-sdk/qveris/client/retry.py
@@ -103,16 +103,21 @@ class RetryPolicy:
         url: str,
         *,
         prepare_attempt: Optional[Callable[[], Awaitable[Dict[str, Any]]]] = None,
+        max_retries: Optional[int] = None,
+        on_attempt: Optional[Callable[[], None]] = None,
         **kwargs: Any,
     ) -> httpx.Response:
         """Send a request through ``client``, retrying 429/503 with backoff."""
         attempt = 0
+        retry_limit = self.max_retries if max_retries is None else max(0, max_retries)
         while True:
             attempt_kwargs = dict(kwargs)
             if prepare_attempt is not None:
                 attempt_kwargs.update(await prepare_attempt())
+            if on_attempt is not None:
+                on_attempt()
             response = await client.request(method, url, **attempt_kwargs)
-            if response.status_code not in RETRYABLE_STATUS or attempt >= self.max_retries:
+            if response.status_code not in RETRYABLE_STATUS or attempt >= retry_limit:
                 return response
 
             # Release the pooled connection before sleeping and re-issuing.

--- a/packages/python-sdk/qveris/config.py
+++ b/packages/python-sdk/qveris/config.py
@@ -16,6 +16,11 @@ Both classes inherit from `pydantic_settings.BaseSettings`, so values can be sup
 `QverisConfig`
 - `QVERIS_API_KEY`: Qveris API key (sent as `Authorization: Bearer ...`)
 - `QVERIS_BASE_URL`: API base URL (defaults to `https://qveris.ai/api/v1`)
+- `QVERIS_CREDENTIAL_AUDIENCE`: optional audience for credential providers
+- `QVERIS_CREDENTIAL_SCOPES`: optional JSON array of credential scopes
+- `QVERIS_MAX_RETRIES`: bounded read-operation retries (paid calls never inherit it)
+- `QVERIS_READ_TIMEOUT`: read/audit HTTP timeout in seconds
+- `QVERIS_CALL_TIMEOUT`: paid-call HTTP timeout in seconds
 
 `AgentConfig`
 - no fixed env var aliases are defined here (pass values explicitly), but you can still rely on
@@ -74,13 +79,35 @@ class QverisConfig(BaseSettings):
     # the custom init source below (see settings_customise_sources / #136).
     api_key: Optional[str] = Field(default=None, validation_alias="QVERIS_API_KEY", repr=False)
     base_url: str = Field(default="https://qveris.ai/api/v1", validation_alias="QVERIS_BASE_URL")
+    credential_audience: Optional[str] = Field(
+        default=None,
+        validation_alias="QVERIS_CREDENTIAL_AUDIENCE",
+        description="Optional audience forwarded to the credential provider.",
+    )
+    credential_scopes: Tuple[str, ...] = Field(
+        default=(),
+        validation_alias="QVERIS_CREDENTIAL_SCOPES",
+        description="Optional scopes forwarded to the credential provider.",
+    )
 
-    # Transport settings. On a 429 (or 503) the client honors Retry-After and
-    # otherwise backs off exponentially with jitter, up to this many retries.
+    # Read-operation transport settings. Paid calls are always single-submit
+    # and do not inherit this retry count.
     max_retries: int = Field(
         default=3,
         validation_alias="QVERIS_MAX_RETRIES",
-        description="Max automatic retries for rate-limited (429) / transient (503) responses.",
+        description="Max automatic retries for read operations after 429/503 responses.",
+    )
+    read_timeout: float = Field(
+        default=30.0,
+        validation_alias="QVERIS_READ_TIMEOUT",
+        gt=0,
+        description="Default timeout in seconds for read and audit operations.",
+    )
+    call_timeout: float = Field(
+        default=120.0,
+        validation_alias="QVERIS_CALL_TIMEOUT",
+        gt=0,
+        description="Default timeout in seconds for paid call operations.",
     )
 
     # Agent behavior settings

--- a/packages/python-sdk/qveris/credentials.py
+++ b/packages/python-sdk/qveris/credentials.py
@@ -3,7 +3,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, Tuple
+from typing import Literal, Optional, Protocol, Tuple
+
+
+CredentialOperation = Literal[
+    "discover",
+    "inspect",
+    "probe",
+    "call",
+    "credits",
+    "usage",
+    "ledger",
+]
+CredentialPurpose = Literal["data_read", "paid_execution", "usage_audit", "ledger_audit"]
+
+
+class CredentialResolutionError(Exception):
+    """Internal credential failure marker that never includes credential data."""
+
+
+@dataclass(frozen=True)
+class _CredentialResult:
+    value: Optional[str] = None
+    error: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -11,7 +33,12 @@ class CredentialContext:
     """Context supplied whenever the client requests a credential."""
 
     resource: str
+    audience: Optional[str] = None
     scopes: Tuple[str, ...] = ()
+    operation: CredentialOperation = "discover"
+    purpose: CredentialPurpose = "data_read"
+    session_id: Optional[str] = None
+    correlation_id: Optional[str] = None
 
 
 class CredentialProvider(Protocol):
@@ -37,10 +64,19 @@ class ApiKeyCredentialProvider:
 
 async def resolve_credential(provider: CredentialProvider, context: CredentialContext) -> str:
     """Resolve a valid credential without including its value in errors."""
-    try:
-        credential = await provider.get_credential(context)
-    except Exception:
-        raise RuntimeError("QVeris credential provider failed to provide a credential") from None
-    if not isinstance(credential, str) or not credential.strip() or "\r" in credential or "\n" in credential:
-        raise ValueError("QVeris credential provider returned an invalid credential")
-    return credential.strip()
+
+    async def attempt() -> _CredentialResult:
+        try:
+            value = await provider.get_credential(context)
+        except Exception:
+            return _CredentialResult(error="provider_failed")
+        if not isinstance(value, str) or not value.strip() or "\r" in value or "\n" in value:
+            return _CredentialResult(error="invalid_credential")
+        return _CredentialResult(value=value.strip())
+
+    result = await attempt()
+    if result.error == "provider_failed":
+        raise CredentialResolutionError("QVeris credential provider failed to provide a credential") from None
+    if result.error == "invalid_credential" or result.value is None:
+        raise CredentialResolutionError("QVeris credential provider returned an invalid credential") from None
+    return result.value

--- a/packages/python-sdk/qveris/errors.py
+++ b/packages/python-sdk/qveris/errors.py
@@ -1,0 +1,96 @@
+"""Public, credential-safe exceptions and request metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class RequestMetadata:
+    """Client-side metadata for one logical SDK operation."""
+
+    operation: str
+    http_attempts: int = 0
+    retry_attempts: int = 0
+    compatibility_replays: int = 0
+    request_id: Optional[str] = None
+    elapsed_ms: float = 0.0
+
+
+class QverisError(Exception):
+    """Base class for public SDK errors.
+
+    These errors intentionally never retain an HTTP request, response, bearer
+    credential, or lower-level exception object.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        operation: str,
+        request_metadata: RequestMetadata,
+    ) -> None:
+        super().__init__(message)
+        self.operation = operation
+        self.request_metadata = request_metadata
+
+
+class QverisApiError(QverisError):
+    """A safe representation of an HTTP or API-envelope failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int,
+        operation: str,
+        request_metadata: RequestMetadata,
+        code: Optional[str] = None,
+        category: Optional[str] = None,
+        details: Any = None,
+    ) -> None:
+        super().__init__(message, operation=operation, request_metadata=request_metadata)
+        self.status = status
+        self.code = code
+        self.category = category
+        self.details = details
+
+
+class QverisTransportError(QverisError):
+    """A safe transport failure without the original transport exception."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_type: str,
+        operation: str,
+        request_metadata: RequestMetadata,
+    ) -> None:
+        super().__init__(message, operation=operation, request_metadata=request_metadata)
+        self.error_type = error_type
+        self.status = 408 if error_type == "timeout" else 0
+
+
+class QverisCredentialError(QverisError):
+    """Credential acquisition failed without exposing provider internals."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        operation: str,
+        request_metadata: RequestMetadata,
+    ) -> None:
+        super().__init__(message, operation=operation, request_metadata=request_metadata)
+        self.status = 0
+
+
+class QverisContractError(QverisError):
+    """The API returned an invalid or explicit failure envelope."""
+
+
+class QverisClientClosedError(QverisError):
+    """The client is closing or has already been closed."""

--- a/packages/python-sdk/qveris/types.py
+++ b/packages/python-sdk/qveris/types.py
@@ -1,12 +1,23 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+
+from .errors import RequestMetadata
 
 
 class QverisModel(BaseModel):
     """Base SDK model that tolerates additive API fields."""
 
     model_config = ConfigDict(extra="allow")
+    _request_metadata: Optional[RequestMetadata] = PrivateAttr(default=None)
+
+    @property
+    def request_metadata(self) -> Optional[RequestMetadata]:
+        """Client-side attempt metadata; excluded from wire serialization."""
+        return self._request_metadata
+
+    def _set_request_metadata(self, metadata: RequestMetadata) -> None:
+        self._request_metadata = metadata
 
 
 # --- Capability and billing types ---
@@ -155,7 +166,7 @@ class SearchResponse(QverisModel):
 
 class ExecuteResultTruncated(QverisModel):
     message: str
-    full_content_file_url: str
+    full_content_file_url: str = Field(repr=False)
     truncated_content: str
     content_schema: Optional[Dict[str, Any]] = None
 
@@ -163,7 +174,7 @@ class ExecuteResultTruncated(QverisModel):
 class ToolExecutionResponse(QverisModel):
     execution_id: str
     success: bool
-    result: Optional[Any] = None
+    result: Optional[Any] = Field(default=None, repr=False)
     error_message: Optional[str] = None
     elapsed_time_ms: Optional[float] = None
     execution_time: Optional[float] = None

--- a/packages/python-sdk/tests/test_client_contracts.py
+++ b/packages/python-sdk/tests/test_client_contracts.py
@@ -9,6 +9,7 @@ from qveris.client.api import QverisClient
 from qveris.client.retry import RetryPolicy
 from qveris.config import QverisConfig
 from qveris.credentials import ApiKeyCredentialProvider, CredentialContext
+from qveris.errors import QverisApiError, QverisContractError, QverisCredentialError
 
 
 def make_client(handler: Callable[[httpx.Request], httpx.Response]) -> QverisClient:
@@ -24,10 +25,10 @@ def make_client(handler: Callable[[httpx.Request], httpx.Response]) -> QverisCli
 
 @pytest.mark.asyncio
 async def test_api_key_provider_preserves_authorization_without_repr_leak() -> None:
-    requests = []
+    authorizations = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
+        authorizations.append(request.headers["Authorization"])
         return httpx.Response(200, json={"search_id": "search-1", "results": []})
 
     client = make_client(handler)
@@ -36,7 +37,7 @@ async def test_api_key_provider_preserves_authorization_without_repr_leak() -> N
     finally:
         await client.close()
 
-    assert requests[0].headers["Authorization"] == "Bearer sk-test"
+    assert authorizations == ["Bearer sk-test"]
     assert "sk-test" not in repr(ApiKeyCredentialProvider("sk-test"))
 
 
@@ -52,10 +53,10 @@ class RecordingCredentialProvider:
 
 @pytest.mark.asyncio
 async def test_async_credential_provider_receives_api_resource() -> None:
-    requests = []
+    authorizations = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
+        authorizations.append(request.headers["Authorization"])
         return httpx.Response(200, json={"search_id": "search-1", "results": []})
 
     provider = RecordingCredentialProvider()
@@ -75,7 +76,7 @@ async def test_async_credential_provider_receives_api_resource() -> None:
         await client.close()
 
     assert provider.contexts == [CredentialContext(resource="https://custom.example/api/v1", scopes=())]
-    assert requests[0].headers["Authorization"] == "Bearer short-lived-token"
+    assert authorizations == ["Bearer short-lived-token"]
 
 
 def test_rejects_api_key_and_credential_provider_together() -> None:
@@ -139,7 +140,7 @@ async def test_invalid_provider_credential_is_not_exposed() -> None:
     provider = RecordingCredentialProvider("secret-token\nforged-header")
     client = QverisClient(QverisConfig(api_key=None), credential_provider=provider)
     try:
-        with pytest.raises(ValueError, match="invalid credential") as exc_info:
+        with pytest.raises(QverisCredentialError, match="invalid credential") as exc_info:
             await client.discover("weather")
     finally:
         await client.close()
@@ -155,7 +156,7 @@ async def test_provider_failure_text_is_not_exposed() -> None:
 
     client = QverisClient(QverisConfig(api_key=None), credential_provider=FailingCredentialProvider())
     try:
-        with pytest.raises(RuntimeError, match="failed to provide a credential") as exc_info:
+        with pytest.raises(QverisCredentialError, match="failed to provide a credential") as exc_info:
             await client.discover("weather")
     finally:
         await client.close()
@@ -184,6 +185,20 @@ def test_qveris_config_reads_env_when_no_init_value(monkeypatch: pytest.MonkeyPa
 
     assert config.api_key == "sk-env"
     assert config.base_url == "https://env.example/api/v1"
+
+
+def test_qveris_config_reads_credential_context_and_timeout_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QVERIS_CREDENTIAL_AUDIENCE", "qveris-api")
+    monkeypatch.setenv("QVERIS_CREDENTIAL_SCOPES", '["tools.read", "usage.read"]')
+    monkeypatch.setenv("QVERIS_READ_TIMEOUT", "9")
+    monkeypatch.setenv("QVERIS_CALL_TIMEOUT", "15")
+
+    config = QverisConfig(api_key="sk-test")
+
+    assert config.credential_audience == "qveris-api"
+    assert config.credential_scopes == ("tools.read", "usage.read")
+    assert config.read_timeout == 9
+    assert config.call_timeout == 15
 
 
 def test_qveris_config_ignores_generic_env_names(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -456,7 +471,7 @@ async def test_probe_preserves_explicit_empty_checks_for_server_validation() -> 
 
     client = make_client(handler)
     try:
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(QverisApiError):
             await client.probe("weather.forecast.v1", parameters={}, checks=[])
     finally:
         await client.close()
@@ -563,7 +578,13 @@ async def test_call_projection_retries_only_legacy_extra_field_rejection() -> No
 
     client = make_client(handler)
     try:
-        await client.call("weather.forecast.v1", {}, respond_with="summary")
+        with pytest.warns(DeprecationWarning, match="may resubmit"):
+            await client.call(
+                "weather.forecast.v1",
+                {},
+                respond_with="summary",
+                compatibility_mode="legacy_optional_fields",
+            )
     finally:
         await client.close()
 
@@ -587,7 +608,7 @@ async def test_call_invalid_projection_is_not_downgraded() -> None:
 
     client = make_client(handler)
     try:
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(QverisApiError):
             await client.call("weather.forecast.v1", {}, respond_with="fields:")
     finally:
         await client.close()
@@ -651,7 +672,7 @@ async def test_failure_envelope_raises_before_model_parsing() -> None:
 
     client = make_client(handler)
     try:
-        with pytest.raises(RuntimeError, match="quota exhausted"):
+        with pytest.raises(QverisContractError, match="quota exhausted"):
             await client.discover("weather forecast API")
     finally:
         await client.close()

--- a/packages/python-sdk/tests/test_client_tool_calls.py
+++ b/packages/python-sdk/tests/test_client_tool_calls.py
@@ -139,4 +139,10 @@ async def test_handle_tool_call_returns_structured_error_for_builtin_failures() 
 
     assert handled is True
     assert is_error is True
-    assert result == {"error": "HTTP 402: not enough credits"}
+    assert result == {
+        "error": "Payment Required",
+        "status": 402,
+        "code": None,
+        "operation": "call",
+        "http_attempts": 1,
+    }

--- a/packages/python-sdk/tests/test_observability.py
+++ b/packages/python-sdk/tests/test_observability.py
@@ -13,6 +13,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from qveris import observability  # noqa: E402
 from qveris.client.api import QverisClient  # noqa: E402
 from qveris.config import QverisConfig  # noqa: E402
+from qveris.errors import QverisApiError, QverisTransportError  # noqa: E402
 
 
 def make_client(handler: Callable[[httpx.Request], httpx.Response]) -> QverisClient:
@@ -110,13 +111,36 @@ async def test_call_span_marked_error_on_http_failure(spans: InMemorySpanExporte
 
     client = make_client(handler)
     try:
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(QverisApiError):
             await client.call("t1", {}, search_id="s1")
     finally:
         await client.close()
 
     span = _span_by_name(spans, "qveris.call")
     assert span.status.status_code == StatusCode.ERROR
+
+
+@pytest.mark.asyncio
+async def test_transport_failure_span_does_not_record_credential(spans: InMemorySpanExporter) -> None:
+    synthetic_token = "sk-synthetic-observability-273"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("transport failed", request=request)
+
+    client = QverisClient(
+        QverisConfig(api_key=synthetic_token),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(QverisTransportError):
+            await client.call("t1", {}, search_id="s1")
+    finally:
+        await client.close()
+
+    span = _span_by_name(spans, "qveris.call")
+    rendered = json.dumps(dict(span.attributes), default=str)
+    rendered += json.dumps([(event.name, dict(event.attributes or {})) for event in span.events], default=str)
+    assert synthetic_token not in rendered
 
 
 @pytest.mark.asyncio

--- a/packages/python-sdk/tests/test_observability.py
+++ b/packages/python-sdk/tests/test_observability.py
@@ -144,6 +144,34 @@ async def test_transport_failure_span_does_not_record_credential(spans: InMemory
 
 
 @pytest.mark.asyncio
+async def test_api_failure_span_does_not_record_credential_or_signed_url(spans: InMemorySpanExporter) -> None:
+    synthetic_token = "sk-synthetic-api-observability-273"
+    signed_url = "https://files.example/result?X-Amz-Signature=otel-secret"
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503,
+            json={"message": f"Rejected Bearer {synthetic_token}; inspect {signed_url}"},
+        )
+
+    client = QverisClient(
+        QverisConfig(api_key=synthetic_token),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(QverisApiError):
+            await client.call("t1", {}, search_id="s1")
+    finally:
+        await client.close()
+
+    span = _span_by_name(spans, "qveris.call")
+    rendered = json.dumps(dict(span.attributes), default=str)
+    rendered += json.dumps([(event.name, dict(event.attributes or {})) for event in span.events], default=str)
+    assert synthetic_token not in rendered
+    assert "X-Amz-Signature=otel-secret" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_broken_tracer_does_not_break_the_call(monkeypatch: pytest.MonkeyPatch) -> None:
     # A misbehaving tracer provider must never break the traced operation.
     class BrokenTracer:

--- a/packages/python-sdk/tests/test_public_exports.py
+++ b/packages/python-sdk/tests/test_public_exports.py
@@ -4,7 +4,10 @@ from qveris import (
     CredentialContext,
     CredentialProvider,
     Message,
+    QverisApiError,
     QverisClient,
+    QverisError,
+    RequestMetadata,
     SearchResponse,
     ToolExecutionResponse,
 )
@@ -23,6 +26,8 @@ from qveris.types import ToolInfo, ToolParameter
 def test_public_sdk_exports_cover_core_classes_and_models() -> None:
     assert Agent.__name__ == "Agent"
     assert QverisClient.__name__ == "QverisClient"
+    assert issubclass(QverisApiError, QverisError)
+    assert RequestMetadata(operation="discover").http_attempts == 0
     assert ApiKeyCredentialProvider.__name__ == "ApiKeyCredentialProvider"
     assert CredentialContext(resource="https://qveris.ai/api/v1").scopes == ()
     assert CredentialProvider.__name__ == "CredentialProvider"

--- a/packages/python-sdk/tests/test_safe_paid_call.py
+++ b/packages/python-sdk/tests/test_safe_paid_call.py
@@ -25,7 +25,7 @@ PAID_CALL_POLICY = json.loads(
 
 
 def call_success() -> Dict[str, Any]:
-    return {"execution_id": "exec-1", "success": True, "result": {"ok": True}}
+    return PAID_CALL_POLICY["contract_fixtures"]["n"]["body"]
 
 
 def make_client(handler, *, debug_callback=None, max_retries: int = 3) -> QverisClient:
@@ -65,10 +65,8 @@ async def test_paid_call_strict_mode_does_not_replay_unsupported_projection() ->
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
-        return httpx.Response(
-            422,
-            json={"detail": [{"type": "extra_forbidden", "loc": ["body", "respond_with"]}]},
-        )
+        fixture = PAID_CALL_POLICY["contract_fixtures"]["n_minus_1"]
+        return httpx.Response(fixture["status"], json=fixture["body"])
 
     client = make_client(handler)
     try:
@@ -108,11 +106,10 @@ async def test_paid_call_legacy_mode_replays_once_and_marks_metadata() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         if len(requests) == 1:
-            return httpx.Response(
-                422,
-                json={"detail": [{"type": "extra_forbidden", "loc": ["body", "respond_with"]}]},
-            )
-        return httpx.Response(200, json=call_success())
+            fixture = PAID_CALL_POLICY["contract_fixtures"]["n_minus_1"]
+        else:
+            fixture = PAID_CALL_POLICY["contract_fixtures"]["n"]
+        return httpx.Response(fixture["status"], json=fixture["body"])
 
     client = make_client(handler)
     try:
@@ -228,14 +225,15 @@ async def test_paid_call_cancellation_preserves_cancellation_without_replay() ->
 
 
 @pytest.mark.asyncio
-async def test_debug_and_api_error_details_redact_credentials_and_signed_urls() -> None:
+@pytest.mark.parametrize("status", [401, 403, 429, 503])
+async def test_debug_and_api_error_details_redact_credentials_and_signed_urls(status: int) -> None:
     debug: List[str] = []
     embedded_signed_url = "https://files.example/result?X-Amz-Signature=embedded-secret"
     selection_token = "opaque-selection-secret-273"
 
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
-            401,
+            status,
             json={
                 "message": f"Rejected Bearer {SYNTHETIC_TOKEN}; inspect {embedded_signed_url}",
                 "authorization": f"Bearer {SYNTHETIC_TOKEN}",
@@ -247,7 +245,7 @@ async def test_debug_and_api_error_details_redact_credentials_and_signed_urls() 
     client = make_client(handler, debug_callback=debug.append)
     try:
         with pytest.raises(QverisApiError) as exc_info:
-            await client.discover("weather")
+            await client.call("paid-tool", {})
     finally:
         await client.close()
 
@@ -308,6 +306,48 @@ async def test_credential_context_is_operation_aware_and_concurrent_tokens_do_no
     assert all(context.purpose == "data_read" for context in contexts)
     assert all(context.audience == "qveris-api" for context in contexts)
     assert all(context.scopes == ("tools.read",) for context in contexts)
+
+
+@pytest.mark.asyncio
+async def test_child_tasks_keep_credential_context_and_authorization_isolated() -> None:
+    contexts: Dict[str, CredentialContext] = {}
+
+    class ChildTaskCredentialProvider:
+        async def get_credential(self, context: CredentialContext) -> str:
+            assert context.correlation_id is not None
+            contexts[context.correlation_id] = context
+            await asyncio.sleep(0)
+            return f"child-token-{context.correlation_id}"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = json.loads(request.content)["query"]
+        assert request.headers["Authorization"] == f"Bearer child-token-{query}"
+        return httpx.Response(200, json={"search_id": query, "results": []})
+
+    client = QverisClient(
+        QverisConfig(api_key=None),
+        credential_provider=ChildTaskCredentialProvider(),
+        transport=httpx.MockTransport(handler),
+    )
+
+    async def parent(parent_id: str) -> None:
+        child_ids = [f"{parent_id}-child-{index}" for index in range(5)]
+        child_tasks = [
+            asyncio.create_task(client.discover(child_id, correlation_id=child_id)) for child_id in child_ids
+        ]
+        await asyncio.gather(*child_tasks)
+
+    try:
+        await asyncio.gather(*(parent(f"parent-{index}") for index in range(10)))
+    finally:
+        await client.close()
+
+    expected_ids = {
+        f"parent-{parent_index}-child-{child_index}" for parent_index in range(10) for child_index in range(5)
+    }
+    assert set(contexts) == expected_ids
+    assert all(context.correlation_id == correlation_id for correlation_id, context in contexts.items())
+    assert all(context.operation == "discover" for context in contexts.values())
 
 
 @pytest.mark.asyncio

--- a/packages/python-sdk/tests/test_safe_paid_call.py
+++ b/packages/python-sdk/tests/test_safe_paid_call.py
@@ -1,0 +1,438 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+from qveris.client.api import QverisClient
+from qveris.client.retry import RetryPolicy
+from qveris.config import QverisConfig
+from qveris.credentials import CredentialContext
+from qveris.errors import (
+    QverisApiError,
+    QverisClientClosedError,
+    QverisTransportError,
+)
+from qveris.types import ExecuteResultTruncated, ToolExecutionResponse
+
+
+SYNTHETIC_TOKEN = "synthetic-credential-value-273"
+PAID_CALL_POLICY = json.loads(
+    (Path(__file__).parents[3] / "test-fixtures" / "paid-call-policy.json").read_text(encoding="utf-8")
+)
+
+
+def call_success() -> Dict[str, Any]:
+    return {"execution_id": "exec-1", "success": True, "result": {"ok": True}}
+
+
+def make_client(handler, *, debug_callback=None, max_retries: int = 3) -> QverisClient:
+    return QverisClient(
+        QverisConfig(api_key=SYNTHETIC_TOKEN, max_retries=max_retries),
+        debug_callback=debug_callback,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", PAID_CALL_POLICY["read_operations"]["retryable_statuses"])
+async def test_paid_call_never_retries_retryable_statuses(status: int) -> None:
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(status, json={"message": "try again"})
+
+    client = make_client(handler)
+    client._retry = RetryPolicy(sleep=lambda _delay: asyncio.sleep(0))
+    try:
+        with pytest.raises(QverisApiError) as exc_info:
+            await client.call("paid-tool", {})
+    finally:
+        await client.close()
+
+    assert len(requests) == PAID_CALL_POLICY["paid_call"]["expected_http_attempts"]
+    assert exc_info.value.status == status
+    assert exc_info.value.request_metadata.http_attempts == 1
+    assert exc_info.value.request_metadata.retry_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_paid_call_strict_mode_does_not_replay_unsupported_projection() -> None:
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            422,
+            json={"detail": [{"type": "extra_forbidden", "loc": ["body", "respond_with"]}]},
+        )
+
+    client = make_client(handler)
+    try:
+        with pytest.raises(QverisApiError) as exc_info:
+            await client.call("paid-tool", {}, respond_with="summary")
+    finally:
+        await client.close()
+
+    assert len(requests) == 1
+    assert exc_info.value.request_metadata.http_attempts == 1
+    assert exc_info.value.request_metadata.compatibility_replays == 0
+
+
+@pytest.mark.asyncio
+async def test_paid_call_does_not_replay_unauthorized_response() -> None:
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(401, json={"message": "credential rejected"})
+
+    client = make_client(handler)
+    try:
+        with pytest.raises(QverisApiError) as exc_info:
+            await client.call("paid-tool", {})
+    finally:
+        await client.close()
+
+    assert len(requests) == PAID_CALL_POLICY["paid_call"]["expected_http_attempts"]
+    assert exc_info.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_paid_call_legacy_mode_replays_once_and_marks_metadata() -> None:
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                422,
+                json={"detail": [{"type": "extra_forbidden", "loc": ["body", "respond_with"]}]},
+            )
+        return httpx.Response(200, json=call_success())
+
+    client = make_client(handler)
+    try:
+        with pytest.warns(DeprecationWarning, match="may resubmit"):
+            response = await client.call(
+                "paid-tool",
+                {},
+                respond_with="summary",
+                compatibility_mode="legacy_optional_fields",
+            )
+    finally:
+        await client.close()
+
+    assert len(requests) == 2
+    assert "respond_with" in json.loads(requests[0].content)
+    assert "respond_with" not in json.loads(requests[1].content)
+    assert response.request_metadata is not None
+    assert response.request_metadata.http_attempts == 2
+    assert response.request_metadata.retry_attempts == 0
+    assert response.request_metadata.compatibility_replays == 1
+    assert "request_metadata" not in response.model_dump()
+
+
+@pytest.mark.asyncio
+async def test_transport_error_drops_request_exception_context_and_secret_locals() -> None:
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise httpx.ReadTimeout("synthetic transport failure", request=request)
+
+    client = make_client(handler)
+    try:
+        with pytest.raises(QverisTransportError) as exc_info:
+            await client.call("paid-tool", {})
+    finally:
+        await client.close()
+
+    error = exc_info.value
+    assert len(requests) == 1
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert not hasattr(error, "request")
+    assert not hasattr(error, "response")
+    assert SYNTHETIC_TOKEN not in repr(error)
+    assert SYNTHETIC_TOKEN not in str(error)
+
+    traceback = error.__traceback__
+    while traceback is not None:
+        for value in traceback.tb_frame.f_locals.values():
+            assert SYNTHETIC_TOKEN not in repr(value)
+        traceback = traceback.tb_next
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        lambda request: httpx.ConnectError("dns or tls connect failed", request=request),
+        lambda request: httpx.ConnectTimeout("connect timed out", request=request),
+        lambda request: httpx.ReadError("read failed", request=request),
+        lambda request: httpx.ReadTimeout("read timed out", request=request),
+        lambda request: httpx.WriteError("write failed", request=request),
+        lambda request: httpx.WriteTimeout("write timed out", request=request),
+        lambda request: httpx.PoolTimeout("pool timed out", request=request),
+    ],
+)
+async def test_paid_call_transport_failures_are_single_submit(error_factory) -> None:
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise error_factory(request)
+
+    client = make_client(handler)
+    try:
+        with pytest.raises(QverisTransportError):
+            await client.call("paid-tool", {})
+    finally:
+        await client.close()
+
+    assert len(requests) == PAID_CALL_POLICY["paid_call"]["expected_http_attempts"]
+
+
+@pytest.mark.asyncio
+async def test_paid_call_cancellation_preserves_cancellation_without_replay() -> None:
+    started = asyncio.Event()
+
+    class BlockingTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.attempts = 0
+
+        async def handle_async_request(self, _request: httpx.Request) -> httpx.Response:
+            self.attempts += 1
+            started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    transport = BlockingTransport()
+    client = QverisClient(QverisConfig(api_key=SYNTHETIC_TOKEN), transport=transport)
+    task = asyncio.create_task(client.call("paid-tool", {}))
+    await started.wait()
+    task.cancel()
+    try:
+        with pytest.raises(asyncio.CancelledError) as exc_info:
+            await task
+    finally:
+        await client.close()
+
+    assert transport.attempts == PAID_CALL_POLICY["paid_call"]["expected_http_attempts"]
+    assert exc_info.value.__cause__ is None
+    assert SYNTHETIC_TOKEN not in repr(exc_info.value.__context__)
+
+
+@pytest.mark.asyncio
+async def test_debug_and_api_error_details_redact_credentials_and_signed_urls() -> None:
+    debug: List[str] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={
+                "message": f"Rejected Bearer {SYNTHETIC_TOKEN}",
+                "authorization": f"Bearer {SYNTHETIC_TOKEN}",
+                "full_content_file_url": "https://files.example/result?X-Amz-Signature=secret",
+            },
+        )
+
+    client = make_client(handler, debug_callback=debug.append)
+    try:
+        with pytest.raises(QverisApiError) as exc_info:
+            await client.discover("weather")
+    finally:
+        await client.close()
+
+    rendered = repr(exc_info.value.details) + "\n" + "\n".join(debug)
+    assert SYNTHETIC_TOKEN not in rendered
+    assert "X-Amz-Signature=secret" not in rendered
+    assert exc_info.value.details["authorization"] == "***"
+    assert exc_info.value.details["full_content_file_url"] == "***"
+
+    traceback = exc_info.value.__traceback__
+    while traceback is not None:
+        for value in traceback.tb_frame.f_locals.values():
+            if isinstance(value, httpx.Response):
+                assert SYNTHETIC_TOKEN not in value.text
+                assert "X-Amz-Signature=secret" not in value.text
+                assert value.request.headers["Authorization"] == "Bearer ***"
+        traceback = traceback.tb_next
+
+
+@pytest.mark.asyncio
+async def test_credential_context_is_operation_aware_and_concurrent_tokens_do_not_cross() -> None:
+    contexts: List[CredentialContext] = []
+
+    class ContextCredentialProvider:
+        async def get_credential(self, context: CredentialContext) -> str:
+            contexts.append(context)
+            await asyncio.sleep(0)
+            return f"token-{context.correlation_id}"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = json.loads(request.content)["query"]
+        assert request.headers["Authorization"] == f"Bearer token-{query}"
+        return httpx.Response(200, json={"search_id": query, "results": []})
+
+    provider = ContextCredentialProvider()
+    client = QverisClient(
+        QverisConfig(
+            api_key=None,
+            credential_audience="qveris-api",
+            credential_scopes=("tools.read",),
+        ),
+        credential_provider=provider,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        await asyncio.gather(
+            *(client.discover(f"request-{index}", correlation_id=f"request-{index}") for index in range(100))
+        )
+    finally:
+        await client.close()
+
+    assert len(contexts) == 100
+    assert {context.correlation_id for context in contexts} == {f"request-{index}" for index in range(100)}
+    assert all(context.operation == "discover" for context in contexts)
+    assert all(context.purpose == "data_read" for context in contexts)
+    assert all(context.audience == "qveris-api" for context in contexts)
+    assert all(context.scopes == ("tools.read",) for context in contexts)
+
+
+@pytest.mark.asyncio
+async def test_paid_call_credential_context_includes_purpose_and_safe_references() -> None:
+    contexts: List[CredentialContext] = []
+
+    class RecordingProvider:
+        async def get_credential(self, context: CredentialContext) -> str:
+            contexts.append(context)
+            return "short-lived-token"
+
+    client = QverisClient(
+        QverisConfig(api_key=None),
+        credential_provider=RecordingProvider(),
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, json=call_success())),
+    )
+    try:
+        await client.call(
+            "paid-tool",
+            {},
+            session_id="session-1",
+            correlation_id="correlation-1",
+        )
+    finally:
+        await client.close()
+
+    assert contexts == [
+        CredentialContext(
+            resource="https://qveris.ai/api/v1",
+            operation="call",
+            purpose="paid_execution",
+            session_id="session-1",
+            correlation_id="correlation-1",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_http_timeout_starts_after_credential_acquisition_and_is_operation_specific() -> None:
+    timeouts: List[Dict[str, float]] = []
+
+    class SlowCredentialProvider:
+        async def get_credential(self, _context: CredentialContext) -> str:
+            await asyncio.sleep(0.01)
+            return "short-lived-token"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        timeouts.append(request.extensions["timeout"])
+        if request.url.path.endswith("/search"):
+            return httpx.Response(200, json={"search_id": "search-1", "results": []})
+        return httpx.Response(200, json=call_success())
+
+    client = QverisClient(
+        QverisConfig(api_key=None, read_timeout=7, call_timeout=11),
+        credential_provider=SlowCredentialProvider(),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        await client.discover("weather")
+        await client.call("paid-tool", {}, timeout=13)
+    finally:
+        await client.close()
+
+    assert timeouts[0] == {"connect": 7.0, "read": 7.0, "write": 7.0, "pool": 7.0}
+    assert timeouts[1] == {"connect": 13.0, "read": 13.0, "write": 13.0, "pool": 13.0}
+
+
+@pytest.mark.asyncio
+async def test_shared_client_is_not_closed_and_close_rejects_new_requests() -> None:
+    shared = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, json={"search_id": "search-1", "results": []})
+        )
+    )
+    client = QverisClient(QverisConfig(api_key=SYNTHETIC_TOKEN), http_client=shared)
+    await asyncio.gather(client.close(), client.close())
+
+    assert not shared.is_closed
+    with pytest.raises(QverisClientClosedError):
+        await client.discover("weather")
+    with pytest.raises(QverisClientClosedError):
+        await client.inspect([])
+    await shared.aclose()
+
+
+@pytest.mark.asyncio
+async def test_owned_client_close_waits_for_inflight_request_and_closes_once() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class CountingTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.close_count = 0
+
+        async def handle_async_request(self, _request: httpx.Request) -> httpx.Response:
+            started.set()
+            await release.wait()
+            return httpx.Response(200, json={"search_id": "search-1", "results": []})
+
+        async def aclose(self) -> None:
+            self.close_count += 1
+
+    transport = CountingTransport()
+    client = QverisClient(QverisConfig(api_key=SYNTHETIC_TOKEN), transport=transport)
+    request_task = asyncio.create_task(client.discover("weather"))
+    await started.wait()
+    close_tasks = [asyncio.create_task(client.close()), asyncio.create_task(client.close())]
+    await asyncio.sleep(0)
+    assert not any(task.done() for task in close_tasks)
+
+    release.set()
+    await request_task
+    await asyncio.gather(*close_tasks)
+
+    assert transport.close_count == 1
+
+
+def test_signed_url_is_serialized_but_excluded_from_repr() -> None:
+    signed_url = "https://files.example/result?X-Amz-Signature=secret"
+    truncated = ExecuteResultTruncated(
+        message="truncated",
+        full_content_file_url=signed_url,
+        truncated_content="preview",
+    )
+    response = ToolExecutionResponse(
+        execution_id="exec-1",
+        success=True,
+        result={"full_content_file_url": signed_url},
+    )
+
+    assert truncated.model_dump()["full_content_file_url"] == signed_url
+    assert signed_url not in repr(truncated)
+    assert response.model_dump()["result"]["full_content_file_url"] == signed_url
+    assert signed_url not in repr(response)

--- a/packages/python-sdk/tests/test_safe_paid_call.py
+++ b/packages/python-sdk/tests/test_safe_paid_call.py
@@ -230,14 +230,17 @@ async def test_paid_call_cancellation_preserves_cancellation_without_replay() ->
 @pytest.mark.asyncio
 async def test_debug_and_api_error_details_redact_credentials_and_signed_urls() -> None:
     debug: List[str] = []
+    embedded_signed_url = "https://files.example/result?X-Amz-Signature=embedded-secret"
+    selection_token = "opaque-selection-secret-273"
 
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             401,
             json={
-                "message": f"Rejected Bearer {SYNTHETIC_TOKEN}",
+                "message": f"Rejected Bearer {SYNTHETIC_TOKEN}; inspect {embedded_signed_url}",
                 "authorization": f"Bearer {SYNTHETIC_TOKEN}",
                 "full_content_file_url": "https://files.example/result?X-Amz-Signature=secret",
+                "selectionToken": selection_token,
             },
         )
 
@@ -251,8 +254,11 @@ async def test_debug_and_api_error_details_redact_credentials_and_signed_urls() 
     rendered = repr(exc_info.value.details) + "\n" + "\n".join(debug)
     assert SYNTHETIC_TOKEN not in rendered
     assert "X-Amz-Signature=secret" not in rendered
+    assert "X-Amz-Signature=embedded-secret" not in rendered
+    assert selection_token not in rendered
     assert exc_info.value.details["authorization"] == "***"
     assert exc_info.value.details["full_content_file_url"] == "***"
+    assert exc_info.value.details["selectionToken"] == "***"
 
     traceback = exc_info.value.__traceback__
     while traceback is not None:
@@ -416,6 +422,68 @@ async def test_owned_client_close_waits_for_inflight_request_and_closes_once() -
     await request_task
     await asyncio.gather(*close_tasks)
 
+    assert transport.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelling_owned_transport_close_finishes_close_and_keeps_state_consistent() -> None:
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    class BlockingCloseTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.close_count = 0
+
+        async def handle_async_request(self, _request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"search_id": "search-1", "results": []})
+
+        async def aclose(self) -> None:
+            self.close_count += 1
+            close_started.set()
+            await release_close.wait()
+
+    transport = BlockingCloseTransport()
+    client = QverisClient(QverisConfig(api_key=SYNTHETIC_TOKEN), transport=transport)
+    close_task = asyncio.create_task(client.close())
+    await close_started.wait()
+
+    close_task.cancel()
+    await asyncio.sleep(0)
+    assert not close_task.done()
+
+    release_close.set()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    assert transport.close_count == 1
+    with pytest.raises(QverisClientClosedError):
+        await client.discover("weather")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_owned_transport_close_failure_still_seals_client_state() -> None:
+    class FailingCloseTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.close_count = 0
+
+        async def handle_async_request(self, _request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"search_id": "search-1", "results": []})
+
+        async def aclose(self) -> None:
+            self.close_count += 1
+            raise RuntimeError("synthetic close failure")
+
+    transport = FailingCloseTransport()
+    client = QverisClient(QverisConfig(api_key=SYNTHETIC_TOKEN), transport=transport)
+
+    with pytest.raises(RuntimeError, match="synthetic close failure"):
+        await client.close()
+
+    assert transport.close_count == 1
+    with pytest.raises(QverisClientClosedError):
+        await client.discover("weather")
+    await client.close()
     assert transport.close_count == 1
 
 

--- a/test-fixtures/paid-call-policy.json
+++ b/test-fixtures/paid-call-policy.json
@@ -1,0 +1,11 @@
+{
+  "paid_call": {
+    "automatic_retry_statuses": [],
+    "allow_auth_replay": false,
+    "optional_field_fallback": "never",
+    "expected_http_attempts": 1
+  },
+  "read_operations": {
+    "retryable_statuses": [429, 503]
+  }
+}

--- a/test-fixtures/paid-call-policy.json
+++ b/test-fixtures/paid-call-policy.json
@@ -7,5 +7,29 @@
   },
   "read_operations": {
     "retryable_statuses": [429, 503]
+  },
+  "contract_fixtures": {
+    "n": {
+      "status": 200,
+      "body": {
+        "execution_id": "exec-current",
+        "success": true,
+        "result": {
+          "ok": true
+        }
+      }
+    },
+    "n_minus_1": {
+      "status": 422,
+      "body": {
+        "detail": [
+          {
+            "type": "extra_forbidden",
+            "loc": ["body", "respond_with"],
+            "msg": "Extra input"
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implements the service-independent P0 delivery gate from #273:

- makes paid calls strict single-submit by default across Python SDK, JS SDK, CLI, and MCP
- prevents `429`/`503`, CLI OAuth `401` refresh, and projection fallback paths from replaying a paid request
- retains an explicit deprecated legacy projection replay only in the Python and JS SDKs
- adds Python credential-safe typed errors, immutable per-operation request metadata, bounded recursive redaction, signed-URL repr isolation, and safe tool-handler errors
- adds Python operation-aware credential context, read/call timeouts, shared-client or owned-transport injection, and concurrent/idempotent close semantics
- adds shared paid-call policy and current/N-1 projection contract fixtures, plus timeout, transport, credential, child-task concurrency, lifecycle, debug, and OpenTelemetry safety coverage
- updates English/Chinese guides, generated API references, package READMEs, and changelogs

## Root cause

The prior clients used one retry policy for read operations and paid execution, and projection compatibility could submit `/tools/execute` a second time outside normal retry accounting. The CLI also refreshed OAuth credentials after `401` and replayed the same paid request. Python additionally exposed raw transport/request state through exception chains and lacked explicit transport ownership and operation context.

## Impact

Default paid execution now makes at most one physical HTTP submission when the remote outcome may be billable or unknown. Read and audit operations retain bounded `429`/`503` retry behavior. Python callers migrate from raw `httpx` failures to the exported `QverisError` hierarchy and can inspect `response.request_metadata` or `error.request_metadata` without retaining credentials or raw transport objects.

Capability Resolve/Query, selection tokens, idempotency keys, and execution lookup remain intentionally blocked on WonderfulValley/qveris-website#2100 and are not guessed in this change.

## Validation

- `npm test` — CLI 134, MCP 181, JS SDK 67, OpenClaw plugin 78, Python 178 passed / 1 skipped, release checks 36
- `npm run build`
- `npm run typecheck`
- package example typechecks for JS SDK and MCP
- package lint plus Python Ruff checks
- regenerated JS and Python API reference docs
- public documentation region-boundary scan

Refs #273
