### PR TITLE
fix(openclaw): verify the published npm Registry artifact

### DIFF
--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -65,6 +65,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Verify published npm artifact with OpenClaw
+        run: npm run check:runtime:registry -- --expected-git-head "$GITHUB_SHA"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -5,13 +5,14 @@ on:
     tags:
       - "qveris-plugin-v*"
 
-permissions:
-  contents: write
-  id-token: write # npm provenance
+permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
     defaults:
       run:
         working-directory: packages/openclaw-qveris-plugin
@@ -69,6 +70,8 @@ jobs:
     name: Verify Registry artifact and create release
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: packages/openclaw-qveris-plugin
@@ -82,6 +85,16 @@ jobs:
         with:
           node-version: 22.22.3
           registry-url: https://registry.npmjs.org
+
+      - name: Load verified release version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#qveris-plugin-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -65,6 +65,27 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  verify_release:
+    name: Verify Registry artifact and create release
+    needs: publish
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/openclaw-qveris-plugin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.3
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Verify published npm artifact with OpenClaw
         run: npm run check:runtime:registry -- --expected-git-head "$GITHUB_SHA"
 

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ### Changed
 
-- The release workflow now waits for the exact npm Registry artifact after publishing, verifies its version, integrity metadata, and source commit, then installs it through the official OpenClaw plugin manager in isolated state before creating the GitHub Release.
+- The release workflow now waits for the exact public npm Registry artifact after publishing, verifies its version, downloaded integrity, source commit, runtime metadata, and concrete compiled tools, then installs it through the official OpenClaw plugin manager in isolated state before creating the GitHub Release. Publishing and verification run as separate jobs so a failed post-publish check can be retried without attempting to republish an immutable npm version.
 
 ## [2026.7.30] - 2026-07-30
 

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+### Changed
+
+- The release workflow now waits for the exact npm Registry artifact after publishing, verifies its version, integrity metadata, and source commit, then installs it through the official OpenClaw plugin manager in isolated state before creating the GitHub Release.
+
 ## [2026.7.30] - 2026-07-30
 
 ### Fixed

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -34,13 +34,15 @@
     "check:pack": "node scripts/check-pack.mjs",
     "check:runtime": "npm run build && node scripts/check-openclaw-runtime.mjs",
     "check:runtime:packed": "npm run build && node scripts/check-openclaw-runtime.mjs --pack",
+    "check:runtime:registry": "node scripts/check-openclaw-registry-release.mjs",
     "prepack": "npm run build",
     "test:integration": "node scripts/run-integration-tests.mjs",
-    "test": "vitest run",
+    "test:registry-release": "node --test scripts/check-openclaw-registry-release.node-test.mjs",
+    "test": "vitest run && npm run test:registry-release",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . && prettier --check \"src/**/*.ts\" \"index.ts\" \"scripts/**/*.mjs\"",
     "lint:fix": "eslint . --fix && prettier --write \"src/**/*.ts\" \"index.ts\" \"scripts/**/*.mjs\"",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage && npm run test:registry-release"
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.52"

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.mjs
@@ -8,6 +8,7 @@ const scriptPath = fileURLToPath(import.meta.url);
 const packageRoot = path.resolve(path.dirname(scriptPath), "..");
 const requiredToolNames = ["qveris_discover", "qveris_call", "qveris_inspect"];
 const syntheticApiKey = "synthetic-openclaw-registry-release-key";
