### PR TITLE
fix: harden paid-call redirect and error boundaries

### DIFF
--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -208,7 +208,7 @@ qveris call 1 --params '{"city": "London"}' --respond-with summary
 qveris call 1 --params '{"city": "London"}' --respond-with 'fields:$.temperature,$.humidity'
 ```
 
-Projection flags are opt-in. Paid calls are strict single-submit: the CLI does not retry `429`/`503`, refresh OAuth after `401` and replay, or remove a rejected projection field and resubmit. Projection rejections and invalid projections remain `422` errors. `QVERIS_MAX_RETRIES` continues to apply to read and audit commands only.
+Projection flags are opt-in. Paid calls are strict single-submit: the CLI does not retry `429`/`503`, follow HTTP redirects, refresh OAuth after `401` and replay, or remove a rejected projection field and resubmit. Projection rejections and invalid projections remain `422` errors. `QVERIS_MAX_RETRIES` continues to apply to read and audit commands only.
 
 **Dry run (no credits consumed):**
 

--- a/docs/en-US/js-sdk.md
+++ b/docs/en-US/js-sdk.md
@@ -112,7 +112,7 @@ Option shapes:
 - `inspect(toolIds, { searchId?, sessionId?, timeoutMs? })` — `toolIds` accepts a single string or an array; an **empty array short-circuits** and returns an empty response without a network request.
 - `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs?, compatibilityMode? })`
 
-Projection options are opt-in. Paid calls are strict single-submit: `429`/`503` and projection errors are returned without replay. The deprecated `compatibilityMode: 'legacyOptionalFields'` opt-in permits exactly one replay without an optional field rejected by an older service; invalid projections remain errors.
+Projection options are opt-in. Paid calls are strict single-submit: HTTP redirects are not followed, and `429`/`503` and projection errors are returned without replay. The deprecated `compatibilityMode: 'legacyOptionalFields'` opt-in permits exactly one replay without an optional field rejected by an older service; invalid projections remain errors.
 
 `usage(...)` and `ledger(...)` take filter objects such as `start_date`, `end_date`, `summary`, `bucket`, `charge_outcome`, `execution_id`, `search_id`, `direction`, `entry_type`, `min_credits`, `max_credits`, `limit`, `page`, `page_size`.
 

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -288,7 +288,7 @@ Example:
 }
 ```
 
