### PR TITLE
fix(openclaw): restore contract-driven tool registration

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -269,6 +269,19 @@ jobs:
         run: npm run check:pack
         env:
           NPM_CONFIG_OFFLINE: "true"
+      - name: Verify runtime contract with locked latest stable OpenClaw
+        run: npm run check:runtime
+      - name: Verify packed-package installation with latest stable OpenClaw
+        if: runner.os == 'Linux'
+        run: npm run check:runtime:packed
+      - name: Verify minimum and extended-stable OpenClaw compatibility
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          for version in 2026.6.11 2026.6.33; do
+            npm install --no-save --package-lock=false "openclaw@${version}"
+            npm run check:runtime
+          done
 
   lint:
     needs: plan

--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -57,6 +57,9 @@ jobs:
         env:
           NPM_CONFIG_OFFLINE: "true"
 
+      - name: Verify packed plugin with the latest stable OpenClaw runtime
+        run: npm run check:runtime:packed
+
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
@@ -75,9 +78,10 @@ jobs:
 
             ## Highlights
 
-            - Publishes compiled JavaScript runtime files under `dist/`.
-            - Points `openclaw.extensions` at `./dist/index.js` for current OpenClaw package-install compatibility.
-            - Keeps TypeScript source in the package for inspection, but no longer depends on TypeScript runtime loading.
+            - Declares `qveris_discover`, `qveris_call`, and `qveris_inspect` in `contracts.tools`.
+            - Adds explicit startup activation and API-key availability metadata for current OpenClaw hosts.
+            - Marks read-only Discover/Inspect replay-safe while keeping paid Call replay-unsafe.
+            - Verifies source and packed-package registration against supported OpenClaw runtimes.
 
             See [README](packages/openclaw-qveris-plugin/README.md) for usage.
           generate_release_notes: true

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -11,11 +11,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 ### Fixed
 
 - Declared all three runtime tools in `contracts.tools`, restoring tool registration on OpenClaw `>=2026.6.11`. The manifest now also declares explicit startup activation, API-key availability signals, and replay safety for read-only Discover/Inspect while keeping paid Call replay-unsafe. ([#272])
-- Added source, compiled-runtime, packed-package, and minimum/extended/latest OpenClaw compatibility checks so manifest and runtime tool names cannot drift silently.
+- Added source, compiled-factory, packed-package provenance, and minimum/extended/latest OpenClaw compatibility checks so public tool names, credential gating, and manifest/runtime registration cannot drift silently.
 
 ### Changed
 
-- Aligned the full-toolkit development and CI Node.js pin with the `22.22.3` minimum required by the tested OpenClaw `2026.7.1` development dependency. The published plugin's existing runtime compatibility floor is unchanged.
+- Aligned the full-toolkit development and CI Node.js pin with the `22.22.3` minimum required by the tested OpenClaw `2026.7.1-2` development dependency. The published plugin's existing runtime compatibility floor is unchanged.
 
 ## [2026.7.15] - 2026-07-15
 

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,6 +6,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+## [2026.7.30] - 2026-07-30
+
+### Fixed
+
+- Declared all three runtime tools in `contracts.tools`, restoring tool registration on OpenClaw `>=2026.6.11`. The manifest now also declares explicit startup activation, API-key availability signals, and replay safety for read-only Discover/Inspect while keeping paid Call replay-unsafe. ([#272])
+- Added source, compiled-runtime, packed-package, and minimum/extended/latest OpenClaw compatibility checks so manifest and runtime tool names cannot drift silently.
+
 ### Changed
 
 - Aligned the full-toolkit development and CI Node.js pin with the `22.22.3` minimum required by the tested OpenClaw `2026.7.1` development dependency. The published plugin's existing runtime compatibility floor is unchanged.
@@ -36,7 +43,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 - First published build with compiled `dist/` output. ([#90])
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.15...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.30...HEAD
+[2026.7.30]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.15...qveris-plugin-v2026.7.30
 [2026.7.15]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.6.4...qveris-plugin-v2026.7.15
 [2026.6.4]: https://github.com/QVerisAI/qveris-agent-toolkit/releases/tag/qveris-plugin-v2026.6.4
 [#206]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/206
@@ -45,3 +53,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 [#152]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/152
 [#104]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/104
 [#90]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/90
+[#272]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/272

--- a/packages/openclaw-qveris-plugin/README.md
+++ b/packages/openclaw-qveris-plugin/README.md
@@ -19,9 +19,14 @@ Three tools are registered into the agent's context once the plugin is loaded:
 
 The typical agent workflow is: `qveris_discover` → `qveris_inspect` (optional) → `qveris_call`.
 
+The native plugin manifest declares the same three names in `contracts.tools`, so current OpenClaw hosts can
+attribute and load the owning plugin before importing its runtime. Discover and Inspect are declared replay-safe;
+the paid Call tool is deliberately replay-unsafe.
+
 ## Requirements
 
-- Node.js >= 22.19.0
+- Node.js >= 22.22.3 for the current stable OpenClaw host; the plugin package itself retains its Node.js >=
+  22.19.0 compatibility floor for older supported hosts
 - OpenClaw >= 2026.6.11
 - A QVeris API key — sign up at [qveris.ai](https://qveris.ai)
 
@@ -52,7 +57,12 @@ Before publishing, verify the package contents:
 npm run build
 npm pack --dry-run --json
 npm run check:pack
+npm run check:runtime
+npm run check:runtime:packed
 ```
+
+The runtime checks use an isolated OpenClaw state directory and a synthetic key. They do not call the QVeris API.
+CI runs the same contract against the minimum supported host, the extended-stable host, and the latest stable host.
 
 Real network integration tests must live under `integration/` and are disabled by default:
 
@@ -193,16 +203,20 @@ After restarting the gateway, verify the plugin is loaded and tools are register
 # Restart gateway
 openclaw gateway restart
 
-# Inspect plugin
-openclaw plugins inspect qveris
+# Inspect the loaded runtime, registered tools, and diagnostics
+openclaw plugins inspect qveris --runtime --json
 ```
 
-Expected output should include:
+Expected JSON should include:
 
-```
-Status: loaded
-Tools:
-qveris_discover, qveris_call, qveris_inspect
+```json
+{
+  "plugin": {
+    "status": "loaded",
+    "toolNames": ["qveris_discover", "qveris_call", "qveris_inspect"]
+  },
+  "diagnostics": []
+}
 ```
 
 ---
@@ -215,7 +229,14 @@ Make sure `tools.alsoAllow: ["qveris"]` is set. Without this, plugin tools are e
 
 ### Plugin loaded but tools missing from `plugins inspect`
 
-The API key is not configured. Check:
+First inspect the runtime:
+
+```bash
+openclaw plugins inspect qveris --runtime --json
+```
+
+If diagnostics report that `contracts.tools` is missing, upgrade `@qverisai/qveris` to `2026.7.30` or later and
+restart the Gateway. If the manifest contract is present but the instantiated tools are empty, check the API key:
 
 ```bash
 openclaw config get plugins.entries.qveris

--- a/packages/openclaw-qveris-plugin/README.md
+++ b/packages/openclaw-qveris-plugin/README.md
@@ -61,8 +61,10 @@ npm run check:runtime
 npm run check:runtime:packed
 ```
 
-The runtime checks use an isolated OpenClaw state directory and a synthetic key. They do not call the QVeris API.
-CI runs the same contract against the minimum supported host, the extended-stable host, and the latest stable host.
+The package check instantiates the compiled factory with config, environment, and missing-credential cases. The
+runtime checks separately validate OpenClaw's registration contract and installed-package provenance in an isolated
+state directory. All checks use synthetic credentials and do not call the QVeris API. CI runs the host contract
+against the minimum supported host, the extended-stable host, and the latest stable host.
 
 Real network integration tests must live under `integration/` and are disabled by default:
 
@@ -219,6 +221,9 @@ Expected JSON should include:
 }
 ```
 
+`plugin.toolNames` and `tools[].names` describe the runtime registration contract; they do not prove that the
+credential-gated factory returned concrete tools for a particular agent turn.
+
 ---
 
 ## Troubleshooting
@@ -236,7 +241,7 @@ openclaw plugins inspect qveris --runtime --json
 ```
 
 If diagnostics report that `contracts.tools` is missing, upgrade `@qverisai/qveris` to `2026.7.30` or later and
-restart the Gateway. If the manifest contract is present but the instantiated tools are empty, check the API key:
+restart the Gateway. If the registration is present but the agent does not receive the tools, check the API key:
 
 ```bash
 openclaw config get plugins.entries.qveris

--- a/packages/openclaw-qveris-plugin/index.ts
+++ b/packages/openclaw-qveris-plugin/index.ts
@@ -2,13 +2,15 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
 import { createQverisTools } from "./src/qveris-tools.js";
 
+export const QVERIS_TOOL_NAMES = ["qveris_discover", "qveris_call", "qveris_inspect"] as const;
+
 export default definePluginEntry({
   id: "qveris",
   name: "QVeris Plugin",
   description: "QVeris capability discovery, tool inspection, and tool calling",
   register(api: OpenClawPluginApi) {
     api.registerTool((ctx) => createQverisTools({ api, ctx }), {
-      names: ["qveris_discover", "qveris_call", "qveris_inspect"],
+      names: [...QVERIS_TOOL_NAMES],
     });
   },
 });

--- a/packages/openclaw-qveris-plugin/openclaw.plugin.json
+++ b/packages/openclaw-qveris-plugin/openclaw.plugin.json
@@ -1,5 +1,8 @@
 {
   "id": "qveris",
+  "name": "QVeris Plugin",
+  "description": "QVeris capability discovery, tool inspection, and tool calling",
+  "version": "2026.7.30",
   "setup": {
     "providers": [
       {
@@ -9,6 +12,43 @@
       }
     ],
     "requiresRuntime": false
+  },
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": ["qveris_discover", "qveris_call", "qveris_inspect"]
+  },
+  "toolMetadata": {
+    "qveris_discover": {
+      "authSignals": [{ "provider": "qveris" }],
+      "configSignals": [
+        {
+          "rootPath": "plugins.entries.qveris.config",
+          "required": ["apiKey"]
+        }
+      ],
+      "replaySafe": true
+    },
+    "qveris_call": {
+      "authSignals": [{ "provider": "qveris" }],
+      "configSignals": [
+        {
+          "rootPath": "plugins.entries.qveris.config",
+          "required": ["apiKey"]
+        }
+      ]
+    },
+    "qveris_inspect": {
+      "authSignals": [{ "provider": "qveris" }],
+      "configSignals": [
+        {
+          "rootPath": "plugins.entries.qveris.config",
+          "required": ["apiKey"]
+        }
+      ],
+      "replaySafe": true
+    }
   },
   "uiHints": {
     "apiKey": {

--- a/packages/openclaw-qveris-plugin/openclaw.plugin.json
+++ b/packages/openclaw-qveris-plugin/openclaw.plugin.json
@@ -37,7 +37,8 @@
           "rootPath": "plugins.entries.qveris.config",
           "required": ["apiKey"]
         }
-      ]
+      ],
+      "replaySafe": false
     },
     "qveris_inspect": {
       "authSignals": [{ "provider": "qveris" }],

--- a/packages/openclaw-qveris-plugin/package-lock.json
+++ b/packages/openclaw-qveris-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.7.15",
+  "version": "2026.7.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/qveris",
-      "version": "2026.7.15",
+      "version": "2026.7.30",
       "dependencies": {
         "@sinclair/typebox": "0.34.52"
       },
@@ -17,7 +17,7 @@
         "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.7.0",
-        "openclaw": "2026.7.1",
+        "openclaw": "2026.7.1-2",
         "prettier": "^3.9.5",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.63.0",
@@ -2612,9 +2612,9 @@
       "license": "MIT"
     },
     "node_modules/openclaw": {
-      "version": "2026.7.1",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1.tgz",
-      "integrity": "sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==",
+      "version": "2026.7.1-2",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1-2.tgz",
+      "integrity": "sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
@@ -2633,7 +2633,7 @@
         "@mistralai/mistralai": "2.4.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",
-        "@openclaw/ai": "2026.7.1",
+        "@openclaw/ai": "2026.7.1-2",
         "@openclaw/fs-safe": "0.4.1",
         "@openclaw/proxyline": "0.3.3",
         "@silvia-odwyer/photon-node": "0.3.4",
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/openclaw/node_modules/@openclaw/ai": {
-      "version": "2026.7.1",
-      "resolved": "https://registry.npmjs.org/@openclaw/ai/-/ai-2026.7.1.tgz",
-      "integrity": "sha512-FsKy5DXSHf4qyN8Huoz/10HZRgoEwLF4uk8UWaCafaIler+q5Fsl51HcrIqIrEe0S38OT7LOaxnR++MOshAlmw==",
+      "version": "2026.7.1-2",
+      "resolved": "https://registry.npmjs.org/@openclaw/ai/-/ai-2026.7.1-2.tgz",
+      "integrity": "sha512-st+NH0cxlQqdbEur//yYqM7WlYBjeEBnop3cztJTSCONKjv6LNoGguI9cH65asZG94FdM/39z857isRGPnZvEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.7.15",
+  "version": "2026.7.30",
   "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
   "repository": {
     "type": "git",
@@ -32,6 +32,8 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "check:pack": "node scripts/check-pack.mjs",
+    "check:runtime": "npm run build && node scripts/check-openclaw-runtime.mjs",
+    "check:runtime:packed": "npm run build && node scripts/check-openclaw-runtime.mjs --pack",
     "prepack": "npm run build",
     "test:integration": "node scripts/run-integration-tests.mjs",
     "test": "vitest run",
@@ -50,7 +52,7 @@
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.7.0",
-    "openclaw": "2026.7.1",
+    "openclaw": "2026.7.1-2",
     "prettier": "^3.9.5",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.63.0",

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-runtime.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-runtime.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,20 +7,15 @@ import { fileURLToPath } from "node:url";
 const packageRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const packageJson = readJson(path.join(packageRoot, "package.json"));
 const manifest = readJson(path.join(packageRoot, "openclaw.plugin.json"));
+const requiredToolNames = ["qveris_discover", "qveris_call", "qveris_inspect"];
 const expectedToolNames = [...(manifest.contracts?.tools ?? [])];
 const args = process.argv.slice(2);
 const pack = takeFlag(args, "--pack");
-const installSpec = takeOption(args, "--install-spec");
 
 if (args.length > 0) {
   fail(`Unknown arguments: ${args.join(" ")}`);
 }
-if (pack && installSpec) {
-  fail("--pack and --install-spec are mutually exclusive");
-}
-if (expectedToolNames.length === 0) {
-  fail("openclaw.plugin.json must declare contracts.tools before runtime validation");
-}
+assertArrayEqual(expectedToolNames, requiredToolNames, "manifest public tool contract");
 
 const openclawPackagePath = path.join(packageRoot, "node_modules", "openclaw", "package.json");
 const openclawPackage = readJson(openclawPackagePath);
@@ -40,13 +35,10 @@ const env = {
 delete env.QVERIS_BASE_URL;
 
 try {
-  let spec = installSpec;
-  if (pack) {
-    spec = createPackageTarball(stateDir);
-  }
+  const spec = pack ? createPackageTarball(stateDir) : undefined;
 
   if (spec) {
-    runOpenClaw(["plugins", "install", spec, "--pin"]);
+    runOpenClaw(["plugins", "install", spec, "--pin"], { timeoutMs: 300_000 });
   } else {
     writeFileSync(
       configPath,
@@ -68,7 +60,8 @@ try {
 
   const inspection = JSON.parse(runOpenClaw(["plugins", "inspect", manifest.id, "--runtime", "--json"]));
   const registeredToolNames = [...(inspection.plugin?.toolNames ?? [])].sort();
-  const instantiatedToolNames = [...(inspection.tools ?? [])]
+  // OpenClaw reports factory registration groups here, not credential-gated concrete tool instances.
+  const registrationGroupNames = [...(inspection.tools ?? [])]
     .flatMap((tool) => (Array.isArray(tool.names) ? tool.names : [tool.name]))
     .filter((name) => typeof name === "string")
     .sort();
@@ -77,8 +70,19 @@ try {
 
   assertEqual(inspection.plugin?.id, manifest.id, "runtime plugin id");
   assertEqual(inspection.plugin?.status, "loaded", "runtime plugin status");
+  assertEqual(inspection.plugin?.version, packageJson.version, "runtime plugin version");
   assertArrayEqual(registeredToolNames, expected, "registered tool names");
-  assertArrayEqual(instantiatedToolNames, expected, "instantiated tool names");
+  assertArrayEqual(registrationGroupNames, expected, "runtime registration-group names");
+  assertArrayEqual(
+    [...(inspection.plugin?.contracts?.tools ?? [])],
+    expectedToolNames,
+    "runtime manifest tool contract",
+  );
+  if (spec) {
+    assertPathWithin(inspection.plugin?.rootDir, stateDir, "installed plugin root");
+  } else {
+    assertSamePath(inspection.plugin?.rootDir, packageRoot, "source plugin root");
+  }
   if (errorDiagnostics.length > 0) {
     fail(`OpenClaw reported runtime diagnostics:\n${JSON.stringify(errorDiagnostics, null, 2)}`);
   }
@@ -100,6 +104,7 @@ function createPackageTarball(destination) {
     cwd: packageRoot,
     encoding: "utf8",
     env,
+    maxBuffer: 10 * 1024 * 1024,
     timeout: 120_000,
   });
   if (result.status !== 0) {
@@ -112,12 +117,13 @@ function createPackageTarball(destination) {
   return path.join(destination, packed.filename);
 }
 
-function runOpenClaw(openclawArgs) {
+function runOpenClaw(openclawArgs, options = {}) {
   const result = spawnSync(process.execPath, [openclawBin, ...openclawArgs], {
-    cwd: packageRoot,
+    cwd: stateDir,
     encoding: "utf8",
     env,
-    timeout: 120_000,
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: options.timeoutMs ?? 120_000,
   });
   if (result.status !== 0) {
     fail(`openclaw ${openclawArgs.join(" ")} failed (${result.status ?? "signal"}):\n${formatProcessOutput(result)}`);
@@ -126,7 +132,7 @@ function runOpenClaw(openclawArgs) {
 }
 
 function formatProcessOutput(result) {
-  return [result.stdout, result.stderr]
+  return [result.stdout, result.stderr, result.error?.stack ?? result.error?.message]
     .map((output) => output?.trim())
     .filter(Boolean)
     .join("\n");
@@ -151,17 +157,6 @@ function takeFlag(argv, name) {
   return true;
 }
 
-function takeOption(argv, name) {
-  const index = argv.indexOf(name);
-  if (index === -1) return undefined;
-  const value = argv[index + 1];
-  if (!value || value.startsWith("--")) {
-    fail(`${name} requires a value`);
-  }
-  argv.splice(index, 2);
-  return value;
-}
-
 function assertEqual(actual, expected, label) {
   if (actual !== expected) {
     fail(`${label} mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
@@ -171,6 +166,34 @@ function assertEqual(actual, expected, label) {
 function assertArrayEqual(actual, expected, label) {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     fail(`${label} mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertSamePath(actual, expected, label) {
+  const actualPath = resolveRealPath(actual, label);
+  const expectedPath = resolveRealPath(expected, `${label} expectation`);
+  if (actualPath !== expectedPath) {
+    fail(`${label} mismatch: expected ${JSON.stringify(expectedPath)}, received ${JSON.stringify(actualPath)}`);
+  }
+}
+
+function assertPathWithin(actual, expectedParent, label) {
+  const actualPath = resolveRealPath(actual, label);
+  const parentPath = resolveRealPath(expectedParent, `${label} parent`);
+  const relative = path.relative(parentPath, actualPath);
+  if (relative === "" || relative.startsWith(`..${path.sep}`) || relative === ".." || path.isAbsolute(relative)) {
+    fail(`${label} must be inside ${JSON.stringify(parentPath)}, received ${JSON.stringify(actualPath)}`);
+  }
+}
+
+function resolveRealPath(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${label} must be a non-empty path`);
+  }
+  try {
+    return realpathSync(value);
+  } catch (error) {
+    fail(`${label} cannot be resolved: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-runtime.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-runtime.mjs
@@ -1,0 +1,179 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const packageJson = readJson(path.join(packageRoot, "package.json"));
+const manifest = readJson(path.join(packageRoot, "openclaw.plugin.json"));
+const expectedToolNames = [...(manifest.contracts?.tools ?? [])];
+const args = process.argv.slice(2);
+const pack = takeFlag(args, "--pack");
+const installSpec = takeOption(args, "--install-spec");
+
+if (args.length > 0) {
+  fail(`Unknown arguments: ${args.join(" ")}`);
+}
+if (pack && installSpec) {
+  fail("--pack and --install-spec are mutually exclusive");
+}
+if (expectedToolNames.length === 0) {
+  fail("openclaw.plugin.json must declare contracts.tools before runtime validation");
+}
+
+const openclawPackagePath = path.join(packageRoot, "node_modules", "openclaw", "package.json");
+const openclawPackage = readJson(openclawPackagePath);
+const openclawBin = resolveOpenClawBin(openclawPackagePath, openclawPackage.bin);
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "qveris-openclaw-runtime-"));
+const homeDir = path.join(stateDir, "home");
+const configPath = path.join(stateDir, "openclaw.json");
+const env = {
+  ...process.env,
+  HOME: homeDir,
+  USERPROFILE: homeDir,
+  OPENCLAW_HOME: homeDir,
+  OPENCLAW_STATE_DIR: stateDir,
+  OPENCLAW_CONFIG_PATH: configPath,
+  QVERIS_API_KEY: "synthetic-openclaw-runtime-contract-key",
+};
+delete env.QVERIS_BASE_URL;
+
+try {
+  let spec = installSpec;
+  if (pack) {
+    spec = createPackageTarball(stateDir);
+  }
+
+  if (spec) {
+    runOpenClaw(["plugins", "install", spec, "--pin"]);
+  } else {
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          plugins: {
+            allow: [manifest.id],
+            load: { paths: [packageRoot] },
+            entries: { [manifest.id]: { enabled: true } },
+          },
+          tools: { alsoAllow: [manifest.id] },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  }
+
+  const inspection = JSON.parse(runOpenClaw(["plugins", "inspect", manifest.id, "--runtime", "--json"]));
+  const registeredToolNames = [...(inspection.plugin?.toolNames ?? [])].sort();
+  const instantiatedToolNames = [...(inspection.tools ?? [])]
+    .flatMap((tool) => (Array.isArray(tool.names) ? tool.names : [tool.name]))
+    .filter((name) => typeof name === "string")
+    .sort();
+  const expected = [...expectedToolNames].sort();
+  const errorDiagnostics = [...(inspection.diagnostics ?? [])].filter((diagnostic) => diagnostic.level === "error");
+
+  assertEqual(inspection.plugin?.id, manifest.id, "runtime plugin id");
+  assertEqual(inspection.plugin?.status, "loaded", "runtime plugin status");
+  assertArrayEqual(registeredToolNames, expected, "registered tool names");
+  assertArrayEqual(instantiatedToolNames, expected, "instantiated tool names");
+  if (errorDiagnostics.length > 0) {
+    fail(`OpenClaw reported runtime diagnostics:\n${JSON.stringify(errorDiagnostics, null, 2)}`);
+  }
+
+  console.log(
+    `OpenClaw runtime contract OK: host ${openclawPackage.version}, plugin ${packageJson.version}, tools ${expected.join(", ")}`,
+  );
+} finally {
+  if (process.env.QVERIS_KEEP_OPENCLAW_RUNTIME_STATE !== "1") {
+    rmSync(stateDir, { recursive: true, force: true });
+  } else {
+    console.log(`Preserved OpenClaw runtime state: ${stateDir}`);
+  }
+}
+
+function createPackageTarball(destination) {
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  const result = spawnSync(npm, ["pack", "--json", "--pack-destination", destination], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env,
+    timeout: 120_000,
+  });
+  if (result.status !== 0) {
+    fail(`npm pack failed (${result.status ?? "signal"}):\n${formatProcessOutput(result)}`);
+  }
+  const [packed] = JSON.parse(result.stdout);
+  if (!packed?.filename) {
+    fail(`npm pack did not report a filename:\n${result.stdout}`);
+  }
+  return path.join(destination, packed.filename);
+}
+
+function runOpenClaw(openclawArgs) {
+  const result = spawnSync(process.execPath, [openclawBin, ...openclawArgs], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env,
+    timeout: 120_000,
+  });
+  if (result.status !== 0) {
+    fail(`openclaw ${openclawArgs.join(" ")} failed (${result.status ?? "signal"}):\n${formatProcessOutput(result)}`);
+  }
+  return result.stdout.trim();
+}
+
+function formatProcessOutput(result) {
+  return [result.stdout, result.stderr]
+    .map((output) => output?.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function resolveOpenClawBin(packagePath, bin) {
+  const relativeBin = typeof bin === "string" ? bin : bin?.openclaw;
+  if (typeof relativeBin !== "string" || relativeBin.length === 0) {
+    fail("Installed openclaw package does not declare an openclaw executable");
+  }
+  return path.resolve(path.dirname(packagePath), relativeBin);
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function takeFlag(argv, name) {
+  const index = argv.indexOf(name);
+  if (index === -1) return false;
+  argv.splice(index, 1);
+  return true;
+}
+
+function takeOption(argv, name) {
+  const index = argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    fail(`${name} requires a value`);
+  }
+  argv.splice(index, 2);
+  return value;
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    fail(`${label} mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertArrayEqual(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
+  }
+}
+
+function fail(message) {
+  throw new Error(message);
+}

--- a/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
@@ -1,9 +1,28 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { isDeepStrictEqual } from "node:util";
 
 const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const pluginManifest = JSON.parse(readFileSync("openclaw.plugin.json", "utf8"));
 const expectedRepositoryUrl = "https://github.com/QVerisAI/qveris-agent-toolkit";
+const minimumOpenClawVersion = "2026.6.11";
+const minimumOpenClawRange = `>=${minimumOpenClawVersion}`;
+const requiredToolNames = ["qveris_discover", "qveris_call", "qveris_inspect"];
+const expectedToolMetadata = Object.fromEntries(
+  requiredToolNames.map((toolName) => [
+    toolName,
+    {
+      authSignals: [{ provider: "qveris" }],
+      configSignals: [
+        {
+          rootPath: "plugins.entries.qveris.config",
+          required: ["apiKey"],
+        },
+      ],
+      replaySafe: toolName !== "qveris_call",
+    },
+  ]),
+);
 if (packageJson.repository?.url !== expectedRepositoryUrl) {
   fail("package.json repository.url must match the public provenance repository:", [
     `expected: ${expectedRepositoryUrl}`,
@@ -16,6 +35,33 @@ if (!Array.isArray(extensions) || !extensions.includes("./dist/index.js")) {
 }
 if (extensions.some((entry) => typeof entry === "string" && /\.tsx?$/.test(entry))) {
   fail("package.json openclaw.extensions must not point at TypeScript source entries for npm packages:", extensions);
+}
+const openclawCompatibilityValues = {
+  "peerDependencies.openclaw": packageJson.peerDependencies?.openclaw,
+  "openclaw.compat.pluginApi": packageJson.openclaw?.compat?.pluginApi,
+  "openclaw.build.openclawVersion": packageJson.openclaw?.build?.openclawVersion,
+  "openclaw.build.pluginSdkVersion": packageJson.openclaw?.build?.pluginSdkVersion,
+  "openclaw.install.minHostVersion": packageJson.openclaw?.install?.minHostVersion,
+};
+const expectedOpenClawCompatibilityValues = {
+  "peerDependencies.openclaw": minimumOpenClawRange,
+  "openclaw.compat.pluginApi": minimumOpenClawRange,
+  "openclaw.build.openclawVersion": minimumOpenClawVersion,
+  "openclaw.build.pluginSdkVersion": minimumOpenClawVersion,
+  "openclaw.install.minHostVersion": minimumOpenClawRange,
+};
+const invalidCompatibilityValues = Object.entries(openclawCompatibilityValues).filter(
+  ([key, value]) => value !== expectedOpenClawCompatibilityValues[key],
+);
+if (invalidCompatibilityValues.length > 0) {
+  fail("OpenClaw compatibility metadata must keep the verified minimum host aligned:", [
+    `expected exact version ${minimumOpenClawVersion} for build metadata`,
+    `expected range ${minimumOpenClawRange} for peer, compat, and install metadata`,
+    ...invalidCompatibilityValues.map(
+      ([key, value]) =>
+        `${key}: expected ${JSON.stringify(expectedOpenClawCompatibilityValues[key])}, received ${JSON.stringify(value)}`,
+    ),
+  ]);
 }
 
 const requiredFiles = new Set([
@@ -68,11 +114,13 @@ execFileSync("npm", ["run", "build"], { stdio: "inherit", shell });
 const runtimeModule = await import(new URL("../dist/index.js", import.meta.url));
 const runtimePlugin = runtimeModule.default;
 const registrations = [];
-runtimePlugin.register({
-  registerTool(_factory, options) {
-    registrations.push(options);
+const runtimeApi = {
+  pluginConfig: { apiKey: "synthetic-compiled-contract-key" },
+  registerTool(factory, options) {
+    registrations.push({ factory, options });
   },
-});
+};
+runtimePlugin.register(runtimeApi);
 
 if (pluginManifest.id !== runtimePlugin.id) {
   fail("openclaw.plugin.json id must match the compiled runtime plugin id:", [
@@ -95,12 +143,22 @@ if (pluginManifest.version !== packageJson.version) {
 if (pluginManifest.activation?.onStartup !== true) {
   fail("openclaw.plugin.json must explicitly activate this required-tool plugin at Gateway startup");
 }
-if (registrations.length !== 1 || !Array.isArray(registrations[0]?.names)) {
+if (
+  registrations.length !== 1 ||
+  typeof registrations[0]?.factory !== "function" ||
+  !Array.isArray(registrations[0]?.options?.names)
+) {
   fail("Compiled runtime must make exactly one named tool-factory registration");
 }
 
 const declaredToolNames = pluginManifest.contracts?.tools;
-const registeredToolNames = registrations[0]?.names;
+const registeredToolNames = registrations[0]?.options?.names;
+if (JSON.stringify(declaredToolNames) !== JSON.stringify(requiredToolNames)) {
+  fail("openclaw.plugin.json contracts.tools must preserve the public QVeris tool contract:", [
+    `expected: ${JSON.stringify(requiredToolNames)}`,
+    `manifest: ${JSON.stringify(declaredToolNames)}`,
+  ]);
+}
 if (!Array.isArray(declaredToolNames) || JSON.stringify(declaredToolNames) !== JSON.stringify(registeredToolNames)) {
   fail("openclaw.plugin.json contracts.tools must exactly match the compiled runtime registration:", [
     `manifest: ${JSON.stringify(declaredToolNames)}`,
@@ -111,33 +169,40 @@ if (new Set(declaredToolNames).size !== declaredToolNames.length) {
   fail("openclaw.plugin.json contracts.tools must not contain duplicate names");
 }
 
-const metadataToolNames = Object.keys(pluginManifest.toolMetadata ?? {}).sort();
-if (JSON.stringify(metadataToolNames) !== JSON.stringify([...declaredToolNames].sort())) {
-  fail("openclaw.plugin.json toolMetadata must cover exactly the declared tools:", [
-    `contracts.tools: ${JSON.stringify([...declaredToolNames].sort())}`,
-    `toolMetadata: ${JSON.stringify(metadataToolNames)}`,
+if (!isDeepStrictEqual(pluginManifest.toolMetadata, expectedToolMetadata)) {
+  fail("openclaw.plugin.json toolMetadata must preserve exact availability and replay semantics:", [
+    `expected: ${JSON.stringify(expectedToolMetadata)}`,
+    `manifest: ${JSON.stringify(pluginManifest.toolMetadata)}`,
   ]);
 }
-for (const toolName of declaredToolNames) {
-  const metadata = pluginManifest.toolMetadata[toolName];
-  const hasQverisAuthSignal = metadata.authSignals?.some((signal) => signal?.provider === "qveris");
-  const hasQverisConfigSignal = metadata.configSignals?.some(
-    (signal) =>
-      signal?.rootPath === "plugins.entries.qveris.config" &&
-      Array.isArray(signal.required) &&
-      signal.required.includes("apiKey"),
-  );
-  if (!hasQverisAuthSignal || !hasQverisConfigSignal) {
-    fail(`openclaw.plugin.json toolMetadata.${toolName} must declare QVeris auth and config signals`);
-  }
+const expectedSetup = {
+  providers: [{ id: "qveris", authMethods: ["api-key"], envVars: ["QVERIS_API_KEY"] }],
+  requiresRuntime: false,
+};
+if (!isDeepStrictEqual(pluginManifest.setup, expectedSetup)) {
+  fail("openclaw.plugin.json setup must preserve declarative API-key discovery:", [
+    `expected: ${JSON.stringify(expectedSetup)}`,
+    `manifest: ${JSON.stringify(pluginManifest.setup)}`,
+  ]);
 }
-for (const replaySafeTool of ["qveris_discover", "qveris_inspect"]) {
-  if (pluginManifest.toolMetadata[replaySafeTool]?.replaySafe !== true) {
-    fail(`openclaw.plugin.json toolMetadata.${replaySafeTool} must be replaySafe`);
+
+const toolFactory = registrations[0].factory;
+assertConcreteToolNames(toolFactory({}), requiredToolNames, "plugin-config credential");
+const originalApiKey = process.env.QVERIS_API_KEY;
+try {
+  runtimeApi.pluginConfig = {};
+  delete process.env.QVERIS_API_KEY;
+  if (toolFactory({}) !== null) {
+    fail("Compiled tool factory must return null when neither config nor environment credentials are present");
   }
-}
-if (pluginManifest.toolMetadata.qveris_call?.replaySafe === true) {
-  fail("Paid qveris_call must never be declared replaySafe");
+  process.env.QVERIS_API_KEY = "synthetic-compiled-environment-key";
+  assertConcreteToolNames(toolFactory({}), requiredToolNames, "environment credential");
+} finally {
+  if (originalApiKey === undefined) {
+    delete process.env.QVERIS_API_KEY;
+  } else {
+    process.env.QVERIS_API_KEY = originalApiKey;
+  }
 }
 
 const raw = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
@@ -180,3 +245,16 @@ if (riskyFiles.length > 0) {
 }
 
 console.log(`Pack check OK: ${files.length} files`);
+
+function assertConcreteToolNames(tools, expectedNames, credentialPath) {
+  if (!Array.isArray(tools)) {
+    fail(`Compiled tool factory did not return tools for the ${credentialPath}`);
+  }
+  const concreteNames = tools.map((tool) => tool?.name);
+  if (JSON.stringify(concreteNames) !== JSON.stringify(expectedNames)) {
+    fail(`Compiled tool factory names drifted for the ${credentialPath}:`, [
+      `expected: ${JSON.stringify(expectedNames)}`,
+      `received: ${JSON.stringify(concreteNames)}`,
+    ]);
+  }
+}

--- a/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-pack.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+const pluginManifest = JSON.parse(readFileSync("openclaw.plugin.json", "utf8"));
 const expectedRepositoryUrl = "https://github.com/QVerisAI/qveris-agent-toolkit";
 if (packageJson.repository?.url !== expectedRepositoryUrl) {
   fail("package.json repository.url must match the public provenance repository:", [
@@ -63,6 +64,81 @@ function fail(message, details = []) {
 const shell = process.platform === "win32";
 
 execFileSync("npm", ["run", "build"], { stdio: "inherit", shell });
+
+const runtimeModule = await import(new URL("../dist/index.js", import.meta.url));
+const runtimePlugin = runtimeModule.default;
+const registrations = [];
+runtimePlugin.register({
+  registerTool(_factory, options) {
+    registrations.push(options);
+  },
+});
+
+if (pluginManifest.id !== runtimePlugin.id) {
+  fail("openclaw.plugin.json id must match the compiled runtime plugin id:", [
+    `manifest: ${pluginManifest.id}`,
+    `runtime: ${runtimePlugin.id}`,
+  ]);
+}
+if (pluginManifest.name !== runtimePlugin.name || pluginManifest.description !== runtimePlugin.description) {
+  fail("openclaw.plugin.json presentation metadata must match the compiled runtime plugin:", [
+    `manifest name/description: ${pluginManifest.name} / ${pluginManifest.description}`,
+    `runtime name/description: ${runtimePlugin.name} / ${runtimePlugin.description}`,
+  ]);
+}
+if (pluginManifest.version !== packageJson.version) {
+  fail("openclaw.plugin.json version must match package.json:", [
+    `manifest: ${pluginManifest.version}`,
+    `package: ${packageJson.version}`,
+  ]);
+}
+if (pluginManifest.activation?.onStartup !== true) {
+  fail("openclaw.plugin.json must explicitly activate this required-tool plugin at Gateway startup");
+}
+if (registrations.length !== 1 || !Array.isArray(registrations[0]?.names)) {
+  fail("Compiled runtime must make exactly one named tool-factory registration");
+}
+
+const declaredToolNames = pluginManifest.contracts?.tools;
+const registeredToolNames = registrations[0]?.names;
+if (!Array.isArray(declaredToolNames) || JSON.stringify(declaredToolNames) !== JSON.stringify(registeredToolNames)) {
+  fail("openclaw.plugin.json contracts.tools must exactly match the compiled runtime registration:", [
+    `manifest: ${JSON.stringify(declaredToolNames)}`,
+    `runtime: ${JSON.stringify(registeredToolNames)}`,
+  ]);
+}
+if (new Set(declaredToolNames).size !== declaredToolNames.length) {
+  fail("openclaw.plugin.json contracts.tools must not contain duplicate names");
+}
+
+const metadataToolNames = Object.keys(pluginManifest.toolMetadata ?? {}).sort();
+if (JSON.stringify(metadataToolNames) !== JSON.stringify([...declaredToolNames].sort())) {
+  fail("openclaw.plugin.json toolMetadata must cover exactly the declared tools:", [
+    `contracts.tools: ${JSON.stringify([...declaredToolNames].sort())}`,
+    `toolMetadata: ${JSON.stringify(metadataToolNames)}`,
+  ]);
+}
+for (const toolName of declaredToolNames) {
+  const metadata = pluginManifest.toolMetadata[toolName];
+  const hasQverisAuthSignal = metadata.authSignals?.some((signal) => signal?.provider === "qveris");
+  const hasQverisConfigSignal = metadata.configSignals?.some(
+    (signal) =>
+      signal?.rootPath === "plugins.entries.qveris.config" &&
+      Array.isArray(signal.required) &&
+      signal.required.includes("apiKey"),
+  );
+  if (!hasQverisAuthSignal || !hasQverisConfigSignal) {
+    fail(`openclaw.plugin.json toolMetadata.${toolName} must declare QVeris auth and config signals`);
+  }
+}
+for (const replaySafeTool of ["qveris_discover", "qveris_inspect"]) {
+  if (pluginManifest.toolMetadata[replaySafeTool]?.replaySafe !== true) {
+    fail(`openclaw.plugin.json toolMetadata.${replaySafeTool} must be replaySafe`);
+  }
+}
+if (pluginManifest.toolMetadata.qveris_call?.replaySafe === true) {
+  fail("Paid qveris_call must never be declared replaySafe");
+}
 
 const raw = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
   encoding: "utf8",

--- a/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
@@ -1,9 +1,10 @@
+import { readFileSync } from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
-import plugin from "../index.js";
+import plugin, { QVERIS_TOOL_NAMES } from "../index.js";
 import { inferCsvAnalysis, inferJsonAnalysis, inferTextAnalysis } from "./qveris-materialization.js";
 import { createQverisTools } from "./qveris-tools.js";
 
@@ -110,6 +111,57 @@ const SAMPLE_INSPECT_RESPONSE = {
 // ---------------------------------------------------------------------------
 
 describe("plugin registration", () => {
+  it("keeps manifest ownership, activation, auth, and replay metadata aligned with runtime registration", () => {
+    const manifest = JSON.parse(readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8")) as {
+      id?: string;
+      name?: string;
+      description?: string;
+      version?: string;
+      activation?: { onStartup?: boolean };
+      contracts?: { tools?: string[] };
+      setup?: { providers?: Array<{ id?: string; envVars?: string[] }> };
+      toolMetadata?: Record<
+        string,
+        {
+          authSignals?: Array<{ provider?: string }>;
+          configSignals?: Array<{ rootPath?: string; required?: string[] }>;
+          replaySafe?: boolean;
+        }
+      >;
+    };
+    const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+      version?: string;
+    };
+
+    expect(manifest).toMatchObject({
+      id: plugin.id,
+      name: plugin.name,
+      description: plugin.description,
+      version: packageJson.version,
+      activation: { onStartup: true },
+      contracts: { tools: [...QVERIS_TOOL_NAMES] },
+    });
+    expect(manifest.setup?.providers).toContainEqual(
+      expect.objectContaining({ id: "qveris", envVars: expect.arrayContaining(["QVERIS_API_KEY"]) }),
+    );
+    expect(Object.keys(manifest.toolMetadata ?? {}).sort()).toEqual([...QVERIS_TOOL_NAMES].sort());
+
+    for (const toolName of QVERIS_TOOL_NAMES) {
+      expect(manifest.toolMetadata?.[toolName]).toMatchObject({
+        authSignals: [{ provider: "qveris" }],
+        configSignals: [
+          {
+            rootPath: "plugins.entries.qveris.config",
+            required: ["apiKey"],
+          },
+        ],
+      });
+    }
+    expect(manifest.toolMetadata?.qveris_discover?.replaySafe).toBe(true);
+    expect(manifest.toolMetadata?.qveris_inspect?.replaySafe).toBe(true);
+    expect(manifest.toolMetadata?.qveris_call?.replaySafe).not.toBe(true);
+  });
+
   it("registers tool factory with correct names", () => {
     const registrations: {
       factories: unknown[];
@@ -132,7 +184,7 @@ describe("plugin registration", () => {
     expect(registrations.factories).toHaveLength(1);
     expect(typeof registrations.factories[0]).toBe("function");
     expect(registrations.opts[0]).toEqual({
-      names: ["qveris_discover", "qveris_call", "qveris_inspect"],
+      names: [...QVERIS_TOOL_NAMES],
     });
   });
 });

--- a/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
+++ b/packages/openclaw-qveris-plugin/src/qveris-tools.test.ts
@@ -119,7 +119,10 @@ describe("plugin registration", () => {
       version?: string;
       activation?: { onStartup?: boolean };
       contracts?: { tools?: string[] };
-      setup?: { providers?: Array<{ id?: string; envVars?: string[] }> };
+      setup?: {
+        providers?: Array<{ id?: string; authMethods?: string[]; envVars?: string[] }>;
+        requiresRuntime?: boolean;
+      };
       toolMetadata?: Record<
         string,
         {
@@ -130,20 +133,29 @@ describe("plugin registration", () => {
       >;
     };
     const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+      peerDependencies?: { openclaw?: string };
       version?: string;
+      openclaw?: {
+        compat?: { pluginApi?: string };
+        build?: { openclawVersion?: string; pluginSdkVersion?: string };
+        install?: { minHostVersion?: string };
+      };
     };
+    const canonicalToolNames = ["qveris_discover", "qveris_call", "qveris_inspect"];
 
+    expect(QVERIS_TOOL_NAMES).toEqual(canonicalToolNames);
     expect(manifest).toMatchObject({
       id: plugin.id,
       name: plugin.name,
       description: plugin.description,
       version: packageJson.version,
       activation: { onStartup: true },
-      contracts: { tools: [...QVERIS_TOOL_NAMES] },
+      contracts: { tools: canonicalToolNames },
+      setup: {
+        providers: [{ id: "qveris", authMethods: ["api-key"], envVars: ["QVERIS_API_KEY"] }],
+        requiresRuntime: false,
+      },
     });
-    expect(manifest.setup?.providers).toContainEqual(
-      expect.objectContaining({ id: "qveris", envVars: expect.arrayContaining(["QVERIS_API_KEY"]) }),
-    );
     expect(Object.keys(manifest.toolMetadata ?? {}).sort()).toEqual([...QVERIS_TOOL_NAMES].sort());
 
     for (const toolName of QVERIS_TOOL_NAMES) {
@@ -159,7 +171,15 @@ describe("plugin registration", () => {
     }
     expect(manifest.toolMetadata?.qveris_discover?.replaySafe).toBe(true);
     expect(manifest.toolMetadata?.qveris_inspect?.replaySafe).toBe(true);
-    expect(manifest.toolMetadata?.qveris_call?.replaySafe).not.toBe(true);
+    expect(manifest.toolMetadata?.qveris_call?.replaySafe).toBe(false);
+    expect(packageJson).toMatchObject({
+      peerDependencies: { openclaw: ">=2026.6.11" },
+      openclaw: {
+        compat: { pluginApi: ">=2026.6.11" },
+        build: { openclawVersion: "2026.6.11", pluginSdkVersion: "2026.6.11" },
+        install: { minHostVersion: ">=2026.6.11" },
+      },
+    });
   });
 
   it("registers tool factory with correct names", () => {


### PR DESCRIPTION
## Summary

- declare `qveris_discover`, `qveris_call`, and `qveris_inspect` in `contracts.tools`
- add explicit startup activation and auth/config availability metadata required by current OpenClaw hosts
- mark read-only Discover/Inspect replay-safe while keeping paid Call replay-unsafe
- prepare `@qverisai/qveris` `2026.7.30` and update its changelog, troubleshooting guidance, and release notes
- lock the three public tool names and OpenClaw compatibility metadata as independent test oracles
- validate compiled-factory output for config, environment, and missing-credential cases
- add isolated source and packed-package runtime checks with installed-package provenance assertions

## Root cause

OpenClaw `>=2026.6.11` rejects agent-tool registrations unless the manifest declares ownership in `contracts.tools`. Version `2026.7.15` registered the three runtime names but omitted that manifest contract, so the plugin loaded with `toolNames: []` and emitted `plugin must declare contracts.tools before registering agent tools`.

The issue was reproduced against an isolated OpenClaw state directory before the fix. The same inspection now reports all three registered tools with no error diagnostics. A separate compiled-factory check verifies that all three concrete tool descriptors are produced when either supported credential path is configured, and that the factory returns `null` when credentials are absent.

## Deep-review corrections

- corrected the original test assumption that `plugins inspect --runtime` proves concrete factory instantiation; `tools[].names` is registration metadata even when the factory returns `null`
- restored an independent literal oracle for the public three-tool contract, so synchronously deleting a tool from the manifest and runtime cannot make tests pass
- made `qveris_call` explicitly `replaySafe: false` and now checks exact auth/config/replay metadata
- verifies the packed check loads from the fresh isolated install root rather than accidentally discovering the source working directory
- runs OpenClaw from the isolated state directory and verifies plugin version, runtime contracts, source/install root, bounded output, and actionable process errors
- increased the install timeout to five minutes to avoid false release failures on a slow npm registry

## Compatibility matrix

| OpenClaw host | Source runtime | Packed install |
| --- | --- | --- |
| `2026.6.11` minimum | pass | pass |
| `2026.6.33` extended stable | pass | covered by source contract |
| `2026.7.1-2` current stable | pass | pass |

Runtime checks use a synthetic key and do not call the QVeris API.

## Validation

- full monorepo tests: pass (CLI 134, MCP 181, JS SDK 67, plugin 79, Python SDK 183 with 1 skipped, release checks 42)
- plugin coverage: pass
- monorepo typecheck: pass
- JavaScript/TypeScript and Python lint/format: pass
- monorepo build: pass
- package contents and compiled manifest/runtime invariants: pass
- production dependency audit: 0 vulnerabilities (`npm audit --omit=dev`)
- public documentation region-boundary scan: no new violations

Closes #272