+const publicRegistryUrl = "https://registry.npmjs.org";
 
 export class ReleaseInvariantError extends Error {
   constructor(message) {
@@ -37,31 +38,55 @@ export function validateRegistryMetadata(metadata, expected) {
       `npm Registry gitHead mismatch: expected ${JSON.stringify(expected.gitHead)}, received ${JSON.stringify(metadata.gitHead)}`,
     );
   }
-  if (typeof metadata["dist.integrity"] !== "string" || metadata["dist.integrity"].length === 0) {
-    throw new ReleaseInvariantError("npm Registry metadata is missing dist.integrity");
+  if (
+    typeof metadata["dist.integrity"] !== "string" ||
+    !/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(metadata["dist.integrity"])
+  ) {
+    throw new ReleaseInvariantError("npm Registry metadata has an invalid dist.integrity");
   }
 }
 
-export function validateRuntimeResult(result, expected, stateDir) {
+export function validateRuntimeResult(result, expected, metadata, stateDir) {
   const inspection = result?.inspection;
   const installedPackage = result?.installedPackage;
   const plugin = inspection?.plugin;
   const expectedSortedNames = [...expected.toolNames].sort();
-  const registrationGroupNames = [...(inspection?.tools ?? [])]
+  const runtimeTools = assertArray(inspection?.tools, "runtime registration groups");
+  const diagnostics = assertArray(inspection?.diagnostics, "runtime diagnostics");
+  const runtimeToolNames = assertArray(plugin?.toolNames, "runtime tool names");
+  const manifestToolNames = assertArray(plugin?.contracts?.tools, "runtime manifest tool contract");
+  const registrationGroupNames = runtimeTools
     .flatMap((tool) => (Array.isArray(tool?.names) ? tool.names : [tool?.name]))
     .filter((name) => typeof name === "string")
     .sort();
-  const errorDiagnostics = [...(inspection?.diagnostics ?? [])].filter((diagnostic) => diagnostic?.level === "error");
+  const errorDiagnostics = diagnostics.filter((diagnostic) => diagnostic?.level === "error");
 
   assertEqual(plugin?.id, expected.pluginId, "runtime plugin id");
   assertEqual(plugin?.status, "loaded", "runtime plugin status");
   assertEqual(plugin?.version, expected.version, "runtime plugin version");
-  assertArrayEqual([...(plugin?.toolNames ?? [])].sort(), expectedSortedNames, "runtime tool names");
-  assertArrayEqual([...(plugin?.contracts?.tools ?? [])], expected.toolNames, "runtime manifest tool contract");
+  assertArrayEqual([...runtimeToolNames].sort(), expectedSortedNames, "runtime tool names");
+  assertArrayEqual([...manifestToolNames], expected.toolNames, "runtime manifest tool contract");
   assertArrayEqual(registrationGroupNames, expectedSortedNames, "runtime registration-group names");
   assertPathWithin(plugin?.rootDir, stateDir, "registry-installed plugin root");
   assertEqual(installedPackage?.name, expected.packageName, "installed package name");
   assertEqual(installedPackage?.version, expected.version, "installed package version");
+  assertEqual(result?.installedIntegrity, metadata["dist.integrity"], "installed package integrity");
+  assertEqual(result?.compiledRuntime?.pluginId, expected.pluginId, "compiled runtime plugin id");
+  assertArrayEqual(
+    result?.compiledRuntime?.exportedToolNames,
+    expected.toolNames,
+    "compiled runtime exported tool names",
+  );
+  assertArrayEqual(
+    result?.compiledRuntime?.registrationNames,
+    expected.toolNames,
+    "compiled runtime registration names",
+  );
+  assertArrayEqual(
+    result?.compiledRuntime?.concreteToolNames,
+    expected.toolNames,
+    "compiled runtime concrete tool names",
+  );
   if (errorDiagnostics.length > 0) {
     throw new ReleaseInvariantError(`OpenClaw reported runtime error diagnostics: ${JSON.stringify(errorDiagnostics)}`);
   }
@@ -92,9 +117,12 @@ export async function verifyRegistryRelease(options) {
     delayMs: retryDelayMs,
     sleep: operations.sleep,
     secrets,
-    operation: () => operations.fetchRegistryMetadata(spec),
+    operation: async () => {
+      const candidate = await operations.fetchRegistryMetadata(spec);
+      validateRegistryMetadata(candidate, expected);
+      return candidate;
+    },
   });
-  validateRegistryMetadata(metadata, expected);
 
   const failures = [];
   for (let attempt = 1; attempt <= installAttempts; attempt += 1) {
@@ -103,7 +131,7 @@ export async function verifyRegistryRelease(options) {
     let attemptError;
     try {
       result = await operations.installAndInspect({ spec, stateDir });
-      validateRuntimeResult(result, expected, stateDir);
+      validateRuntimeResult(result, expected, metadata, stateDir);
     } catch (error) {
       attemptError = error;
     }
@@ -132,7 +160,7 @@ export async function verifyRegistryRelease(options) {
   );
 }
 
-export function createDefaultOperations({ packageJson, manifest, expected }) {
+export function createDefaultOperations({ packageJson, manifest }) {
   const openclawPackagePath = path.join(packageRoot, "node_modules", "openclaw", "package.json");
   const openclawPackage = readJson(openclawPackagePath);
   const openclawBin = resolveOpenClawBin(openclawPackagePath, openclawPackage.bin);
@@ -142,7 +170,17 @@ export function createDefaultOperations({ packageJson, manifest, expected }) {
       const npm = process.platform === "win32" ? "npm.cmd" : "npm";
       const result = spawnSync(
         npm,
-        ["view", spec, "version", "dist.integrity", "gitHead", "--json", "--prefer-online"],
+        [
+          "view",
+          spec,
+          "version",
+          "dist.integrity",
+          "gitHead",
+          "--json",
+          "--prefer-online",
+          "--registry",
+          publicRegistryUrl,
+        ],
         {
           cwd: packageRoot,
           encoding: "utf8",
@@ -168,7 +206,7 @@ export function createDefaultOperations({ packageJson, manifest, expected }) {
     createStateDir() {
       return mkdtempSync(path.join(os.tmpdir(), "qveris-openclaw-registry-release-"));
     },
-    installAndInspect({ spec, stateDir }) {
+    async installAndInspect({ spec, stateDir }) {
       const homeDir = path.join(stateDir, "home");
       const configPath = path.join(stateDir, "openclaw.json");
       const env = {
@@ -179,6 +217,8 @@ export function createDefaultOperations({ packageJson, manifest, expected }) {
         OPENCLAW_STATE_DIR: stateDir,
         OPENCLAW_CONFIG_PATH: configPath,
         QVERIS_API_KEY: syntheticApiKey,
+        NPM_CONFIG_REGISTRY: publicRegistryUrl,
+        npm_config_registry: publicRegistryUrl,
       };
       delete env.QVERIS_BASE_URL;
 
@@ -203,7 +243,12 @@ export function createDefaultOperations({ packageJson, manifest, expected }) {
       const installedRoot = inspection?.plugin?.rootDir;
       assertPathWithin(installedRoot, stateDir, "registry-installed plugin root");
       const installedPackage = readJson(path.join(installedRoot, "package.json"));
-      return { inspection, installedPackage };
+      const managedProjectRoot = path.resolve(installedRoot, "../../..");
+      assertPathWithin(managedProjectRoot, stateDir, "OpenClaw managed npm project root");
+      const packageLock = readJson(path.join(managedProjectRoot, "package-lock.json"));
+      const installedIntegrity = packageLock?.packages?.[`node_modules/${packageJson.name}`]?.integrity;
+      const compiledRuntime = await inspectCompiledRuntime(installedRoot);
+      return { inspection, installedPackage, installedIntegrity, compiledRuntime };
     },
     cleanupStateDir(stateDir) {
       rmSync(stateDir, { recursive: true, force: true });
@@ -213,7 +258,6 @@ export function createDefaultOperations({ packageJson, manifest, expected }) {
     },
     openclawVersion: openclawPackage.version,
     packageVersion: packageJson.version,
-    expected,
   };
 }
 
@@ -249,6 +293,52 @@ function runOpenClaw(openclawBin, args, { cwd, env, timeoutMs }) {
     );
   }
   return result.stdout.trim();
+}
+
+async function inspectCompiledRuntime(installedRoot) {
+  try {
+    const entryUrl = pathToFileURL(path.join(installedRoot, "dist", "index.js"));
+    entryUrl.searchParams.set("registry-release-root", installedRoot);
+    const runtimeModule = await import(entryUrl.href);
+    const runtimePlugin = runtimeModule.default;
+    if (!runtimePlugin || typeof runtimePlugin.register !== "function") {
+      throw new ReleaseInvariantError("compiled runtime must export a plugin with register()");
+    }
+
+    const registrations = [];
+    const runtimeApi = {
+      pluginConfig: { apiKey: syntheticApiKey },
+      registerTool(factory, options) {
+        registrations.push({ factory, options });
+      },
+    };
+    runtimePlugin.register(runtimeApi);
+    if (
+      registrations.length !== 1 ||
+      typeof registrations[0]?.factory !== "function" ||
+      !Array.isArray(registrations[0]?.options?.names)
+    ) {
+      throw new ReleaseInvariantError("compiled runtime must make exactly one named tool-factory registration");
+    }
+    const concreteTools = registrations[0].factory({});
+    if (!Array.isArray(concreteTools)) {
+      throw new ReleaseInvariantError("compiled runtime tool factory must instantiate concrete tools with credentials");
+    }
+
+    return {
+      pluginId: runtimePlugin.id,
+      exportedToolNames: assertArray(runtimeModule.QVERIS_TOOL_NAMES, "compiled runtime exported tool names"),
+      registrationNames: registrations[0].options.names,
+      concreteToolNames: concreteTools.map((tool) => tool?.name),
+    };
+  } catch (error) {
+    if (error instanceof ReleaseInvariantError) {
+      throw error;
+    }
+    throw new ReleaseInvariantError(
+      `failed to inspect compiled Registry runtime: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 function formatProcessOutput(result) {
@@ -305,6 +395,13 @@ function assertArrayEqual(actual, expected, label) {
   }
 }
 
+function assertArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new ReleaseInvariantError(`${label} must be an array`);
+  }
+  return value;
+}
+
 function assertPathWithin(actual, expectedParent, label) {
   const actualPath = resolveRealPath(actual, label);
   const parentPath = resolveRealPath(expectedParent, `${label} parent`);
@@ -352,7 +449,7 @@ async function main() {
     toolNames: requiredToolNames,
   };
   const sensitiveValues = [process.env.NODE_AUTH_TOKEN, process.env.NPM_TOKEN, process.env.QVERIS_API_KEY];
-  const operations = createDefaultOperations({ packageJson, manifest, expected });
+  const operations = createDefaultOperations({ packageJson, manifest });
   const result = await verifyRegistryRelease({ expected, operations, sensitiveValues });
   console.log(
     `npm Registry release OK: host ${operations.openclawVersion}, plugin ${expected.version}, ` +

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.mjs
@@ -1,0 +1,374 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const packageRoot = path.resolve(path.dirname(scriptPath), "..");
+const requiredToolNames = ["qveris_discover", "qveris_call", "qveris_inspect"];
+const syntheticApiKey = "synthetic-openclaw-registry-release-key";
+
+export class ReleaseInvariantError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ReleaseInvariantError";
+  }
+}
+
+export class ReleaseTransientError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ReleaseTransientError";
+  }
+}
+
+export function validateRegistryMetadata(metadata, expected) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new ReleaseTransientError("npm Registry metadata must be a JSON object");
+  }
+  if (metadata.version !== expected.version) {
+    throw new ReleaseInvariantError(
+      `npm Registry version mismatch: expected ${JSON.stringify(expected.version)}, received ${JSON.stringify(metadata.version)}`,
+    );
+  }
+  if (metadata.gitHead !== expected.gitHead) {
+    throw new ReleaseInvariantError(
+      `npm Registry gitHead mismatch: expected ${JSON.stringify(expected.gitHead)}, received ${JSON.stringify(metadata.gitHead)}`,
+    );
+  }
+  if (typeof metadata["dist.integrity"] !== "string" || metadata["dist.integrity"].length === 0) {
+    throw new ReleaseInvariantError("npm Registry metadata is missing dist.integrity");
+  }
+}
+
+export function validateRuntimeResult(result, expected, stateDir) {
+  const inspection = result?.inspection;
+  const installedPackage = result?.installedPackage;
+  const plugin = inspection?.plugin;
+  const expectedSortedNames = [...expected.toolNames].sort();
+  const registrationGroupNames = [...(inspection?.tools ?? [])]
+    .flatMap((tool) => (Array.isArray(tool?.names) ? tool.names : [tool?.name]))
+    .filter((name) => typeof name === "string")
+    .sort();
+  const errorDiagnostics = [...(inspection?.diagnostics ?? [])].filter((diagnostic) => diagnostic?.level === "error");
+
+  assertEqual(plugin?.id, expected.pluginId, "runtime plugin id");
+  assertEqual(plugin?.status, "loaded", "runtime plugin status");
+  assertEqual(plugin?.version, expected.version, "runtime plugin version");
+  assertArrayEqual([...(plugin?.toolNames ?? [])].sort(), expectedSortedNames, "runtime tool names");
+  assertArrayEqual([...(plugin?.contracts?.tools ?? [])], expected.toolNames, "runtime manifest tool contract");
+  assertArrayEqual(registrationGroupNames, expectedSortedNames, "runtime registration-group names");
+  assertPathWithin(plugin?.rootDir, stateDir, "registry-installed plugin root");
+  assertEqual(installedPackage?.name, expected.packageName, "installed package name");
+  assertEqual(installedPackage?.version, expected.version, "installed package version");
+  if (errorDiagnostics.length > 0) {
+    throw new ReleaseInvariantError(`OpenClaw reported runtime error diagnostics: ${JSON.stringify(errorDiagnostics)}`);
+  }
+}
+
+export async function verifyRegistryRelease(options) {
+  const {
+    expected,
+    operations,
+    metadataAttempts = 12,
+    installAttempts = 3,
+    retryDelayMs = 5_000,
+    sensitiveValues = [],
+  } = options;
+  assertPositiveInteger(metadataAttempts, "metadataAttempts");
+  assertPositiveInteger(installAttempts, "installAttempts");
+  if (!Number.isInteger(retryDelayMs) || retryDelayMs < 0) {
+    throw new ReleaseInvariantError("retryDelayMs must be a non-negative integer");
+  }
+
+  const spec = `${expected.packageName}@${expected.version}`;
+  const secrets = [syntheticApiKey, ...sensitiveValues].filter(
+    (value) => typeof value === "string" && value.length > 0,
+  );
+  const metadata = await retryTransientPhase({
+    label: "npm Registry metadata",
+    attempts: metadataAttempts,
+    delayMs: retryDelayMs,
+    sleep: operations.sleep,
+    secrets,
+    operation: () => operations.fetchRegistryMetadata(spec),
+  });
+  validateRegistryMetadata(metadata, expected);
+
+  const failures = [];
+  for (let attempt = 1; attempt <= installAttempts; attempt += 1) {
+    const stateDir = operations.createStateDir();
+    let result;
+    let attemptError;
+    try {
+      result = await operations.installAndInspect({ spec, stateDir });
+      validateRuntimeResult(result, expected, stateDir);
+    } catch (error) {
+      attemptError = error;
+    }
+
+    try {
+      await operations.cleanupStateDir(stateDir);
+    } catch (cleanupError) {
+      const detail = sanitizeError(cleanupError, secrets);
+      throw new ReleaseInvariantError(`failed to clean isolated OpenClaw state ${JSON.stringify(stateDir)}: ${detail}`);
+    }
+
+    if (!attemptError) {
+      return { metadata, attempts: attempt };
+    }
+    if (attemptError instanceof ReleaseInvariantError) {
+      throw new ReleaseInvariantError(sanitizeError(attemptError, secrets));
+    }
+    failures.push(`attempt ${attempt}: ${sanitizeError(attemptError, secrets)}`);
+    if (attempt < installAttempts) {
+      await operations.sleep(retryDelayMs);
+    }
+  }
+
+  throw new ReleaseTransientError(
+    `registry-installed OpenClaw verification failed after ${installAttempts} attempts:\n- ${failures.join("\n- ")}`,
+  );
+}
+
+export function createDefaultOperations({ packageJson, manifest, expected }) {
+  const openclawPackagePath = path.join(packageRoot, "node_modules", "openclaw", "package.json");
+  const openclawPackage = readJson(openclawPackagePath);
+  const openclawBin = resolveOpenClawBin(openclawPackagePath, openclawPackage.bin);
+
+  return {
+    fetchRegistryMetadata(spec) {
+      const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+      const result = spawnSync(
+        npm,
+        ["view", spec, "version", "dist.integrity", "gitHead", "--json", "--prefer-online"],
+        {
+          cwd: packageRoot,
+          encoding: "utf8",
+          env: process.env,
+          maxBuffer: 10 * 1024 * 1024,
+          timeout: 60_000,
+          shell: process.platform === "win32",
+        },
+      );
+      if (result.status !== 0) {
+        throw new ReleaseTransientError(
+          `npm view failed (${result.status ?? "signal"}): ${formatProcessOutput(result)}`,
+        );
+      }
+      try {
+        return JSON.parse(result.stdout);
+      } catch (error) {
+        throw new ReleaseTransientError(
+          `npm view returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    },
+    createStateDir() {
+      return mkdtempSync(path.join(os.tmpdir(), "qveris-openclaw-registry-release-"));
+    },
+    installAndInspect({ spec, stateDir }) {
+      const homeDir = path.join(stateDir, "home");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const env = {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_HOME: homeDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        QVERIS_API_KEY: syntheticApiKey,
+      };
+      delete env.QVERIS_BASE_URL;
+
+      runOpenClaw(openclawBin, ["plugins", "install", spec, "--pin"], {
+        cwd: stateDir,
+        env,
+        timeoutMs: 300_000,
+      });
+      const rawInspection = runOpenClaw(openclawBin, ["plugins", "inspect", manifest.id, "--runtime", "--json"], {
+        cwd: stateDir,
+        env,
+        timeoutMs: 120_000,
+      });
+      let inspection;
+      try {
+        inspection = JSON.parse(rawInspection);
+      } catch (error) {
+        throw new ReleaseInvariantError(
+          `OpenClaw runtime inspection returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      const installedRoot = inspection?.plugin?.rootDir;
+      assertPathWithin(installedRoot, stateDir, "registry-installed plugin root");
+      const installedPackage = readJson(path.join(installedRoot, "package.json"));
+      return { inspection, installedPackage };
+    },
+    cleanupStateDir(stateDir) {
+      rmSync(stateDir, { recursive: true, force: true });
+    },
+    sleep(delayMs) {
+      return new Promise((resolve) => setTimeout(resolve, delayMs));
+    },
+    openclawVersion: openclawPackage.version,
+    packageVersion: packageJson.version,
+    expected,
+  };
+}
+
+async function retryTransientPhase({ label, attempts, delayMs, sleep, secrets, operation }) {
+  const failures = [];
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (error instanceof ReleaseInvariantError) {
+        throw new ReleaseInvariantError(sanitizeError(error, secrets));
+      }
+      failures.push(`attempt ${attempt}: ${sanitizeError(error, secrets)}`);
+      if (attempt < attempts) {
+        await sleep(delayMs);
+      }
+    }
+  }
+  throw new ReleaseTransientError(`${label} failed after ${attempts} attempts:\n- ${failures.join("\n- ")}`);
+}
+
+function runOpenClaw(openclawBin, args, { cwd, env, timeoutMs }) {
+  const result = spawnSync(process.execPath, [openclawBin, ...args], {
+    cwd,
+    encoding: "utf8",
+    env,
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: timeoutMs,
+  });
+  if (result.status !== 0) {
+    throw new ReleaseTransientError(
+      `openclaw ${args.join(" ")} failed (${result.status ?? "signal"}): ${formatProcessOutput(result)}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function formatProcessOutput(result) {
+  return [result.stdout, result.stderr, result.error?.stack ?? result.error?.message]
+    .map((output) => output?.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function parseExpectedGitHead(argv) {
+  const args = [...argv];
+  const index = args.indexOf("--expected-git-head");
+  if (index === -1 || index === args.length - 1) {
+    throw new ReleaseInvariantError("--expected-git-head <40-character commit SHA> is required");
+  }
+  const [gitHead] = args.splice(index + 1, 1);
+  args.splice(index, 1);
+  if (args.length > 0) {
+    throw new ReleaseInvariantError(`unknown arguments: ${args.join(" ")}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(gitHead)) {
+    throw new ReleaseInvariantError("--expected-git-head must be a lowercase 40-character commit SHA");
+  }
+  return gitHead;
+}
+
+function resolveOpenClawBin(packagePath, bin) {
+  const relativeBin = typeof bin === "string" ? bin : bin?.openclaw;
+  if (typeof relativeBin !== "string" || relativeBin.length === 0) {
+    throw new ReleaseInvariantError("installed openclaw package does not declare an openclaw executable");
+  }
+  return path.resolve(path.dirname(packagePath), relativeBin);
+}
+
+function assertPositiveInteger(value, label) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new ReleaseInvariantError(`${label} must be a positive integer`);
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new ReleaseInvariantError(
+      `${label} mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function assertArrayEqual(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new ReleaseInvariantError(
+      `${label} mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function assertPathWithin(actual, expectedParent, label) {
+  const actualPath = resolveRealPath(actual, label);
+  const parentPath = resolveRealPath(expectedParent, `${label} parent`);
+  const relative = path.relative(parentPath, actualPath);
+  if (relative === "" || relative.startsWith(`..${path.sep}`) || relative === ".." || path.isAbsolute(relative)) {
+    throw new ReleaseInvariantError(
+      `${label} must be inside ${JSON.stringify(parentPath)}, received ${JSON.stringify(actualPath)}`,
+    );
+  }
+}
+
+function resolveRealPath(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ReleaseInvariantError(`${label} must be a non-empty path`);
+  }
+  try {
+    return realpathSync(value);
+  } catch (error) {
+    throw new ReleaseInvariantError(
+      `${label} cannot be resolved: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function sanitizeError(error, secrets) {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const secret of secrets) {
+    message = message.split(secret).join("***");
+  }
+  return message;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+async function main() {
+  const packageJson = readJson(path.join(packageRoot, "package.json"));
+  const manifest = readJson(path.join(packageRoot, "openclaw.plugin.json"));
+  const expected = {
+    packageName: packageJson.name,
+    version: packageJson.version,
+    gitHead: parseExpectedGitHead(process.argv.slice(2)),
+    pluginId: manifest.id,
+    toolNames: requiredToolNames,
+  };
+  const sensitiveValues = [process.env.NODE_AUTH_TOKEN, process.env.NPM_TOKEN, process.env.QVERIS_API_KEY];
+  const operations = createDefaultOperations({ packageJson, manifest, expected });
+  const result = await verifyRegistryRelease({ expected, operations, sensitiveValues });
+  console.log(
+    `npm Registry release OK: host ${operations.openclawVersion}, plugin ${expected.version}, ` +
+      `tools ${expected.toolNames.join(", ")}, install attempts ${result.attempts}`,
+  );
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch((error) => {
+    const secrets = [
+      syntheticApiKey,
+      process.env.NODE_AUTH_TOKEN,
+      process.env.NPM_TOKEN,
+      process.env.QVERIS_API_KEY,
+    ].filter(Boolean);
+    console.error(sanitizeError(error, secrets));
+    process.exitCode = 1;
+  });
+}

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
@@ -396,14 +396,18 @@ test("keeps Registry verification between npm publish and GitHub Release creatio
   const workflow = readFileSync(path.join(repositoryRoot, ".github/workflows/qveris-plugin-publish.yml"), "utf8");
   const publishIndex = workflow.indexOf("- name: Publish to npm");
   const verificationJobIndex = workflow.indexOf("verify_release:");
+  const versionIndex = workflow.indexOf("- name: Load verified release version");
   const registryIndex = workflow.indexOf("- name: Verify published npm artifact with OpenClaw");
   const releaseIndex = workflow.indexOf("- name: Create GitHub Release");
 
   assert.ok(publishIndex >= 0);
   assert.ok(verificationJobIndex > publishIndex);
+  assert.ok(versionIndex > verificationJobIndex);
+  assert.ok(registryIndex > versionIndex);
   assert.ok(registryIndex > verificationJobIndex);
   assert.ok(releaseIndex > registryIndex);
   assert.match(workflow.slice(verificationJobIndex, registryIndex), /needs: publish/);
+  assert.match(workflow.slice(versionIndex, registryIndex), /echo "VERSION=\$PKG_VERSION" >> "\$GITHUB_ENV"/);
   assert.match(
     workflow.slice(registryIndex, releaseIndex),
     /check:runtime:registry -- --expected-git-head "\$GITHUB_SHA"/,

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
@@ -27,7 +27,7 @@ function metadata(overrides = {}) {
   return {
     version: expected.version,
     gitHead: expected.gitHead,
-    "dist.integrity": "sha512-test",
+    "dist.integrity": "sha512-dGVzdA==",
     ...overrides,
   };
 }
@@ -55,6 +55,13 @@ function runtimeFixture(root, overrides = {}) {
     installedPackage: {
       name: expected.packageName,
       version: expected.version,
+    },
+    installedIntegrity: metadata()["dist.integrity"],
+    compiledRuntime: {
+      pluginId: expected.pluginId,
+      exportedToolNames: [...expected.toolNames],
+      registrationNames: [...expected.toolNames],
+      concreteToolNames: [...expected.toolNames],
     },
   };
   return {
@@ -117,7 +124,7 @@ test("accepts exact Registry metadata", () => {
 for (const [label, value, pattern] of [
   ["version", metadata({ version: "2026.7.29" }), /version mismatch/],
   ["gitHead", metadata({ gitHead: "b".repeat(40) }), /gitHead mismatch/],
-  ["integrity", metadata({ "dist.integrity": "" }), /missing dist\.integrity/],
+  ["integrity", metadata({ "dist.integrity": "not-an-integrity" }), /invalid dist\.integrity/],
 ]) {
   test(`rejects Registry ${label} drift`, () => {
     assert.throws(() => validateRegistryMetadata(value, expected), ReleaseInvariantError);
@@ -127,16 +134,16 @@ for (const [label, value, pattern] of [
 
 test("retries delayed Registry visibility before installing", async () => {
   const fixture = fixtureOperations({
-    metadataSequence: [new ReleaseTransientError("not visible"), metadata()],
+    metadataSequence: [new ReleaseTransientError("not visible"), [], metadata()],
   });
   const result = await verifyRegistryRelease({
     expected,
     operations: fixture.operations,
-    metadataAttempts: 2,
+    metadataAttempts: 3,
     retryDelayMs: 7,
   });
   assert.equal(result.attempts, 1);
-  assert.deepEqual(fixture.sleeps, [7]);
+  assert.deepEqual(fixture.sleeps, [7, 7]);
   assert.deepEqual(fixture.cleaned, fixture.roots);
 });
 
@@ -205,7 +212,7 @@ test("rejects an out-of-state source fallback", () => {
   const sourceDir = mkdtempSync(path.join(os.tmpdir(), "qveris-registry-release-source-"));
   try {
     const result = runtimeFixture(sourceDir);
-    assert.throws(() => validateRuntimeResult(result, expected, stateDir), /must be inside/);
+    assert.throws(() => validateRuntimeResult(result, expected, metadata(), stateDir), /must be inside/);
   } finally {
     rmSync(stateDir, { recursive: true, force: true });
     rmSync(sourceDir, { recursive: true, force: true });
@@ -249,6 +256,34 @@ for (const [label, mutate, pattern] of [
     /runtime error diagnostics/,
   ],
   [
+    "registration group shape",
+    (value) => {
+      value.inspection.tools = {};
+    },
+    /runtime registration groups must be an array/,
+  ],
+  [
+    "diagnostics shape",
+    (value) => {
+      value.inspection.diagnostics = {};
+    },
+    /runtime diagnostics must be an array/,
+  ],
+  [
+    "tool-name shape",
+    (value) => {
+      value.inspection.plugin.toolNames = {};
+    },
+    /runtime tool names must be an array/,
+  ],
+  [
+    "manifest-contract shape",
+    (value) => {
+      value.inspection.plugin.contracts.tools = {};
+    },
+    /runtime manifest tool contract must be an array/,
+  ],
+  [
     "installed package name",
     (value) => {
       value.installedPackage.name = "@qverisai/not-qveris";
@@ -262,13 +297,48 @@ for (const [label, mutate, pattern] of [
     },
     /installed package version mismatch/,
   ],
+  [
+    "installed package integrity",
+    (value) => {
+      value.installedIntegrity = "sha512-b3RoZXI=";
+    },
+    /installed package integrity mismatch/,
+  ],
+  [
+    "compiled runtime plugin id",
+    (value) => {
+      value.compiledRuntime.pluginId = "not-qveris";
+    },
+    /compiled runtime plugin id mismatch/,
+  ],
+  [
+    "compiled exported tool names",
+    (value) => {
+      value.compiledRuntime.exportedToolNames = ["qveris_discover", "qveris_inspect"];
+    },
+    /compiled runtime exported tool names mismatch/,
+  ],
+  [
+    "compiled registration names",
+    (value) => {
+      value.compiledRuntime.registrationNames = ["qveris_discover", "qveris_inspect"];
+    },
+    /compiled runtime registration names mismatch/,
+  ],
+  [
+    "compiled concrete tool names",
+    (value) => {
+      value.compiledRuntime.concreteToolNames = ["qveris_discover", "qveris_inspect"];
+    },
+    /compiled runtime concrete tool names mismatch/,
+  ],
 ]) {
   test(`rejects runtime ${label} drift`, () => {
     const stateDir = mkdtempSync(path.join(os.tmpdir(), "qveris-registry-release-drift-"));
     try {
       const value = runtimeFixture(stateDir);
       mutate(value);
-      assert.throws(() => validateRuntimeResult(value, expected, stateDir), pattern);
+      assert.throws(() => validateRuntimeResult(value, expected, metadata(), stateDir), pattern);
     } finally {
       rmSync(stateDir, { recursive: true, force: true });
     }
@@ -325,12 +395,15 @@ test("reports retry exhaustion and redacts sensitive values", async () => {
 test("keeps Registry verification between npm publish and GitHub Release creation", () => {
   const workflow = readFileSync(path.join(repositoryRoot, ".github/workflows/qveris-plugin-publish.yml"), "utf8");
   const publishIndex = workflow.indexOf("- name: Publish to npm");
+  const verificationJobIndex = workflow.indexOf("verify_release:");
   const registryIndex = workflow.indexOf("- name: Verify published npm artifact with OpenClaw");
   const releaseIndex = workflow.indexOf("- name: Create GitHub Release");
 
   assert.ok(publishIndex >= 0);
-  assert.ok(registryIndex > publishIndex);
+  assert.ok(verificationJobIndex > publishIndex);
+  assert.ok(registryIndex > verificationJobIndex);
   assert.ok(releaseIndex > registryIndex);
+  assert.match(workflow.slice(verificationJobIndex, registryIndex), /needs: publish/);
   assert.match(
     workflow.slice(registryIndex, releaseIndex),
     /check:runtime:registry -- --expected-git-head "\$GITHUB_SHA"/,

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
@@ -1,0 +1,338 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Keep these Node fault-injection tests outside Vitest's *.test.* discovery.
+import {
+  ReleaseInvariantError,
+  ReleaseTransientError,
+  validateRegistryMetadata,
+  validateRuntimeResult,
+  verifyRegistryRelease,
+} from "./check-openclaw-registry-release.mjs";
+
+const expected = {
+  packageName: "@qverisai/qveris",
+  version: "2026.7.30",
+  gitHead: "a".repeat(40),
+  pluginId: "qveris",
+  toolNames: ["qveris_discover", "qveris_call", "qveris_inspect"],
+};
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function metadata(overrides = {}) {
+  return {
+    version: expected.version,
+    gitHead: expected.gitHead,
+    "dist.integrity": "sha512-test",
+    ...overrides,
+  };
+}
+
+function runtimeFixture(root, overrides = {}) {
+  const pluginRoot = path.join(root, "npm", "node_modules", "@qverisai", "qveris");
+  mkdirSync(pluginRoot, { recursive: true });
+  writeFileSync(
+    path.join(pluginRoot, "package.json"),
+    `${JSON.stringify({ name: expected.packageName, version: expected.version })}\n`,
+  );
+  const base = {
+    inspection: {
+      plugin: {
+        id: expected.pluginId,
+        status: "loaded",
+        version: expected.version,
+        rootDir: pluginRoot,
+        toolNames: [...expected.toolNames],
+        contracts: { tools: [...expected.toolNames] },
+      },
+      tools: [{ names: [...expected.toolNames] }],
+      diagnostics: [],
+    },
+    installedPackage: {
+      name: expected.packageName,
+      version: expected.version,
+    },
+  };
+  return {
+    ...base,
+    ...overrides,
+    inspection: {
+      ...base.inspection,
+      ...(overrides.inspection ?? {}),
+      plugin: {
+        ...base.inspection.plugin,
+        ...(overrides.inspection?.plugin ?? {}),
+      },
+    },
+  };
+}
+
+function fixtureOperations({ metadataSequence = [metadata()], installSequence = [] } = {}) {
+  const roots = [];
+  const cleaned = [];
+  const sleeps = [];
+  let metadataIndex = 0;
+  let installIndex = 0;
+  return {
+    roots,
+    cleaned,
+    sleeps,
+    operations: {
+      async fetchRegistryMetadata() {
+        const value = metadataSequence[Math.min(metadataIndex, metadataSequence.length - 1)];
+        metadataIndex += 1;
+        if (value instanceof Error) throw value;
+        return value;
+      },
+      createStateDir() {
+        const root = mkdtempSync(path.join(os.tmpdir(), "qveris-registry-release-test-"));
+        roots.push(root);
+        return root;
+      },
+      async installAndInspect({ stateDir }) {
+        const value = installSequence[installIndex];
+        installIndex += 1;
+        if (value instanceof Error) throw value;
+        return typeof value === "function" ? value(stateDir) : runtimeFixture(stateDir);
+      },
+      cleanupStateDir(stateDir) {
+        cleaned.push(stateDir);
+        rmSync(stateDir, { recursive: true, force: true });
+      },
+      async sleep(delayMs) {
+        sleeps.push(delayMs);
+      },
+    },
+  };
+}
+
+test("accepts exact Registry metadata", () => {
+  assert.doesNotThrow(() => validateRegistryMetadata(metadata(), expected));
+});
+
+for (const [label, value, pattern] of [
+  ["version", metadata({ version: "2026.7.29" }), /version mismatch/],
+  ["gitHead", metadata({ gitHead: "b".repeat(40) }), /gitHead mismatch/],
+  ["integrity", metadata({ "dist.integrity": "" }), /missing dist\.integrity/],
+]) {
+  test(`rejects Registry ${label} drift`, () => {
+    assert.throws(() => validateRegistryMetadata(value, expected), ReleaseInvariantError);
+    assert.throws(() => validateRegistryMetadata(value, expected), pattern);
+  });
+}
+
+test("retries delayed Registry visibility before installing", async () => {
+  const fixture = fixtureOperations({
+    metadataSequence: [new ReleaseTransientError("not visible"), metadata()],
+  });
+  const result = await verifyRegistryRelease({
+    expected,
+    operations: fixture.operations,
+    metadataAttempts: 2,
+    retryDelayMs: 7,
+  });
+  assert.equal(result.attempts, 1);
+  assert.deepEqual(fixture.sleeps, [7]);
+  assert.deepEqual(fixture.cleaned, fixture.roots);
+});
+
+test("retries a transient install from a fresh isolated state", async () => {
+  const fixture = fixtureOperations({
+    installSequence: [new ReleaseTransientError("tarball unavailable"), (root) => runtimeFixture(root)],
+  });
+  const result = await verifyRegistryRelease({
+    expected,
+    operations: fixture.operations,
+    installAttempts: 2,
+    retryDelayMs: 11,
+  });
+  assert.equal(result.attempts, 2);
+  assert.equal(new Set(fixture.roots).size, 2);
+  assert.deepEqual(fixture.cleaned, fixture.roots);
+  assert.deepEqual(fixture.sleeps, [11]);
+});
+
+test("fails closed on Registry metadata mismatch without installing", async () => {
+  const fixture = fixtureOperations({ metadataSequence: [metadata({ gitHead: "b".repeat(40) })] });
+  await assert.rejects(
+    verifyRegistryRelease({ expected, operations: fixture.operations }),
+    /npm Registry gitHead mismatch/,
+  );
+  assert.equal(fixture.roots.length, 0);
+});
+
+test("fails closed on runtime invariant drift without retrying", async () => {
+  const fixture = fixtureOperations({
+    installSequence: [
+      (root) =>
+        runtimeFixture(root, {
+          inspection: { plugin: { version: "2026.7.29" } },
+        }),
+    ],
+  });
+  await assert.rejects(
+    verifyRegistryRelease({ expected, operations: fixture.operations, installAttempts: 3 }),
+    /runtime plugin version mismatch/,
+  );
+  assert.equal(fixture.roots.length, 1);
+  assert.deepEqual(fixture.cleaned, fixture.roots);
+});
+
+test("fails closed when isolated-state cleanup fails", async () => {
+  const fixture = fixtureOperations();
+  fixture.operations.cleanupStateDir = () => {
+    throw new Error("injected cleanup failure");
+  };
+  try {
+    await assert.rejects(
+      verifyRegistryRelease({ expected, operations: fixture.operations, installAttempts: 3 }),
+      /failed to clean isolated OpenClaw state.*injected cleanup failure/,
+    );
+    assert.equal(fixture.roots.length, 1);
+  } finally {
+    for (const root of fixture.roots) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("rejects an out-of-state source fallback", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "qveris-registry-release-state-"));
+  const sourceDir = mkdtempSync(path.join(os.tmpdir(), "qveris-registry-release-source-"));
+  try {
+    const result = runtimeFixture(sourceDir);
+    assert.throws(() => validateRuntimeResult(result, expected, stateDir), /must be inside/);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+    rmSync(sourceDir, { recursive: true, force: true });
+  }
+});
+
+for (const [label, mutate, pattern] of [
+  [
+    "status",
+    (value) => {
+      value.inspection.plugin.status = "disabled";
+    },
+    /runtime plugin status mismatch/,
+  ],
+  [
+    "tool names",
+    (value) => {
+      value.inspection.plugin.toolNames = ["qveris_discover", "qveris_inspect"];
+    },
+    /runtime tool names mismatch/,
+  ],
+  [
+    "manifest contract",
+    (value) => {
+      value.inspection.plugin.contracts.tools = ["qveris_discover", "qveris_inspect"];
+    },
+    /runtime manifest tool contract mismatch/,
+  ],
+  [
+    "registration groups",
+    (value) => {
+      value.inspection.tools = [{ names: ["qveris_discover", "qveris_inspect"] }];
+    },
+    /runtime registration-group names mismatch/,
+  ],
+  [
+    "diagnostics",
+    (value) => {
+      value.inspection.diagnostics = [{ level: "error", message: "broken" }];
+    },
+    /runtime error diagnostics/,
+  ],
+  [
+    "installed package name",
+    (value) => {
+      value.installedPackage.name = "@qverisai/not-qveris";
+    },
+    /installed package name mismatch/,
+  ],
+  [
+    "installed package version",
+    (value) => {
+      value.installedPackage.version = "2026.7.29";
+    },
+    /installed package version mismatch/,
+  ],
+]) {
+  test(`rejects runtime ${label} drift`, () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "qveris-registry-release-drift-"));
+    try {
+      const value = runtimeFixture(stateDir);
+      mutate(value);
+      assert.throws(() => validateRuntimeResult(value, expected, stateDir), pattern);
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("reports Registry visibility exhaustion and redacts sensitive values", async () => {
+  const secret = "registry-secret-that-must-not-escape";
+  const fixture = fixtureOperations({
+    metadataSequence: [new ReleaseTransientError(`first ${secret}`), new ReleaseTransientError(`second ${secret}`)],
+  });
+  await assert.rejects(
+    verifyRegistryRelease({
+      expected,
+      operations: fixture.operations,
+      metadataAttempts: 2,
+      retryDelayMs: 0,
+      sensitiveValues: [secret],
+    }),
+    (error) => {
+      assert.ok(error instanceof ReleaseTransientError);
+      assert.match(error.message, /npm Registry metadata failed after 2 attempts/);
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    },
+  );
+  assert.equal(fixture.roots.length, 0);
+});
+
+test("reports retry exhaustion and redacts sensitive values", async () => {
+  const secret = "synthetic-secret-that-must-not-escape";
+  const fixture = fixtureOperations({
+    installSequence: [new ReleaseTransientError(`first ${secret}`), new ReleaseTransientError(`second ${secret}`)],
+  });
+  await assert.rejects(
+    verifyRegistryRelease({
+      expected,
+      operations: fixture.operations,
+      installAttempts: 2,
+      retryDelayMs: 0,
+      sensitiveValues: [secret],
+    }),
+    (error) => {
+      assert.ok(error instanceof ReleaseTransientError);
+      assert.match(error.message, /attempt 1: first \*\*\*/);
+      assert.match(error.message, /attempt 2: second \*\*\*/);
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    },
+  );
+  assert.deepEqual(fixture.cleaned, fixture.roots);
+});
+
+test("keeps Registry verification between npm publish and GitHub Release creation", () => {
+  const workflow = readFileSync(path.join(repositoryRoot, ".github/workflows/qveris-plugin-publish.yml"), "utf8");
+  const publishIndex = workflow.indexOf("- name: Publish to npm");
+  const registryIndex = workflow.indexOf("- name: Verify published npm artifact with OpenClaw");
+  const releaseIndex = workflow.indexOf("- name: Create GitHub Release");
+
+  assert.ok(publishIndex >= 0);
+  assert.ok(registryIndex > publishIndex);
+  assert.ok(releaseIndex > registryIndex);
+  assert.match(
+    workflow.slice(registryIndex, releaseIndex),
+    /check:runtime:registry -- --expected-git-head "\$GITHUB_SHA"/,
+  );
+});


### PR DESCRIPTION
## Summary

- add a post-publish npm Registry verification gate for the OpenClaw plugin
- require the exact published version, integrity metadata, and `gitHead`
- install the exact Registry version through `openclaw plugins install ... --pin` in fresh isolated state
- verify the managed lock integrity, loaded status, manifest/registration metadata, and concrete compiled-factory tool descriptors
- retry only transient Registry/install failures and fail closed on contract or provenance drift
- run publishing and verification as separate jobs, keeping GitHub Release creation after the Registry gate

## Root cause

The publish workflow verified a locally packed tarball before `npm publish`, then created the GitHub Release without exercising the artifact consumers receive from the npm Registry. A local source or tarball check could therefore pass while Registry propagation, provenance, package contents, or the official OpenClaw installation path was broken.

Deep review also found three recovery/semantic gaps in the first implementation:

- a post-publish failure could not be safely retried because rerunning the same job attempted the immutable `npm publish` step again;
- OpenClaw inspection exposed registration declarations, not the concrete descriptors instantiated by the installed compiled factory.
- the first job split relied on `GITHUB_ENV` crossing jobs, which would have produced a GitHub Release with an empty version.

## Safety and recovery

- each install attempt uses a new isolated OpenClaw state directory
- failed attempts are cleaned before retrying
- the public npm Registry is fixed explicitly for metadata and installation
- version, source commit, downloaded lock integrity, installed root, package identity, and runtime contract mismatches are non-retryable
- failed verification/Release jobs can be rerun without rerunning the successful publish job
- the verification job independently revalidates and loads the tag/package version
- publish receives only `contents: read` plus OIDC; only the Release job receives `contents: write`
- command diagnostics redact synthetic and configured credential values
- the smoke uses only a synthetic QVeris key and makes no paid QVeris calls

## Validation

- 29 Registry-release fault-injection, tamper, cleanup, compiled-runtime, and workflow-order tests
- real npm Registry smoke against `@qverisai/qveris@2026.7.30` with OpenClaw `2026.7.1-2`
- OpenClaw plugin: 79 tests, typecheck, lint, coverage, and 19-file pack check
- full monorepo: CLI 134, MCP 181, JavaScript SDK 67, Python SDK 183 passed / 1 skipped, release tooling 42
- full monorepo typecheck, build, and lint
- current-head GitHub Actions matrix passed on Ubuntu and Windows: https://github.com/QVerisAI/qveris-agent-toolkit/actions/runs/30523104885
- public documentation boundary scan

Closes #282