-Projection inputs are opt-in. Paid `call` / `execute_tool` requests are strict single-submit: the MCP server does not retry `429`/`503` or remove a rejected projection field and resubmit. Projection errors remain errors; `QVERIS_MAX_RETRIES` applies only to read and audit tools.
+Projection inputs are opt-in. Paid `call` / `execute_tool` requests are strict single-submit: the MCP server does not retry `429`/`503`, follow HTTP redirects, or remove a rejected projection field and resubmit. Projection errors remain errors; `QVERIS_MAX_RETRIES` applies only to read and audit tools.
 
 Typical successful response fields:
 

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -191,7 +191,7 @@ agent = Agent(
 
 ## Safe paid calls and transport ownership
 
-Paid `call()` requests are strict single-submit by default. The SDK does not automatically retry `429`/`503`, timeout, or transport failures, and it does not remove a rejected projection field and resubmit. A typed error reports `request_metadata.http_attempts == 1`. If an older service requires the former projection fallback, opt in explicitly:
+Paid `call()` requests are strict single-submit by default. The SDK does not follow HTTP redirects or automatically retry `429`/`503`, timeout, or transport failures, and it does not remove a rejected projection field and resubmit. A typed error reports `request_metadata.http_attempts == 1`. If an older service requires the former projection fallback, opt in explicitly:
 
 ```python
 result = await client.call(

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -208,7 +208,7 @@ qveris call 1 --params '{"city": "London"}' --respond-with summary
 qveris call 1 --params '{"city": "London"}' --respond-with 'fields:$.temperature,$.humidity'
 ```
 
-投影参数仅在显式指定时发送。付费调用严格 single-submit：CLI 不会重试 `429`/`503`，不会在 `401` 后刷新 OAuth 并重放，也不会删除被拒绝的投影字段后再次提交。投影拒绝和无效投影都按 `422` 错误返回。`QVERIS_MAX_RETRIES` 仅继续用于读和审计命令。
+投影参数仅在显式指定时发送。付费调用严格 single-submit：CLI 不会重试 `429`/`503`，不会跟随 HTTP 重定向，不会在 `401` 后刷新 OAuth 并重放，也不会删除被拒绝的投影字段后再次提交。投影拒绝和无效投影都按 `422` 错误返回。`QVERIS_MAX_RETRIES` 仅继续用于读和审计命令。
 
 **试运行（不消耗积分）：**
 

--- a/docs/zh-CN/js-sdk.md
+++ b/docs/zh-CN/js-sdk.md
@@ -110,7 +110,7 @@ AI SDK 集成。该页面直接根据 TypeScript 源码重新生成，并由 CI 
 - `inspect(toolIds, { searchId?, sessionId?, timeoutMs? })` —— `toolIds` 接受单个字符串或数组；**空数组会短路**，直接返回空响应而不发起网络请求。
 - `call(toolId, { parameters, searchId?, sessionId?, maxResponseSize?, respondWith?, timeoutMs?, compatibilityMode? })`
 
-投影参数仅在显式指定时发送。付费调用严格 single-submit：`429`/`503` 和投影错误会直接返回，不会重放。已弃用的 `compatibilityMode: 'legacyOptionalFields'` 可显式允许一次删除旧服务拒绝的可选字段后重放；无效投影仍按错误返回。
+投影参数仅在显式指定时发送。付费调用严格 single-submit：不会跟随 HTTP 重定向，`429`/`503` 和投影错误会直接返回，不会重放。已弃用的 `compatibilityMode: 'legacyOptionalFields'` 可显式允许一次删除旧服务拒绝的可选字段后重放；无效投影仍按错误返回。
 
 `usage(...)` 和 `ledger(...)` 接受过滤对象，如 `start_date`、`end_date`、`summary`、`bucket`、`charge_outcome`、`execution_id`、`search_id`、`direction`、`entry_type`、`min_credits`、`max_credits`、`limit`、`page`、`page_size`。
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -286,7 +286,7 @@ claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --
 }
 ```
 
-投影参数仅在显式指定时发送。付费 `call` / `execute_tool` 请求严格 single-submit：MCP server 不会重试 `429`/`503`，也不会删除被拒绝的投影字段后再次提交。投影错误仍按错误返回；`QVERIS_MAX_RETRIES` 仅用于读和审计工具。
+投影参数仅在显式指定时发送。付费 `call` / `execute_tool` 请求严格 single-submit：MCP server 不会重试 `429`/`503`，不会跟随 HTTP 重定向，也不会删除被拒绝的投影字段后再次提交。投影错误仍按错误返回；`QVERIS_MAX_RETRIES` 仅用于读和审计工具。
 
 典型成功响应字段：
 

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -191,7 +191,7 @@ agent = Agent(
 
 ## 安全付费调用与 transport 所有权
 
-付费 `call()` 默认严格 single-submit。SDK 不会自动重试 `429`/`503`、超时或 transport 失败，也不会删除被拒绝的投影字段后再次提交；类型化错误会报告 `request_metadata.http_attempts == 1`。如果旧服务仍需要原来的投影降级，可显式选择：
+付费 `call()` 默认严格 single-submit。SDK 不会跟随 HTTP 重定向，不会自动重试 `429`/`503`、超时或 transport 失败，也不会删除被拒绝的投影字段后再次提交；类型化错误会报告 `request_metadata.http_attempts == 1`。如果旧服务仍需要原来的投影降级，可显式选择：
 
 ```python
 result = await client.call(

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,7 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- Paid `qveris call` requests are now strict single-submit: the CLI does not retry `429`/`503`, replay after OAuth refresh on `401`, or remove a rejected projection field and resubmit. Read commands retain bounded retry and OAuth refresh behavior. ([#273])
+- Paid `qveris call` requests are now strict single-submit: the CLI does not retry `429`/`503`, follow HTTP redirects, replay after OAuth refresh on `401`, or remove a rejected projection field and resubmit. Read commands retain bounded retry and OAuth refresh behavior. ([#273])
 
 ## [0.9.0] - 2026-07-23
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -248,7 +248,7 @@ qveris call 1 --params '{"symbol": "AAPL"}' --codegen python
 qveris call 1 --params '{"symbol": "AAPL"}' --codegen js
 ```
 
-Projection flags are opt-in. A paid call is always single-submit: the CLI does not retry `429`/`503`, replay after OAuth refresh on `401`, or remove a rejected projection field and resubmit. Projection rejections and invalid projections remain `422` errors.
+Projection flags are opt-in. A paid call is always single-submit: the CLI does not retry `429`/`503`, follow HTTP redirects, replay after OAuth refresh on `401`, or remove a rejected projection field and resubmit. Projection rejections and invalid projections remain `422` errors.
 
 #### Response Truncation
 

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -184,11 +184,13 @@ test("API client preserves read projection fallback but never resubmits a paid c
   ]);
 
   const callBodies = [];
+  const callRedirectModes = [];
   const previous = PAID_CALL_POLICY.contract_fixtures.n_minus_1;
   await assert.rejects(
     withMockFetch(
       (_url, options) => {
         callBodies.push(JSON.parse(options.body));
+        callRedirectModes.push(options.redirect);
         return jsonResponse(previous.body, { status: previous.status });
       },
       () =>
@@ -211,6 +213,8 @@ test("API client preserves read projection fallback but never resubmits a paid c
       respond_with: "summary",
     },
   ]);
+  assert.equal(PAID_CALL_POLICY.paid_call.allow_redirect_replay, false);
+  assert.deepEqual(callRedirectModes, ["error"]);
 });
 
 test("API client does not downgrade invalid projections", async () => {

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -8,7 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- Paid `call()` operations are strict single-submit by default and no longer retry `429`/`503` or automatically remove a rejected projection field and replay. The deprecated `compatibilityMode: "legacyOptionalFields"` opt-in preserves the legacy projection replay when explicitly required. ([#273])
+- Paid `call()` operations are strict single-submit by default and no longer retry `429`/`503`, follow HTTP redirects, or automatically remove a rejected projection field and replay. The deprecated `compatibilityMode: "legacyOptionalFields"` opt-in preserves the legacy projection replay when explicitly required. ([#273])
 
 ## [0.6.0] - 2026-07-23
 

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -120,7 +120,7 @@ API keys never select the endpoint. Endpoint overrides must be HTTP(S) URLs with
 
 ## Rate limiting & retries
 
-The client transparently retries rate-limited (`429`) and transient (`503`) responses for read/audit operations: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Each wait is capped and retries are bounded by `maxRetries`; paid calls remain single-submit.
+The client transparently retries rate-limited (`429`) and transient (`503`) responses for read/audit operations: it honors the `Retry-After` header when present, otherwise backs off exponentially with full jitter. Each wait is capped and retries are bounded by `maxRetries`; paid calls remain single-submit and HTTP redirects are not followed.
 
 ```ts
 const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY!, maxRetries: 5 });

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -11,7 +11,7 @@ const API_KEY = 'sk-test-key';
 const PAID_CALL_POLICY = JSON.parse(
   readFileSync(new URL('../../../test-fixtures/paid-call-policy.json', import.meta.url), 'utf8'),
 ) as {
-  paid_call: { expected_http_attempts: number };
+  paid_call: { expected_http_attempts: number; allow_redirect_replay: boolean };
   read_operations: { retryable_statuses: number[] };
   contract_fixtures: {
     n: { status: number; body: { execution_id: string; success: boolean; result: { ok: boolean } } };
@@ -431,6 +431,8 @@ describe('Qveris client', () => {
     ).rejects.toMatchObject({ status: 422 });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(PAID_CALL_POLICY.paid_call.allow_redirect_replay).toBe(false);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'error' });
   });
 
   it('call legacy compatibility replays once without rejected respond_with', async () => {

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -422,6 +422,7 @@ export class Qveris {
           },
           body: body ? JSON.stringify(body) : undefined,
           signal: controller.signal,
+          redirect: 'error',
         });
 
         if (RETRYABLE_STATUS.has(response.status) && attempt < retryLimit) {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -8,7 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- Paid `call` / `execute_tool` requests are now strict single-submit: the MCP client does not retry `429`/`503` or remove a rejected projection field and resubmit. Read tools retain bounded retry behavior. ([#273])
+- Paid `call` / `execute_tool` requests are now strict single-submit: the MCP client does not retry `429`/`503`, follow HTTP redirects, or remove a rejected projection field and resubmit. Read tools retain bounded retry behavior. ([#273])
 
 ## [0.12.0] - 2026-07-23
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -174,7 +174,7 @@ Call a discovered tool with specific parameters.
 
 The `call` response may include compact pre-settlement `billing`. Final charge status should be checked with `usage_history` or `credits_ledger`.
 
-Projection inputs are opt-in. Paid `call` / `execute_tool` requests are always single-submit: the MCP server does not retry `429`/`503` or remove a rejected projection field and resubmit. Projection errors remain errors.
+Projection inputs are opt-in. Paid `call` / `execute_tool` requests are always single-submit: the MCP server does not retry `429`/`503`, follow HTTP redirects, or remove a rejected projection field and resubmit. Projection errors remain errors.
 
 ### `usage_history`
 

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -9,7 +9,7 @@ import { QverisClient, createClientFromEnv } from './client.js';
 const PAID_CALL_POLICY = JSON.parse(
   readFileSync(new URL('../../../../test-fixtures/paid-call-policy.json', import.meta.url), 'utf8'),
 ) as {
-  paid_call: { expected_http_attempts: number };
+  paid_call: { expected_http_attempts: number; allow_redirect_replay: boolean };
   read_operations: { retryable_statuses: number[] };
   contract_fixtures: {
     n_minus_1: { status: number; body: Record<string, unknown> };
@@ -532,6 +532,8 @@ describe('QverisClient', () => {
       ).rejects.toMatchObject({ status: 422 });
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(PAID_CALL_POLICY.paid_call.allow_redirect_replay).toBe(false);
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'error' });
     });
 
     it('should not downgrade an invalid projection', async () => {

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -183,6 +183,7 @@ export class QverisClient {
           },
           body: body ? JSON.stringify(body) : undefined,
           signal: controller.signal,
+          redirect: 'error',
         });
 
         if (RETRYABLE_STATUS.has(response.status) && attempt < retryLimit) {

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -12,11 +12,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
-- Paid `call()` operations are strict single-submit by default: they no longer retry `429`/`503` or automatically replay after a legacy projection rejection. The deprecated `compatibility_mode="legacy_optional_fields"` opt-in preserves the old projection fallback when explicitly required. Read operations continue to use bounded `max_retries`. ([#273])
+- Paid `call()` operations are strict single-submit by default: they no longer retry `429`/`503`, follow HTTP redirects, or automatically replay after a legacy projection rejection. The deprecated `compatibility_mode="legacy_optional_fields"` opt-in preserves the old projection fallback when explicitly required. Read operations continue to use bounded `max_retries`. ([#273])
 
 ### Security
 
-- Removed raw `httpx` request, response, transport exception, credential-provider exception, signed URL, and unredacted response-body data from public error/debug paths. ([#273])
+- Removed raw `httpx` request, response, transport exception, credential-provider exception, signed URL, and unredacted response-body data from public error/debug paths. Invalid JSON, failure envelopes, and schema-invalid success responses now cross the same credential-safe `QverisContractError` boundary. ([#273])
 
 ## [0.5.0] - 2026-07-23
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -103,7 +103,7 @@ First-class typed APIs:
 
 Backward-compatible aliases remain available: `search_tools`, `get_tools_by_ids`, and `execute_tool`.
 
-Projection arguments are never sent unless explicitly configured. A paid `call()` is strict single-submit by default: it does not retry `429`/`503`, transport/timeout failures, or a rejected optional field. If an older service requires projection fallback, `compatibility_mode="legacy_optional_fields"` explicitly opts into one deprecated replay and records it in `response.request_metadata`.
+Projection arguments are never sent unless explicitly configured. A paid `call()` is strict single-submit by default: it does not retry `429`/`503`, follow HTTP redirects, retry transport/timeout failures, or replay a rejected optional field. If an older service requires projection fallback, `compatibility_mode="legacy_optional_fields"` explicitly opts into one deprecated replay and records it in `response.request_metadata`.
 
 ## Typed Models
 

--- a/packages/python-sdk/qveris/client/api.py
+++ b/packages/python-sdk/qveris/client/api.py
@@ -80,11 +80,17 @@ from .retry import RetryPolicy
 _SENSITIVE_KEYS = frozenset(
     {
         "authorization",
+        "proxy-authorization",
         "api_key",
         "apikey",
+        "x-api-key",
+        "x-auth-token",
         "access_token",
         "refresh_token",
         "token",
+        "credential",
+        "secret",
+        "password",
         "selection_token",
         "full_content_file_url",
         "cookie",
@@ -102,6 +108,25 @@ _SIGNED_URL_MARKERS = (
     "token=",
 )
 _NORMALIZED_SENSITIVE_KEYS = frozenset(re.sub(r"[^a-z0-9]", "", key.lower()) for key in _SENSITIVE_KEYS)
+_SENSITIVE_KEY_SUFFIXES = (
+    "authorization",
+    "apikey",
+    "authtoken",
+    "accesstoken",
+    "refreshtoken",
+    "selectiontoken",
+    "credential",
+    "secret",
+    "password",
+    "cookie",
+)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", str(key).lower())
+    return normalized in _NORMALIZED_SENSITIVE_KEYS or any(
+        normalized.endswith(suffix) for suffix in _SENSITIVE_KEY_SUFFIXES
+    )
 
 
 @dataclass
@@ -117,6 +142,12 @@ class _RequestState:
 class _SendFailure:
     error_type: str
     message: str
+
+
+@dataclass(frozen=True)
+class _DecodedResponse:
+    value: Any = None
+    error_message: Optional[str] = None
 
 
 def _pre_settlement_credits(response: ToolExecutionResponse) -> Optional[float]:
@@ -199,6 +230,7 @@ class QverisClient:
         self._close_lock = asyncio.Lock()
         self._no_active_requests = asyncio.Event()
         self._no_active_requests.set()
+        self._request_cleanup_tasks: Set[asyncio.Task[None]] = set()
         self._active_requests = 0
         self._closing = False
         self._closed = False
@@ -229,6 +261,32 @@ class QverisClient:
             self._active_requests -= 1
             if self._active_requests == 0:
                 self._no_active_requests.set()
+
+    async def _finish_request(self) -> None:
+        """Complete lifecycle accounting even if the caller is cancelled again."""
+        cleanup_task = asyncio.create_task(self._end_request())
+        self._request_cleanup_tasks.add(cleanup_task)
+        cleanup_task.add_done_callback(self._request_cleanup_tasks.discard)
+        await self._await_task_completion(cleanup_task)
+
+    @staticmethod
+    async def _await_task_completion(task: asyncio.Task[None]) -> None:
+        """Wait for an internal cleanup task before propagating caller cancellation."""
+        pending_cancellation: Optional[asyncio.CancelledError] = None
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError as error:
+                if pending_cancellation is None:
+                    pending_cancellation = error
+
+        if task.cancelled():
+            await task
+        task_error = task.exception()
+        if task_error is not None:
+            raise task_error
+        if pending_cancellation is not None:
+            raise pending_cancellation
 
     def _request_metadata(self, state: _RequestState) -> RequestMetadata:
         retries = max(0, state.http_attempts - 1 - state.compatibility_replays)
@@ -263,25 +321,63 @@ class QverisClient:
             correlation_id=correlation_id,
         )
 
-    @staticmethod
-    def _scrub_request_authorization(request: Any) -> None:
+    def _scrub_request_headers(self, request: Any, credential: Optional[str] = None) -> None:
         headers = getattr(request, "headers", None)
         if headers is None:
             return
         try:
-            if "Authorization" in headers:
-                headers["Authorization"] = "Bearer ***"
+            for key, value in list(headers.multi_items()):
+                normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+                if _is_sensitive_key(key):
+                    headers[key] = "Bearer ***" if normalized_key in {"authorization", "proxyauthorization"} else "***"
+                    continue
+                safe_value = value.replace(credential, "***") if credential else value
+                headers[key] = self._redact_sensitive(safe_value)
         except Exception:
             pass
 
     @staticmethod
-    def _scrub_response_credential(response: httpx.Response, credential: Optional[str]) -> None:
+    def _replace_exact_secret(value: Any, secret: str, depth: int = 0) -> Any:
+        """Replace one exact secret in a JSON-compatible value."""
+        if depth >= 32:
+            return "<response value omitted>"
+        if isinstance(value, dict):
+            return {
+                key.replace(secret, "***") if isinstance(key, str) else key: QverisClient._replace_exact_secret(
+                    item, secret, depth + 1
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [QverisClient._replace_exact_secret(item, secret, depth + 1) for item in value]
+        if isinstance(value, tuple):
+            return tuple(QverisClient._replace_exact_secret(item, secret, depth + 1) for item in value)
+        if isinstance(value, str):
+            return value.replace(secret, "***")
+        return value
+
+    def _scrub_response_credential(self, response: httpx.Response, credential: Optional[str]) -> None:
         """Remove the attempt credential before a response leaves the transport boundary."""
         if not credential:
             return
-        secret = credential.encode()
         try:
-            response._content = response.content.replace(secret, b"***")  # type: ignore[attr-defined]
+            content = response.content
+            variants = {
+                credential.encode(),
+                json.dumps(credential, ensure_ascii=False)[1:-1].encode(),
+                json.dumps(credential, ensure_ascii=True)[1:-1].encode(),
+            }
+            if any(variant and variant in content for variant in variants):
+                try:
+                    safe_body = self._replace_exact_secret(response.json(), credential)
+                    content = json.dumps(safe_body, ensure_ascii=False).encode()
+                    response._content = content  # type: ignore[attr-defined]
+                except Exception:
+                    for variant in variants:
+                        if variant:
+                            content = content.replace(variant, b"***")
+                    response._content = content  # type: ignore[attr-defined]
+                response.headers["content-length"] = str(len(content))
         except Exception:
             pass
         try:
@@ -290,11 +386,37 @@ class QverisClient:
                     response.headers[key] = value.replace(credential, "***")
         except Exception:
             pass
+        try:
+            reason = response.extensions.get("reason_phrase")
+            if isinstance(reason, bytes):
+                response.extensions["reason_phrase"] = reason.replace(credential.encode(), b"***")
+            elif isinstance(reason, str):
+                response.extensions["reason_phrase"] = reason.replace(credential, "***")
+        except Exception:
+            pass
+
+    def _scrub_response_headers(self, response: httpx.Response) -> None:
+        """Redact sensitive response headers and status metadata retained in tracebacks."""
+        try:
+            for key, value in list(response.headers.multi_items()):
+                response.headers[key] = "***" if _is_sensitive_key(key) else self._redact_sensitive(value)
+        except Exception:
+            pass
+        try:
+            reason = response.extensions.get("reason_phrase")
+            if isinstance(reason, bytes):
+                safe_reason = self._redact_sensitive(reason.decode(errors="replace"))
+                response.extensions["reason_phrase"] = safe_reason.encode()
+            elif isinstance(reason, str):
+                response.extensions["reason_phrase"] = self._redact_sensitive(reason)
+        except Exception:
+            pass
 
     def _scrub_error_response(self, response: httpx.Response) -> None:
         """Replace an error body with its bounded, recursively redacted form."""
-        if response.status_code < 400:
+        if 200 <= response.status_code < 300:
             return
+        self._scrub_response_headers(response)
         try:
             safe_body = self._redact_sensitive(response.json())
         except (json.JSONDecodeError, UnicodeDecodeError):
@@ -353,9 +475,10 @@ class QverisClient:
                     max_retries=retry_limit,
                     on_attempt=on_attempt,
                     timeout=request_timeout,
+                    follow_redirects=False,
                     **kwargs,
                 )
-                self._scrub_request_authorization(getattr(response, "request", None))
+                self._scrub_request_headers(getattr(response, "request", None), credential)
                 self._scrub_response_credential(response, credential)
                 self._scrub_error_response(response)
                 return response
@@ -364,20 +487,20 @@ class QverisClient:
             except CredentialResolutionError as exc:
                 return _SendFailure("credential", str(exc))
             except httpx.TimeoutException as exc:
-                self._scrub_request_authorization(getattr(exc, "request", None))
+                self._scrub_request_headers(getattr(exc, "request", None), credential)
                 return _SendFailure("timeout", "QVeris request timed out")
             except httpx.TransportError as exc:
-                self._scrub_request_authorization(getattr(exc, "request", None))
+                self._scrub_request_headers(getattr(exc, "request", None), credential)
                 return _SendFailure(type(exc).__name__.lower(), "QVeris transport request failed")
             except Exception as exc:
-                self._scrub_request_authorization(getattr(exc, "request", None))
+                self._scrub_request_headers(getattr(exc, "request", None), credential)
                 return _SendFailure("transport_error", "QVeris transport request failed")
 
         await self._begin_request(state)
         try:
             outcome = await perform()
         finally:
-            await self._end_request()
+            await self._finish_request()
 
         if isinstance(outcome, _SendFailure):
             metadata = self._request_metadata(state)
@@ -459,10 +582,8 @@ class QverisClient:
                 if index >= 100:
                     safe_dict["__truncated__"] = True
                     break
-                normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
-                safe_dict[key] = (
-                    "***" if normalized_key in _NORMALIZED_SENSITIVE_KEYS else self._redact_sensitive(item, depth + 1)
-                )
+                safe_key = self._redact_sensitive(str(key), depth + 1)
+                safe_dict[safe_key] = "***" if _is_sensitive_key(key) else self._redact_sensitive(item, depth + 1)
             return safe_dict
         if isinstance(value, list):
             return [self._redact_sensitive(item, depth + 1) for item in value[:100]]
@@ -488,16 +609,53 @@ class QverisClient:
             return fallback
         return safe[:2048]
 
-    def _parse_response_json(self, response: httpx.Response) -> Any:
-        """Parse response JSON once while still logging non-JSON bodies for debugging."""
+    def _scrub_contract_response(self, response: httpx.Response) -> None:
+        """Remove raw response data before a public contract error is raised."""
+        self._scrub_response_headers(response)
         try:
-            data = response.json()
+            safe_body = self._redact_sensitive(response.json())
+        except Exception:
+            safe_body = {"body": "<invalid API response omitted>"}
+        content = json.dumps(safe_body, ensure_ascii=False).encode()
+        response._content = content  # type: ignore[attr-defined]
+        response.headers["content-length"] = str(len(content))
+
+    def _decode_response_model(
+        self,
+        response: httpx.Response,
+        model_type: Callable[..., Any],
+        *,
+        operation: str,
+        state: _RequestState,
+    ) -> Any:
+        """Decode and validate a success response behind a safe exception boundary."""
+
+        def attempt() -> _DecodedResponse:
+            try:
+                data = response.json()
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                self._debug("[Qveris API] Response body: <non-JSON body omitted>")
+                return _DecodedResponse(error_message="Invalid JSON response from API")
+
             safe_data = self._redact_sensitive(data)
             self._debug(f"[Qveris API] Response body: {json.dumps(safe_data, indent=2)}")
-            return data
-        except json.JSONDecodeError:
-            self._debug("[Qveris API] Response body: <non-JSON body omitted>")
-            raise
+            try:
+                payload = self._unwrap_envelope(data, operation=operation, state=state)
+                return _DecodedResponse(value=model_type(**payload))
+            except QverisContractError as error:
+                return _DecodedResponse(error_message=str(error))
+            except Exception:
+                return _DecodedResponse(error_message="API response did not match the expected contract")
+
+        outcome = attempt()
+        if outcome.error_message is not None:
+            self._scrub_contract_response(response)
+            raise QverisContractError(
+                outcome.error_message,
+                operation=operation,
+                request_metadata=self._request_metadata(state),
+            ) from None
+        return outcome.value
 
     def _url_for(self, method: str, path: str, params: Optional[Dict[str, Any]] = None) -> str:
         """Build the effective request URL using the same httpx client settings."""
@@ -529,7 +687,7 @@ class QverisClient:
         operation: str,
         state: _RequestState,
     ) -> Optional[QverisApiError]:
-        if response.status_code < 400:
+        if 200 <= response.status_code < 300:
             return None
         try:
             raw_details = response.json()
@@ -612,13 +770,10 @@ class QverisClient:
             # wrapper appear reusable while its transport is half-closed.
             close_task = asyncio.create_task(self.client.aclose())
             try:
-                await asyncio.shield(close_task)
+                await self._await_task_completion(close_task)
             except asyncio.CancelledError:
-                try:
-                    await close_task
-                finally:
-                    self._closed = True
-                    self._closing = False
+                self._closed = True
+                self._closing = False
                 raise
             except Exception:
                 self._closed = True
@@ -690,8 +845,7 @@ class QverisClient:
             error = self._api_error_from_response(response, operation="discover", state=state)
             if error is not None:
                 raise error from None
-            data = self._unwrap_envelope(self._parse_response_json(response), operation="discover", state=state)
-            result = SearchResponse(**data)
+            result = self._decode_response_model(response, SearchResponse, operation="discover", state=state)
             result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(
                 span,
@@ -769,8 +923,7 @@ class QverisClient:
             error = self._api_error_from_response(response, operation="inspect", state=state)
             if error is not None:
                 raise error from None
-            data = self._unwrap_envelope(self._parse_response_json(response), operation="inspect", state=state)
-            result = SearchResponse(**data)
+            result = self._decode_response_model(response, SearchResponse, operation="inspect", state=state)
             result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(span, {ATTR_RESULT_COUNT: len(result.results or [])})
             return result
@@ -819,8 +972,7 @@ class QverisClient:
             error = self._api_error_from_response(response, operation="probe", state=state)
             if error is not None:
                 raise error from None
-            data = self._unwrap_envelope(self._parse_response_json(response), operation="probe", state=state)
-            result = ToolProbeResponse(**data)
+            result = self._decode_response_model(response, ToolProbeResponse, operation="probe", state=state)
             result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(span, {ATTR_SUCCESS: result.schema_ is None or result.schema_.valid})
             return result
@@ -913,8 +1065,7 @@ class QverisClient:
             error = self._api_error_from_response(response, operation="call", state=state)
             if error is not None:
                 raise error from None
-            data = self._unwrap_envelope(self._parse_response_json(response), operation="call", state=state)
-            result = ToolExecutionResponse(**data)
+            result = self._decode_response_model(response, ToolExecutionResponse, operation="call", state=state)
             result._set_request_metadata(self._request_metadata(state))
             set_span_attributes(
                 span,
@@ -1005,8 +1156,7 @@ class QverisClient:
         error = self._api_error_from_response(response, operation="usage", state=state)
         if error is not None:
             raise error from None
-        data = self._unwrap_envelope(self._parse_response_json(response), operation="usage", state=state)
-        result = UsageHistoryResponse(**data)
+        result = self._decode_response_model(response, UsageHistoryResponse, operation="usage", state=state)
         result._set_request_metadata(self._request_metadata(state))
         return result
 
@@ -1063,8 +1213,7 @@ class QverisClient:
         error = self._api_error_from_response(response, operation="ledger", state=state)
         if error is not None:
             raise error from None
-        data = self._unwrap_envelope(self._parse_response_json(response), operation="ledger", state=state)
-        result = CreditsLedgerResponse(**data)
+        result = self._decode_response_model(response, CreditsLedgerResponse, operation="ledger", state=state)
         result._set_request_metadata(self._request_metadata(state))
         return result
 

--- a/packages/python-sdk/qveris/types.py
+++ b/packages/python-sdk/qveris/types.py
@@ -179,7 +179,7 @@ class ToolExecutionResponse(QverisModel):
     elapsed_time_ms: Optional[float] = None
     execution_time: Optional[float] = None
     tool_id: Optional[str] = None
-    parameters: Optional[Dict[str, Any]] = None
+    parameters: Optional[Dict[str, Any]] = Field(default=None, repr=False)
     cost: Optional[float] = None
     billing: Optional[CompactBillingStatement] = None
     pre_settlement_bill: Optional[Dict[str, Any]] = None

--- a/packages/python-sdk/tests/test_safe_paid_call.py
+++ b/packages/python-sdk/tests/test_safe_paid_call.py
@@ -13,12 +13,15 @@ from qveris.credentials import CredentialContext
 from qveris.errors import (
     QverisApiError,
     QverisClientClosedError,
+    QverisContractError,
     QverisTransportError,
 )
 from qveris.types import ExecuteResultTruncated, ToolExecutionResponse
 
 
 SYNTHETIC_TOKEN = "synthetic-credential-value-273"
+SYNTHETIC_SIGNED_URL = "https://files.example/result?X-Amz-Signature=contract-secret"
+SYNTHETIC_COOKIE = "synthetic-session-cookie-273"
 PAID_CALL_POLICY = json.loads(
     (Path(__file__).parents[3] / "test-fixtures" / "paid-call-policy.json").read_text(encoding="utf-8")
 )
@@ -97,6 +100,81 @@ async def test_paid_call_does_not_replay_unauthorized_response() -> None:
 
     assert len(requests) == PAID_CALL_POLICY["paid_call"]["expected_http_attempts"]
     assert exc_info.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_api_error_redacts_json_escaped_credential_echo() -> None:
+    escaped_credential = 'synthetic-"quoted\\credential-273'
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={
+                "message": f"Rejected {escaped_credential}",
+                escaped_credential: "credential used as an object key",
+            },
+        )
+
+    client = QverisClient(
+        QverisConfig(api_key=escaped_credential),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(QverisApiError) as exc_info:
+            await client.call("paid-tool", {})
+    finally:
+        await client.close()
+
+    error = exc_info.value
+    assert escaped_credential not in str(error)
+    assert escaped_credential not in repr(error.details)
+    assert "***" in str(error)
+
+
+@pytest.mark.asyncio
+async def test_paid_call_does_not_follow_redirects_from_injected_client() -> None:
+    requests: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/redirected"):
+            return httpx.Response(200, json=call_success())
+        return httpx.Response(
+            307,
+            headers={
+                "location": SYNTHETIC_SIGNED_URL,
+                "set-cookie": f"session={SYNTHETIC_COOKIE}",
+            },
+            json={"message": "redirect"},
+        )
+
+    shared = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        follow_redirects=True,
+        headers={
+            "cookie": f"session={SYNTHETIC_COOKIE}",
+            "x-api-key": SYNTHETIC_TOKEN,
+        },
+    )
+    client = QverisClient(QverisConfig(api_key=SYNTHETIC_TOKEN), http_client=shared)
+    try:
+        with pytest.raises(QverisApiError) as exc_info:
+            await client.call("paid-tool", {})
+    finally:
+        await client.close()
+        await shared.aclose()
+
+    assert PAID_CALL_POLICY["paid_call"]["allow_redirect_replay"] is False
+    assert len(requests) == PAID_CALL_POLICY["paid_call"]["expected_http_attempts"]
+    assert exc_info.value.status == 307
+    traceback = exc_info.value.__traceback__
+    while traceback is not None:
+        for value in traceback.tb_frame.f_locals.values():
+            rendered = repr(value)
+            assert SYNTHETIC_TOKEN not in rendered
+            assert SYNTHETIC_COOKIE not in rendered
+            assert SYNTHETIC_SIGNED_URL not in rendered
+        traceback = traceback.tb_next
 
 
 @pytest.mark.asyncio
@@ -222,6 +300,76 @@ async def test_paid_call_cancellation_preserves_cancellation_without_replay() ->
     assert transport.attempts == PAID_CALL_POLICY["paid_call"]["expected_http_attempts"]
     assert exc_info.value.__cause__ is None
     assert SYNTHETIC_TOKEN not in repr(exc_info.value.__context__)
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_cannot_leak_active_request_lifecycle() -> None:
+    started = asyncio.Event()
+
+    class BlockingTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, _request: httpx.Request) -> httpx.Response:
+            started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    client = QverisClient(QverisConfig(api_key=SYNTHETIC_TOKEN), transport=BlockingTransport())
+    request_task = asyncio.create_task(client.call("paid-tool", {}))
+    await started.wait()
+
+    await client._lifecycle_lock.acquire()
+    request_task.cancel()
+    await asyncio.sleep(0)
+    request_task.cancel()
+    client._lifecycle_lock.release()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    await asyncio.wait_for(client._no_active_requests.wait(), timeout=1)
+    assert client._active_requests == 0
+    await client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_kind", ["invalid_json", "invalid_schema"])
+async def test_contract_errors_drop_raw_response_exception_context_and_secret_locals(failure_kind: str) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        if failure_kind == "invalid_json":
+            return httpx.Response(
+                200,
+                text=f"{SYNTHETIC_TOKEN} {SYNTHETIC_SIGNED_URL}",
+                headers={"content-type": "application/json"},
+            )
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "result": {"full_content_file_url": SYNTHETIC_SIGNED_URL},
+                "credential_echo": SYNTHETIC_TOKEN,
+            },
+        )
+
+    client = make_client(handler)
+    try:
+        with pytest.raises(QverisContractError) as exc_info:
+            await client.call("paid-tool", {})
+    finally:
+        await client.close()
+
+    error = exc_info.value
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert not hasattr(error, "request")
+    assert not hasattr(error, "response")
+    assert SYNTHETIC_TOKEN not in repr(error)
+    assert SYNTHETIC_SIGNED_URL not in repr(error)
+
+    traceback = error.__traceback__
+    while traceback is not None:
+        for value in traceback.tb_frame.f_locals.values():
+            rendered = repr(value)
+            assert SYNTHETIC_TOKEN not in rendered
+            assert SYNTHETIC_SIGNED_URL not in rendered
+        traceback = traceback.tb_next
 
 
 @pytest.mark.asyncio
@@ -490,6 +638,9 @@ async def test_cancelling_owned_transport_close_finishes_close_and_keeps_state_c
     close_task.cancel()
     await asyncio.sleep(0)
     assert not close_task.done()
+    close_task.cancel()
+    await asyncio.sleep(0)
+    assert not close_task.done()
 
     release_close.set()
     with pytest.raises(asyncio.CancelledError):
@@ -538,9 +689,11 @@ def test_signed_url_is_serialized_but_excluded_from_repr() -> None:
         execution_id="exec-1",
         success=True,
         result={"full_content_file_url": signed_url},
+        parameters={"download_url": signed_url},
     )
 
     assert truncated.model_dump()["full_content_file_url"] == signed_url
     assert signed_url not in repr(truncated)
     assert response.model_dump()["result"]["full_content_file_url"] == signed_url
+    assert response.model_dump()["parameters"]["download_url"] == signed_url
     assert signed_url not in repr(response)

--- a/test-fixtures/paid-call-policy.json
+++ b/test-fixtures/paid-call-policy.json
@@ -2,6 +2,7 @@
   "paid_call": {
     "automatic_retry_statuses": [],
     "allow_auth_replay": false,
+    "allow_redirect_replay": false,
     "optional_field_fallback": "never",
     "expected_http_attempts": 1
   },


### PR DESCRIPTION
## Summary

Follow-up to #275. This closes safety gaps found during a deep review of the paid-call implementation.

- prevent paid POST replay through redirects in the JS SDK, MCP server, and Python SDK, including injected Python clients configured to follow redirects
- normalize Python non-2xx and successful-response decoding failures into typed, credential-safe public errors
- redact exact credentials across raw and JSON-escaped forms, object keys, request/response headers, reason phrases, signed redirect URLs, and cookies
- make Python request accounting and owned transport shutdown safe under repeated cancellation
- keep echoed tool parameters out of response `repr` while preserving serialization
- add shared policy coverage, regression tests, changelog entries, and aligned English/Chinese documentation

## Root cause

Native `fetch` follows redirects unless explicitly disabled, and an injected `httpx.AsyncClient` can enable redirects globally. Successful Python response decoding also bypassed the SDK's safe contract-error boundary. Existing byte replacement did not cover JSON-escaped credentials or response metadata, while a second cancellation could interrupt lifecycle cleanup.

## Impact

Paid calls now remain single-submit across redirect, status, auth, projection, and cancellation paths. Public exceptions and tracebacks no longer expose raw request/response credentials or signed redirect data, and client shutdown cannot leak lifecycle accounting under repeated cancellation.

## Validation

- `npm test`: CLI 134, MCP 181, JS SDK 67, OpenClaw 78, Python 183 passed / 1 skipped, release 36
- `npm run build`
- `npm run typecheck`
- JS/MCP/CLI lint and Python Ruff checks
- generated JS/Python API docs drift check
- documentation locale consistency and website staging tests
- public documentation region-boundary scans

Refs #273
