### PR TITLE
docs: expand desktop agent MCP setup

### DIFF
--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -216,11 +216,26 @@ Save it as `.cursor/rules/qveris.mdc` in the project root.
 **Step 1: MCP Server Configuration**
 Use the client's MCP settings to add the standard STDIO server below. This applies to TRAE, Cline, Roo Code, Continue, Kiro, Junie, Augment, Google Antigravity, Qoder, CodeBuddy, and WorkBuddy.
 
-- **GitHub Copilot in VS Code:** add the server beneath the `servers` object in VS Code's `mcp.json`, not directly beneath `mcpServers`.
+- **GitHub Copilot in VS Code:** its `mcp.json` uses a top-level `servers` object, not `mcpServers`. For the Hosted MCP connection, use the endpoint from the QVeris Hosted MCP guide and the same `Authorization: Bearer YOUR_QVERIS_API_KEY` header. For the local stdio fallback, use this complete `mcp.json` shape:
+
+```json
+{
+  "servers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "YOUR_QVERIS_API_KEY"
+      }
+    }
+  }
+}
+```
+
 - **Zed:** create a custom server in the MCP settings and enter the command, arguments, and environment variables as fields rather than pasting a JSON file.
 - **TRAE:** its file is typically `~/.trae/mcp.json` or `%USERPROFILE%\.trae\mcp.json`.
 
-Add the standard MCP server configuration to the `mcpServers` object:
+For the other clients, add the standard MCP server configuration to the `mcpServers` object:
 ```json
 "qveris": {
   "command": "npx",

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -84,7 +84,7 @@ Skip to **Section 3: Verify Installation** once `qveris doctor` passes all check
 
 ### Option B: MCP Server Setup
 
-Detect which coding tool or environment you are currently running in (e.g., Claude Code, OpenCode, Cursor, Cherry Studio, Trae, VS Code).
+Detect which MCP-capable desktop client you are currently running in. QVeris supports Claude Code, ChatGPT (Codex), OpenCode, Cursor, Cherry Studio, TRAE, GitHub Copilot, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, and WorkBuddy.
 
 **Configuration involves two steps for all environments:**
 1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.0) to your environment.
@@ -132,7 +132,20 @@ Save it to:
 - Mac/Linux: `~/.claude/skills/qveris/SKILL.md`
 - Windows: `%USERPROFILE%\.claude\skills\qveris\SKILL.md`
 
-#### B. OpenCode
+#### B. ChatGPT (Codex)
+
+The ChatGPT desktop app, Codex CLI, and Codex IDE extension share the same local MCP configuration. Run:
+
+```bash
+codex mcp add qveris --env QVERIS_API_KEY=YOUR_QVERIS_API_KEY -- npx -y @qverisai/mcp
+```
+
+This adds the server to `~/.codex/config.toml`. You can also add the same STDIO server from **Settings → MCP servers** in the desktop app or IDE extension. ChatGPT on the web cannot read local STDIO configuration.
+
+**Skill Configuration**
+Download the skill definition file and save it to `~/.agents/skills/qveris/SKILL.md`, then restart the client if it does not appear.
+
+#### C. OpenCode
 
 **Step 1: MCP Server Configuration**
 Edit the user configuration file at `~/.config/opencode/opencode.json` (Mac/Linux) or `%USERPROFILE%\.config\opencode\opencode.json` (Windows).
@@ -164,7 +177,7 @@ Save it to:
 - Mac/Linux: `~/.config/opencode/skill/qveris/SKILL.md`
 - Windows: `%USERPROFILE%\.config\opencode\skill\qveris\SKILL.md`
 
-#### C. Cursor
+#### D. Cursor
 
 **Step 1: MCP Server Configuration**
 Locate the MCP settings file: `~/.cursor/mcp.json` (Mac/Linux) or `%USERPROFILE%\.cursor\mcp.json` (Windows).
@@ -187,11 +200,14 @@ Download the skill definition file from:
 
 Save it as `.cursor/rules/qveris.mdc` in the project root.
 
-#### D. Other Environments (Trae, VSCode etc.)
+#### E. Other Desktop MCP Clients
 
 **Step 1: MCP Server Configuration**
-First figure out the MCP configuration file for your specific coding tool.
-- **Trae:** Typically `~/.trae/mcp.json` or `%USERPROFILE%\.trae\mcp.json`.
+Use the client's MCP settings to add the standard STDIO server below. This applies to TRAE, Cline, Roo Code, Continue, Kiro, Junie, Augment, Google Antigravity, Qoder, CodeBuddy, and WorkBuddy.
+
+- **GitHub Copilot in VS Code:** add the server beneath the `servers` object in VS Code's `mcp.json`, not directly beneath `mcpServers`.
+- **Zed:** create a custom server in the MCP settings and enter the command, arguments, and environment variables as fields rather than pasting a JSON file.
+- **TRAE:** its file is typically `~/.trae/mcp.json` or `%USERPROFILE%\.trae\mcp.json`.
 
 Add the standard MCP server configuration to the `mcpServers` object:
 ```json
@@ -208,7 +224,7 @@ Add the standard MCP server configuration to the `mcpServers` object:
 If the environment supports rule or skill files, add the file from:
 `https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/skills/qveris/SKILL.md`
 
-#### E. Cherry Studio
+#### F. Cherry Studio
 
 Open **Settings → MCP Server** in [Cherry Studio](https://cherryai.com/) and add a server with these values:
 
@@ -226,7 +242,7 @@ Open **Settings → MCP Server** in [Cherry Studio](https://cherryai.com/) and a
 
 Save the server, enable it in the conversation, and confirm that `discover`, `inspect`, `probe`, and `call` are available.
 
-#### F. OpenClaw
+#### G. OpenClaw
 
 OpenClaw supports two integration methods. The Plugin method is recommended for full functionality.
 

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -28,7 +28,7 @@ Before configuring QVeris, ensure the runtime environment is ready.
 **Note:** On Windows, use **cmd**, not PowerShell, for setup commands.
 
 ### Node.js
-The QVeris MCP server requires Node.js.
+Node.js is required only for the CLI and local stdio MCP fallback. Do not require it for Hosted MCP.
 1. Check if `node` is installed by running `node --version`.
 2. **If Node.js is NOT installed:**
    - Attempt to install it using the system's package manager (e.g., `winget install OpenJS.NodeJS` on Windows, `brew install node` on macOS, or `apt install nodejs` on Linux).
@@ -36,12 +36,13 @@ The QVeris MCP server requires Node.js.
 
 ## 2. Choose Integration Method
 
-QVeris supports two integration methods. Choose based on your environment:
+QVeris supports three integration methods. Prefer Hosted MCP whenever your client supports remote Streamable HTTP.
 
 | Method | Best For | How It Works |
 |--------|----------|--------------|
+| **Hosted MCP Server** (recommended) | Remote-MCP clients and browser-based agents | One HTTPS endpoint — no local process, Node.js, or package install |
 | **CLI** (recommended) | Agents with shell access (Claude Code, OpenClaw, terminals) | Subprocess calls — zero prompt tokens, 10,000+ real-world, verified tools without bloat |
-| **MCP Server** | MCP clients (Cursor, Claude Desktop, Cherry Studio, OpenCode) | MCP protocol — tools injected into agent context |
+| **Local MCP Server** (fallback) | Clients that require stdio | Local MCP process — tools injected into agent context |
 
 ### Option A: CLI Setup (Recommended for shell-capable agents)
 
@@ -82,7 +83,17 @@ qveris credits   # Check credit balance
 
 Skip to **Section 3: Verify Installation** once `qveris doctor` passes all checks.
 
-### Option B: MCP Server Setup
+### Option B: Hosted MCP Setup (Recommended for remote-capable clients)
+
+Hosted MCP is the preferred MCP connection because it avoids a local Node.js process and package install. Open the Hosted MCP guide on the QVeris site that issued the API key, copy that deployment's endpoint, and add it as a **Streamable HTTP** server with:
+
+```text
+Authorization: Bearer YOUR_QVERIS_API_KEY
+```
+
+Reconnect the client and confirm `discover`, `inspect`, `probe`, and `call` are available. If the client supports only local stdio MCP, continue with Option C.
+
+### Option C: Local MCP Server Setup (Fallback)
 
 Detect which MCP-capable desktop client you are currently running in. QVeris supports Claude Code, ChatGPT (Codex), OpenCode, Cursor, Cherry Studio, TRAE, GitHub Copilot, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, and WorkBuddy.
 

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -142,15 +142,15 @@ Save it to:
 - Mac/Linux: `~/.claude/skills/qveris/SKILL.md`
 - Windows: `%USERPROFILE%\.claude\skills\qveris\SKILL.md`
 
-#### B. ChatGPT (Codex)
+#### B. ChatGPT Desktop and Codex
 
-The ChatGPT desktop app, Codex CLI, and Codex IDE extension share the same local MCP configuration. Run:
+For ChatGPT Desktop, prefer the Hosted MCP connection in Option B: add the QVeris endpoint as a **Streamable HTTP** server with the `Authorization: Bearer YOUR_QVERIS_API_KEY` header. The local STDIO fallback below is for the shared ChatGPT Desktop, Codex CLI, and Codex IDE MCP configuration.
 
 ```bash
 codex mcp add qveris --env QVERIS_API_KEY=YOUR_QVERIS_API_KEY -- npx -y @qverisai/mcp
 ```
 
-This adds the server to `~/.codex/config.toml`. You can also add the same STDIO server from **Settings → MCP servers** in the desktop app or IDE extension. ChatGPT on the web cannot read local STDIO configuration.
+This adds the server to `~/.codex/config.toml`. You can also add the same STDIO server from **Settings → MCP servers** in the desktop app or IDE extension. ChatGPT on the web cannot read local MCP configuration.
 
 **Skill Configuration**
 Download the skill definition file and save it to `~/.agents/skills/qveris/SKILL.md`, then restart the client if it does not appear.
@@ -164,20 +164,18 @@ Add or merge this JSON structure:
 ```json
 {
   "mcp": {
-    "qveris": {
-      "type": "local",
-      "command": ["npx", "-y", "@qverisai/mcp"],
-      "environment": { "QVERIS_API_KEY": "YOUR_QVERIS_API_KEY" },
-      "enabled": true
+    "servers": {
+      "qveris": {
+        "type": "local",
+        "command": ["npx", "-y", "@qverisai/mcp"],
+        "environment": { "QVERIS_API_KEY": "YOUR_QVERIS_API_KEY" }
+      }
     }
-  },
-  "tools": {
-    "qveris*": true
   }
 }
 ```
 
-> **Important:** The `tools` section is **required**. OpenCode connects MCP servers but **disables their tools by default**. Without `"tools": { "qveris*": true }`, the MCP server will show as connected but all `qveris_*` tools will be unavailable. The wildcard pattern `qveris*` enables all tools whose names start with `qveris`.
+> **OpenCode V2:** MCP tools are available automatically once the server is connected; do not add a separate `tools` allowlist.
 
 **Step 2: Skill Configuration**
 Download the skill definition file from:

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -226,7 +226,7 @@ If the environment supports rule or skill files, add the file from:
 
 #### F. Cherry Studio
 
-Open **Settings → MCP Server** in [Cherry Studio](https://cherryai.com/) and add a server with these values:
+Open **Settings → MCP Server** in [Cherry Studio](https://cherry-ai.com/) and add a server with these values:
 
 ```json
 {

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -27,13 +27,6 @@ Before configuring QVeris, ensure the runtime environment is ready.
 
 **Note:** On Windows, use **cmd**, not PowerShell, for setup commands.
 
-### Node.js
-Node.js is required only for the CLI and local stdio MCP fallback. Do not require it for Hosted MCP.
-1. Check if `node` is installed by running `node --version`.
-2. **If Node.js is NOT installed:**
-   - Attempt to install it using the system's package manager (e.g., `winget install OpenJS.NodeJS` on Windows, `brew install node` on macOS, or `apt install nodejs` on Linux).
-   - If you cannot install it automatically, stop and ask the user to install Node.js (LTS version recommended).
-
 ## 2. Choose Integration Method
 
 QVeris supports three integration methods. Prefer Hosted MCP whenever your client supports remote Streamable HTTP.
@@ -43,6 +36,12 @@ QVeris supports three integration methods. Prefer Hosted MCP whenever your clien
 | **Hosted MCP Server** (recommended) | Remote-MCP clients and browser-based agents | One HTTPS endpoint — no local process, Node.js, or package install |
 | **CLI** (recommended) | Agents with shell access (Claude Code, OpenClaw, terminals) | Subprocess calls — zero prompt tokens, 10,000+ real-world, verified tools without bloat |
 | **Local MCP Server** (fallback) | Clients that require stdio | Local MCP process — tools injected into agent context |
+
+### Node.js prerequisite (CLI and Local MCP only)
+
+Skip this section when the selected method is Hosted MCP. Before following the CLI or Local MCP instructions, check whether `node` is installed with `node --version`.
+
+If Node.js is not installed, attempt to install it with the system package manager (for example, `winget install OpenJS.NodeJS` on Windows, `brew install node` on macOS, or `apt install nodejs` on Linux). If installation is not possible, stop and ask the user to install a current LTS version.
 
 ### Option A: CLI Setup (Recommended for shell-capable agents)
 

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -41,7 +41,7 @@ QVeris supports two integration methods. Choose based on your environment:
 | Method | Best For | How It Works |
 |--------|----------|--------------|
 | **CLI** (recommended) | Agents with shell access (Claude Code, OpenClaw, terminals) | Subprocess calls — zero prompt tokens, 10,000+ real-world, verified tools without bloat |
-| **MCP Server** | IDE integrations (Cursor, Claude Desktop, OpenCode) | MCP protocol — tools injected into agent context |
+| **MCP Server** | MCP clients (Cursor, Claude Desktop, Cherry Studio, OpenCode) | MCP protocol — tools injected into agent context |
 
 ### Option A: CLI Setup (Recommended for shell-capable agents)
 
@@ -84,12 +84,14 @@ Skip to **Section 3: Verify Installation** once `qveris doctor` passes all check
 
 ### Option B: MCP Server Setup
 
-Detect which coding tool or environment you are currently running in (e.g., Claude Code, OpenCode, Cursor, Trae, VS Code).
+Detect which coding tool or environment you are currently running in (e.g., Claude Code, OpenCode, Cursor, Cherry Studio, Trae, VS Code).
 
 **Configuration involves two steps for all environments:**
 1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.0) to your environment.
 2. **Skill Configuration:** Teaches the agent how to use the tools using the MCP/client skill definition file.
    - **Skill URL:** `https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/skills/qveris/SKILL.md`
+
+> Cherry Studio uses the MCP server configuration only; it does not require a separate QVeris client skill file.
 
 **General Rule:**
 - **Prefer User/Global Scope:** Configure QVeris globally so it works across all projects.
@@ -206,7 +208,25 @@ Add the standard MCP server configuration to the `mcpServers` object:
 If the environment supports rule or skill files, add the file from:
 `https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/skills/qveris/SKILL.md`
 
-#### E. OpenClaw
+#### E. Cherry Studio
+
+Open **Settings → MCP Server** in [Cherry Studio](https://cherryai.com/) and add a server with these values:
+
+```json
+{
+  "name": "QVeris",
+  "command": "npx",
+  "args": ["-y", "@qverisai/mcp"],
+  "env": {
+    "QVERIS_API_KEY": "YOUR_QVERIS_API_KEY"
+  },
+  "disabledTools": []
+}
+```
+
+Save the server, enable it in the conversation, and confirm that `discover`, `inspect`, `probe`, and `call` are available.
+
+#### F. OpenClaw
 
 OpenClaw supports two integration methods. The Plugin method is recommended for full functionality.
 

--- a/agent/llms-full.txt
+++ b/agent/llms-full.txt
@@ -114,12 +114,13 @@ Every capability includes:
 
 ## Integration Methods
 
-QVeris supports five integration methods:
+QVeris supports six integration methods:
 
 | Method | Use Case | Documentation |
 |--------|----------|--------------|
 | **CLI** (recommended) | Agents with shell access (Claude Code, OpenClaw, terminals) | https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/packages/cli/README.md |
-| **MCP Server** | Cursor / Claude Desktop / Any MCP client | https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/mcp-server.md |
+| **Hosted MCP** (recommended) | Remote Streamable HTTP MCP clients | Hosted MCP guide on the QVeris site that issued the API key |
+| **Local MCP Server** (fallback) | stdio-only MCP clients | https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/mcp-server.md |
 | **JavaScript SDK** | TypeScript/JavaScript projects, Agent frameworks | https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/js-sdk |
 | **Python SDK** | Python projects, Agent frameworks | https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk |
 | **REST API** | Any language, Custom integrations | https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/rest-api.md |

--- a/agent/llms.txt
+++ b/agent/llms.txt
@@ -28,8 +28,9 @@
 - They are runtime + capability routing network, complementary not competing
 
 ## Access methods (recommended order)
-- CLI v0.11.0 (recommended for agents): npm install -g @qverisai/cli — zero prompt tokens, deterministic output, 10,000+ tools without prompt bloat
-- MCP Server v0.14.0: npx @qverisai/mcp — for IDE integrations (Cursor, Claude Desktop, OpenCode)
+- Hosted MCP (recommended for remote-capable MCP clients): open /hosted-mcp on the QVeris site that issued the API key for the correct Streamable HTTP endpoint and Bearer authentication setup — no local process, Node.js, or package install
+- CLI v0.11.0 (recommended for shell-capable agents): npm install -g @qverisai/cli — zero prompt tokens, deterministic output, 10,000+ tools without prompt bloat
+- MCP Server v0.14.0 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
 - JavaScript SDK v0.8.0: npm install @qverisai/sdk
 - Python SDK v0.7.0: pip install qveris
 - REST API: https://qveris.ai/api/v1

--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -381,7 +381,7 @@ console.log(data);
 
 如果你正在配置 AI 编程助手（Cursor、OpenCode、Trae 等），可以将 [Agent 安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给 Agent。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
 
-支持的环境：OpenCode、Cursor、Trae、VS Code、OpenClaw。
+支持的环境：OpenCode、Cursor、Cherry Studio、Trae、VS Code、OpenClaw。
 
 ---
 

--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -46,15 +46,31 @@ CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen 
 
 ### 通过 MCP 使用 QVeris
 
-如果你的客户端支持 **Model Context Protocol (MCP)**，可以添加官方 QVeris MCP 服务器，立即获得：
+如果你的客户端支持 **Model Context Protocol (MCP)** 和远程 Streamable HTTP，应优先使用托管 MCP。它无需本地软件包或 Node.js 进程，立即获得：
 
 - `discover`（发现）
 - `inspect`（检查）
 - `call`（调用）
 
-完整 MCP 参考文档见 [MCP 服务器文档](mcp-server.md)。
+完整 MCP 参考文档见 [MCP 服务器文档](mcp-server.md) 或[托管 MCP 指南](https://qveris.cn/hosted-mcp)。
 
-**配置方式（Cursor / 任意 MCP 客户端）**
+**托管 MCP 配置（首选）**
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+**本地 stdio 备用方案（仅适用于不支持远程 HTTP 的客户端）**
 
 ```json
 {

--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -379,9 +379,9 @@ console.log(data);
 
 ### 在 AI Agent 中安装 QVeris
 
-如果你正在配置 AI 编程助手（Cursor、OpenCode、Trae 等），可以将 [Agent 安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给 Agent。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
+如果你正在配置 AI 编程助手或桌面端 Agent（Cursor、GitHub Copilot、Cline、Roo Code、Continue、Kiro、Junie、Augment、Zed、Google Antigravity、Qoder、CodeBuddy、WorkBuddy、OpenCode、TRAE 等），可以将 [Agent 安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给 Agent。它会自动检测运行环境，并完成可用 MCP 服务器和技能定义的配置。
 
-支持的环境：OpenCode、Cursor、Cherry Studio、Trae、VS Code、OpenClaw。
+支持 MCP 的桌面端客户端包括：Cursor、GitHub Copilot、Cherry Studio、Cline、Roo Code、Continue、Kiro、Junie、Augment、Zed、Google Antigravity、Qoder、CodeBuddy、WorkBuddy、OpenCode、TRAE、Windsurf 和 VS Code。
 
 ---
 

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -116,7 +116,7 @@ qveris mcp validate --target cursor --probe
 
 ### Cherry Studio 配置示例
 
-在 [Cherry Studio](https://cherryai.com/) 中打开**设置 → MCP 服务器**，新增服务器后将以下内容填入对应配置字段：
+在 [Cherry Studio](https://cherry-ai.com/) 中打开**设置 → MCP 服务器**，新增服务器后将以下内容填入对应配置字段：
 
 ```json
 {

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -48,15 +48,37 @@
 
 ## 环境要求
 
-- Node.js `18+`
 - 有效的 `QVERIS_API_KEY`
 - MCP 兼容客户端
+- 仅在使用本地 stdio 备用方案时需要 Node.js `18+`
 
 ---
 
 ## 快速开始
 
-### 通过 `npx` 安装
+### 托管 MCP（推荐）
+
+只要客户端支持远程 Streamable HTTP，就应优先使用托管 MCP。它使用一个受管端点和 Bearer 认证，无需维护本地软件包、Node.js 进程或服务器生命周期。
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_QVERIS_API_KEY"
+      }
+    }
+  }
+}
+```
+
+可前往[托管 MCP 页面](https://qveris.cn/hosted-mcp)复制端点并查看各客户端的配置说明。只有当客户端不支持远程 Streamable HTTP 时，才使用下方本地 stdio 备用方案。
+
+### 本地 stdio 备用方案
+
+#### 通过 `npx` 安装
 
 ```bash
 npx -y @qverisai/mcp
@@ -69,7 +91,7 @@ QVERIS_API_KEY=your-api-key          # 必填
 QVERIS_BASE_URL=https://qveris.cn/api/v1  # 必填：设置 API 地址
 ```
 
-### 使用 QVeris CLI 配置
+#### 使用 QVeris CLI 配置
 
 可以用 CLI 生成客户端配置，无需手写 JSON。默认会打印带有 `YOUR_QVERIS_API_KEY` 占位符的安全配置；占位符输出会故意无法通过 API key 校验，直到你替换占位符或使用 `--include-key`。
 
@@ -135,9 +157,9 @@ qveris mcp validate --target cursor --probe
 
 ### 桌面端 Agent 客户端
 
-除上文客户端外，以下桌面端 Agent 也可通过本地 stdio MCP 使用 QVeris：**GitHub Copilot**、**Cline**、**Roo Code**、**Continue**、**Kiro**、**Junie**、**Augment**、**Zed**、**Google Antigravity**、**Qoder**、**CodeBuddy** 和 **WorkBuddy**。
+除上文客户端外，以下桌面端 Agent 在支持远程 Streamable HTTP 时应优先使用托管 MCP，本地 stdio 仅作为备用方案：**GitHub Copilot**、**Cline**、**Roo Code**、**Continue**、**Kiro**、**Junie**、**Augment**、**Zed**、**Google Antigravity**、**Qoder**、**CodeBuddy** 和 **WorkBuddy**。
 
-请在 MCP 设置中导入以下标准配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
+对于仅支持本地 stdio 的客户端，请在 MCP 设置中导入以下备用配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
 
 ```json
 {
@@ -162,9 +184,9 @@ qveris mcp validate --target cursor --probe
 
 ---
 
-## Hosted MCP
+## 托管 MCP 详细说明
 
-QVeris 提供远程 Streamable HTTP MCP 托管服务，无需安装本地软件包或运行后台进程。如果端点暂时不可用，请在托管服务发布完成前继续使用上文的本地 stdio 软件包。
+QVeris 提供远程 Streamable HTTP MCP 托管服务。对于支持它的客户端，这是首选 MCP 连接方式：无需安装本地软件包或运行后台进程。
 
 ```text
 https://mcp.qveris.cn/mcp

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## 简介
 
-`@qverisai/mcp` 是面向 Cursor 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
+`@qverisai/mcp` 是面向 Cursor、Cherry Studio 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
 `@qverisai/mcp` v0.14.0 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
 
@@ -21,7 +21,7 @@
 
 **适合使用 MCP 服务器的场景：**
 
-- 将 QVeris 集成到 Cursor、OpenCode 或其他 MCP 客户端
+- 将 QVeris 集成到 Cursor、Cherry Studio、OpenCode 或其他 MCP 客户端
 - 希望 Agent 在对话中直接调用 QVeris 工具
 - 希望客户端自动管理工具调用
 
@@ -113,6 +113,25 @@ qveris mcp validate --target cursor --probe
   }
 }
 ```
+
+### Cherry Studio 配置示例
+
+在 [Cherry Studio](https://cherryai.com/) 中打开**设置 → MCP 服务器**，新增服务器后将以下内容填入对应配置字段：
+
+```json
+{
+  "name": "QVeris",
+  "command": "npx",
+  "args": ["-y", "@qverisai/mcp"],
+  "env": {
+    "QVERIS_API_KEY": "your-api-key-here",
+    "QVERIS_BASE_URL": "https://qveris.cn/api/v1"
+  },
+  "disabledTools": []
+}
+```
+
+保存服务器，在对话中启用它，并确认可见 `discover`、`inspect`、`probe` 和 `call`。
 
 各环境的详细配置指南，请参考：
 

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## 简介
 
-`@qverisai/mcp` 是面向 Cursor、Cherry Studio 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
+`@qverisai/mcp` 是面向 Cursor、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
 `@qverisai/mcp` v0.14.0 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
 
@@ -21,7 +21,7 @@
 
 **适合使用 MCP 服务器的场景：**
 
-- 将 QVeris 集成到 Cursor、Cherry Studio、OpenCode 或其他 MCP 客户端
+- 将 QVeris 集成到 Cursor、Cherry Studio、GitHub Copilot、Cline、Roo Code、Continue、Kiro、Junie、Augment、Zed、Google Antigravity、Qoder、CodeBuddy、WorkBuddy、OpenCode 或其他 MCP 客户端
 - 希望 Agent 在对话中直接调用 QVeris 工具
 - 希望客户端自动管理工具调用
 
@@ -132,6 +132,27 @@ qveris mcp validate --target cursor --probe
 ```
 
 保存服务器，在对话中启用它，并确认可见 `discover`、`inspect`、`probe` 和 `call`。
+
+### 桌面端 Agent 客户端
+
+除上文客户端外，以下桌面端 Agent 也可通过本地 stdio MCP 使用 QVeris：**GitHub Copilot**、**Cline**、**Roo Code**、**Continue**、**Kiro**、**Junie**、**Augment**、**Zed**、**Google Antigravity**、**Qoder**、**CodeBuddy** 和 **WorkBuddy**。
+
+请在 MCP 设置中导入以下标准配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "your-api-key-here",
+        "QVERIS_BASE_URL": "https://qveris.cn/api/v1"
+      }
+    }
+  }
+}
+```
 
 各环境的详细配置指南，请参考：
 

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -159,11 +159,46 @@ qveris mcp validate --target cursor --probe
 
 除上文客户端外，以下桌面端 Agent 在支持远程 Streamable HTTP 时应优先使用托管 MCP，本地 stdio 仅作为备用方案：**GitHub Copilot**、**Cline**、**Roo Code**、**Continue**、**Kiro**、**Junie**、**Augment**、**Zed**、**Google Antigravity**、**Qoder**、**CodeBuddy** 和 **WorkBuddy**。
 
-对于仅支持本地 stdio 的客户端，请在 MCP 设置中导入以下备用配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
+对于 GitHub Copilot 以外的仅支持本地 stdio 的客户端，请在 MCP 设置中导入以下备用配置。Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
 
 ```json
 {
   "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "your-api-key-here",
+        "QVERIS_BASE_URL": "https://qveris.cn/api/v1"
+      }
+    }
+  }
+}
+```
+
+#### VS Code 中的 GitHub Copilot
+
+GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServers`。请优先使用以下托管 MCP 配置：
+
+```json
+{
+  "servers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+如果客户端环境不能使用远程 HTTP，请保留同一 `servers` 外层键，改用以下本地 stdio 条目：
+
+```json
+{
+  "servers": {
     "qveris": {
       "command": "npx",
       "args": ["-y", "@qverisai/mcp"],

--- a/docs/cn/zh-CN/opencode-setup.md
+++ b/docs/cn/zh-CN/opencode-setup.md
@@ -32,6 +32,24 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 
 重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
 
+上例是 OpenCode V2 的 `mcp.servers` 格式。如果已安装的 OpenCode 使用的是直接放在 `mcp` 下的服务名称，请使用下面兼容的直接格式，勿混用两种层级：
+
+```json
+{
+  "mcp": {
+    "qveris": {
+      "type": "remote",
+      "url": "https://mcp.qveris.cn/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
 ## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成并写入配置：
@@ -43,6 +61,28 @@ qveris mcp validate --target opencode
 ```
 
 也可以手动配置：
+
+对于 OpenCode V2，请保留上文的 `mcp.servers` 对象，并使用以下本地服务条目：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "qveris": {
+        "type": "local",
+        "command": ["npx", "-y", "@qverisai/mcp"],
+        "environment": {
+          "QVERIS_API_KEY": "your-api-key-here",
+          "QVERIS_BASE_URL": "https://qveris.cn/api/v1"
+        }
+      }
+    }
+  }
+}
+```
+
+对于直接 `mcp` 格式，请使用 QVeris CLI 的输出或下列手动配置：
 
 创建或编辑全局 OpenCode 配置文件：
 
@@ -78,7 +118,7 @@ qveris mcp validate --target opencode
 }
 ```
 
-如果已有 `opencode.json` 文件，请将 `mcp.qveris` 和 `tools["qveris*"]` 部分合并到现有配置中。
+如果已有 `opencode.json` 文件，请合并 V2 的 `mcp.servers.qveris` 条目，或直接格式的 `mcp.qveris` 与 `tools["qveris*"]` 部分。不要将一种格式嵌套到另一种格式内。
 
 ## 3. 技能配置
 

--- a/docs/cn/zh-CN/opencode-setup.md
+++ b/docs/cn/zh-CN/opencode-setup.md
@@ -16,6 +16,26 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
+    "qveris": {
+      "type": "remote",
+      "url": "https://mcp.qveris.cn/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
+
+上例是 QVeris CLI 生成的直接 `mcp.qveris` 配置。如果已安装的 OpenCode 使用 OpenCode V2 的 `mcp.servers` 格式，请使用以下兼容配置，勿混用两种层级：
+
+```json
+{
+  "mcp": {
     "servers": {
       "qveris": {
         "type": "remote",
@@ -25,26 +45,6 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
           "Authorization": "Bearer your-api-key-here"
         }
       }
-    }
-  }
-}
-```
-
-重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
-
-上例是 OpenCode V2 的 `mcp.servers` 格式。如果已安装的 OpenCode 使用的是直接放在 `mcp` 下的服务名称，请使用下面兼容的直接格式，勿混用两种层级：
-
-```json
-{
-  "mcp": {
-    "qveris": {
-      "type": "remote",
-      "url": "https://mcp.qveris.cn/mcp",
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer your-api-key-here"
-      },
-      "enabled": true
     }
   }
 }
@@ -60,7 +60,27 @@ qveris mcp configure --target opencode --write --include-key
 qveris mcp validate --target opencode
 ```
 
-也可以手动配置：
+也可以手动配置。QVeris CLI 目标会写入下面的直接 `mcp` 格式：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "qveris": {
+      "type": "local",
+      "command": ["npx", "-y", "@qverisai/mcp"],
+      "environment": {
+        "QVERIS_API_KEY": "your-api-key-here",
+        "QVERIS_BASE_URL": "https://qveris.cn/api/v1"
+      },
+      "enabled": true
+    }
+  },
+  "tools": {
+    "qveris*": true
+  }
+}
+```
 
 对于 OpenCode V2，请保留上文的 `mcp.servers` 对象，并使用以下本地服务条目：
 
@@ -82,8 +102,6 @@ qveris mcp validate --target opencode
 }
 ```
 
-对于直接 `mcp` 格式，请使用 QVeris CLI 的输出或下列手动配置：
-
 创建或编辑全局 OpenCode 配置文件：
 
 **Mac/Linux：**
@@ -94,28 +112,6 @@ qveris mcp validate --target opencode
 **Windows：**
 ```
 %USERPROFILE%\.config\opencode\opencode.json
-```
-
-添加以下内容（将 `your-api-key-here` 替换为你的实际 API 密钥）：
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "qveris": {
-      "type": "local",
-      "command": ["npx", "-y", "@qverisai/mcp"],
-      "environment": {
-        "QVERIS_API_KEY": "your-api-key-here",
-        "QVERIS_BASE_URL": "https://qveris.cn/api/v1"
-      },
-      "enabled": true
-    }
-  },
-  "tools": {
-    "qveris*": true
-  }
-}
 ```
 
 如果已有 `opencode.json` 文件，请合并 V2 的 `mcp.servers.qveris` 条目，或直接格式的 `mcp.qveris` 与 `tools["qveris*"]` 部分。不要将一种格式嵌套到另一种格式内。

--- a/docs/cn/zh-CN/opencode-setup.md
+++ b/docs/cn/zh-CN/opencode-setup.md
@@ -16,26 +16,6 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "qveris": {
-      "type": "remote",
-      "url": "https://mcp.qveris.cn/mcp",
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer your-api-key-here"
-      },
-      "enabled": true
-    }
-  }
-}
-```
-
-重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
-
-上例是 QVeris CLI 生成的直接 `mcp.qveris` 配置。如果已安装的 OpenCode 使用 OpenCode V2 的 `mcp.servers` 格式，请使用以下兼容配置，勿混用两种层级：
-
-```json
-{
-  "mcp": {
     "servers": {
       "qveris": {
         "type": "remote",
@@ -50,6 +30,10 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 }
 ```
 
+重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
+
+OpenCode V2 会在 `mcp.servers` 下发现具名 MCP 服务器，并自动暴露其工具，因此不需要额外的 `tools` 允许列表。
+
 ## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成并写入配置：
@@ -60,29 +44,7 @@ qveris mcp configure --target opencode --write --include-key
 qveris mcp validate --target opencode
 ```
 
-也可以手动配置。QVeris CLI 目标会写入下面的直接 `mcp` 格式：
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "qveris": {
-      "type": "local",
-      "command": ["npx", "-y", "@qverisai/mcp"],
-      "environment": {
-        "QVERIS_API_KEY": "your-api-key-here",
-        "QVERIS_BASE_URL": "https://qveris.cn/api/v1"
-      },
-      "enabled": true
-    }
-  },
-  "tools": {
-    "qveris*": true
-  }
-}
-```
-
-对于 OpenCode V2，请保留上文的 `mcp.servers` 对象，并使用以下本地服务条目：
+也可以手动配置。QVeris CLI 目标会写入下面的 OpenCode V2 格式：
 
 ```json
 {
@@ -114,7 +76,7 @@ qveris mcp validate --target opencode
 %USERPROFILE%\.config\opencode\opencode.json
 ```
 
-如果已有 `opencode.json` 文件，请合并 V2 的 `mcp.servers.qveris` 条目，或直接格式的 `mcp.qveris` 与 `tools["qveris*"]` 部分。不要将一种格式嵌套到另一种格式内。
+如果已有 `opencode.json` 文件，请将 `mcp.servers.qveris` 条目合并到现有的 `servers` 对象中。
 
 ## 3. 技能配置
 

--- a/docs/cn/zh-CN/opencode-setup.md
+++ b/docs/cn/zh-CN/opencode-setup.md
@@ -4,11 +4,35 @@
 
 ## 前置条件
 
-- 已安装 Node.js
+- 仅使用本地 stdio 备用方案时才需要安装 Node.js
 - 已安装 OpenCode（[安装指南](https://opencode.ai/docs/)）
 - QVeris API 密钥（在[控制台/API密钥](/account?page=api-keys)中创建）
 
-## 1. MCP 服务器配置
+## 1. 托管 MCP 配置（推荐）
+
+OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全局 OpenCode 配置；它无需本地软件包或 Node.js 进程：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "qveris": {
+        "type": "remote",
+        "url": "https://mcp.qveris.cn/mcp",
+        "oauth": false,
+        "headers": {
+          "Authorization": "Bearer your-api-key-here"
+        }
+      }
+    }
+  }
+}
+```
+
+重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
+
+## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成并写入配置：
 
@@ -56,7 +80,7 @@ qveris mcp validate --target opencode
 
 如果已有 `opencode.json` 文件，请将 `mcp.qveris` 和 `tools["qveris*"]` 部分合并到现有配置中。
 
-## 2. 技能配置
+## 3. 技能配置
 
 从 GitHub 仓库下载 QVeris MCP/客户端技能：
 
@@ -100,7 +124,7 @@ OpenCode 的 Agent 会自动发现 QVeris 技能和 MCP 服务器，找到并执
 
 ## 故障排查
 
-**MCP 服务器未连接：**
+**本地 stdio MCP 服务器未连接：**
 - 验证 Node.js 是否已安装：`node --version`
 - 手动测试 MCP 服务器：`npx -y @qverisai/mcp`
 - 检查 API 密钥是否正确

--- a/docs/en-US/claude-code-setup.md
+++ b/docs/en-US/claude-code-setup.md
@@ -4,11 +4,21 @@ This guide explains how to configure QVeris MCP server and skills in Claude Code
 
 ## Prerequisites
 
-- Node.js installed (for running MCP servers)
+- Node.js installed only for the local stdio fallback
 - Claude Code installed
 - QVeris API key (create one in [Dashboard / API Keys](/account?page=api-keys))
 
-## 1. MCP Server Configuration
+## 1. Hosted MCP Configuration (recommended)
+
+Claude Code supports remote HTTP MCP servers. Add QVeris as a user-scoped Streamable HTTP server with Bearer authentication:
+
+```bash
+claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --header "Authorization: Bearer your-api-key-here"
+```
+
+Restart Claude Code, run `/mcp`, and confirm that QVeris is connected. Use the local stdio fallback below only when remote HTTP is not available in the client environment.
+
+## 2. Local stdio fallback
 
 You can generate the command with QVeris CLI:
 
@@ -37,7 +47,7 @@ claude mcp get qveris    # Get details for a specific server
 claude mcp remove qveris # Remove a server
 ```
 
-## 2. Skills Configuration
+## 3. Skills Configuration
 
 Download the QVeris MCP/client skill from the GitHub repository:
 
@@ -78,7 +88,7 @@ Write a python script that prints the current bitcoin price using @.claude/skill
 
 ## Troubleshooting
 
-**MCP Server Not Connecting:**
+**Local stdio MCP Server Not Connecting:**
 - Verify Node.js is installed: `node --version`
 - Test the MCP server manually: `npx -y @qverisai/mcp`
 - Check your API key is correct

--- a/docs/en-US/codex-setup.md
+++ b/docs/en-US/codex-setup.md
@@ -4,11 +4,25 @@ This guide configures the QVeris MCP server and skill for the ChatGPT desktop ap
 
 ## Prerequisites
 
-- Node.js 18.2 or later
 - The ChatGPT desktop app, Codex CLI, or Codex IDE extension
 - A QVeris API key (create one in [Dashboard / API Keys](/account?page=api-keys))
+- Node.js 18.2 or later only for the local stdio fallback
 
-## 1. Add the QVeris MCP server
+## 1. Add Hosted MCP (recommended)
+
+The ChatGPT desktop app, Codex CLI, and Codex IDE extension support Streamable HTTP MCP servers with Bearer authentication and share the same Codex MCP configuration. Add this remote server once, then use it from any of those local clients:
+
+```toml
+[mcp_servers.qveris]
+url = "https://mcp.qveris.ai/mcp"
+http_headers = { Authorization = "Bearer your-api-key-here" }
+```
+
+You can add the same server interactively in **Settings → MCP servers**: choose **Streamable HTTP**, enter `https://mcp.qveris.ai/mcp`, and add the `Authorization: Bearer your-api-key-here` header. Restart the client after saving. See the official [MCP configuration guide](https://learn.chatgpt.com/docs/extend/mcp) for client-specific steps.
+
+## 2. Local stdio fallback
+
+Use this only when Hosted MCP is unavailable in the client environment. Run the following command in a terminal, replacing `your-api-key-here` with your API key:
 
 Run the following command in a terminal, replacing `your-api-key-here` with your API key:
 
@@ -22,7 +36,7 @@ QVeris automatically uses `https://qveris.ai/api/v1` for this setup. If you need
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
 ```
 
-The ChatGPT desktop app, Codex CLI, and IDE extension read this server from `~/.codex/config.toml`, so you only need to add it once. You can also add the same STDIO server from **Settings → MCP servers** in the desktop app or IDE extension. See the official [MCP configuration guide](https://learn.chatgpt.com/docs/extend/mcp) for client-specific steps.
+The ChatGPT desktop app, Codex CLI, and IDE extension read this server from `~/.codex/config.toml`, so you only need to add it once. You can also add the same STDIO server from **Settings → MCP servers** in the desktop app or IDE extension.
 
 ### Manual configuration
 
@@ -37,7 +51,7 @@ args = ["-y", "@qverisai/mcp"]
 QVERIS_API_KEY = "your-api-key-here"
 ```
 
-## 2. Install the QVeris skill
+## 3. Install the QVeris skill
 
 Install the QVeris skill for your user account:
 
@@ -65,7 +79,7 @@ Codex detects skills in `~/.agents/skills`. If the skill does not appear, restar
 
 ## Troubleshooting
 
-**The server does not start:**
+**The local stdio server does not start:**
 
 - Verify Node.js: `node --version`
 - Run the server directly: `QVERIS_API_KEY=your-api-key-here npx -y @qverisai/mcp`
@@ -78,4 +92,4 @@ Codex detects skills in `~/.agents/skills`. If the skill does not appear, restar
 
 **ChatGPT web does not show QVeris:**
 
-- Local `config.toml` and STDIO servers are not available to ChatGPT on the web. Use one of the local clients listed above until a hosted QVeris plugin or remote MCP integration is published.
+- ChatGPT web does not read local `config.toml` files. Use a QVeris plugin when it is available in ChatGPT Work; otherwise use the desktop app, Codex CLI, or IDE extension configured above.

--- a/docs/en-US/codex-setup.md
+++ b/docs/en-US/codex-setup.md
@@ -24,8 +24,6 @@ You can add the same server interactively in **Settings → MCP servers**: choos
 
 Use this only when Hosted MCP is unavailable in the client environment. Run the following command in a terminal, replacing `your-api-key-here` with your API key:
 
-Run the following command in a terminal, replacing `your-api-key-here` with your API key:
-
 ```bash
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here -- npx -y @qverisai/mcp
 ```

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -369,9 +369,9 @@ console.log(data);
 
 ### Set up QVeris in your AI Agent
 
-If you are configuring an AI coding agent (Claude Code, Cursor, OpenCode, Trae, etc.), you can give the [Agent Setup Guide](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) to your agent along with your API key. It will auto-detect the environment and configure both the MCP server and skill definition automatically.
+If you are configuring an AI coding agent or desktop agent (ChatGPT (Codex), Claude Code, Cursor, GitHub Copilot, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, WorkBuddy, OpenCode, TRAE, and others), you can give the [Agent Setup Guide](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) to your agent along with your API key. It will auto-detect the environment and configure the available MCP server and skill definition.
 
-Supported environments: Claude Code, OpenCode, Cursor, Cherry Studio, Trae, VS Code, and OpenClaw.
+Supported MCP desktop clients include ChatGPT (Codex), Claude Desktop, Cursor, GitHub Copilot, Cherry Studio, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, WorkBuddy, OpenCode, TRAE, Windsurf, and VS Code.
 
 ---
 

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -371,7 +371,7 @@ console.log(data);
 
 If you are configuring an AI coding agent (Claude Code, Cursor, OpenCode, Trae, etc.), you can give the [Agent Setup Guide](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) to your agent along with your API key. It will auto-detect the environment and configure both the MCP server and skill definition automatically.
 
-Supported environments: Claude Code, OpenCode, Cursor, Trae, VS Code, and OpenClaw.
+Supported environments: Claude Code, OpenCode, Cursor, Cherry Studio, Trae, VS Code, and OpenClaw.
 
 ---
 

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -45,15 +45,31 @@ The CLI also supports interactive mode (`qveris interactive`), code generation (
 
 ### Use QVeris MCP anywhere MCP is supported
 
-If your client supports **Model Context Protocol (MCP)**, you can add the official QVeris MCP server and immediately get:
+If your client supports **Model Context Protocol (MCP)** and remote Streamable HTTP, use Hosted MCP first. It requires no local package or Node.js process and immediately provides:
 
 - `discover` (Discover)
 - `inspect` (Inspect)
 - `call` (Call)
 
-For the full MCP reference, see [MCP Server documentation](mcp-server.md).
+For the full MCP reference, see [MCP Server documentation](mcp-server.md) or the [Hosted MCP guide](https://qveris.ai/hosted-mcp).
 
-**Configure (Cursor / any MCP client)**
+**Hosted MCP configuration (preferred)**
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+**Local stdio fallback (for clients without remote HTTP support)**
 
 ```json
 {

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -48,15 +48,37 @@ Both surfaces map to the same QVeris protocol:
 
 ## Requirements
 
-- Node.js `18+`
 - A valid `QVERIS_API_KEY`
 - An MCP-compatible client
+- Node.js `18+` only when using the local stdio fallback
 
 ---
 
 ## Quick Start
 
-### Install via `npx`
+### Hosted MCP (recommended)
+
+Prefer Hosted MCP whenever the client supports remote Streamable HTTP. It uses one managed endpoint and Bearer authentication, with no local package, Node.js process, or server lifecycle to maintain.
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_QVERIS_API_KEY"
+      }
+    }
+  }
+}
+```
+
+See the [Hosted MCP page](https://qveris.ai/hosted-mcp) for a copy-ready endpoint and client-specific guidance. Use the local stdio setup below only when your client does not support remote Streamable HTTP.
+
+### Local stdio fallback
+
+#### Install via `npx`
 
 ```bash
 npx -y @qverisai/mcp
@@ -69,7 +91,7 @@ QVERIS_API_KEY=your-api-key          # Required
 QVERIS_BASE_URL=https://qveris.ai/api/v1  # Optional: override API base URL
 ```
 
-### Configure with QVeris CLI
+#### Configure with QVeris CLI
 
 Use the CLI to generate client config without hand-editing JSON. By default it prints a safe config with `YOUR_QVERIS_API_KEY` placeholders; placeholder output intentionally fails API key validation until you replace it or use `--include-key`.
 
@@ -152,7 +174,7 @@ Save the server, enable it in the conversation, and confirm that `discover`, `in
 
 ### Desktop agent clients
 
-The following desktop agents support QVeris through a local stdio MCP server: **ChatGPT (Codex)**, **GitHub Copilot**, **Cline**, **Roo Code**, **Continue**, **Kiro**, **Junie**, **Augment**, **Zed**, **Google Antigravity**, **Qoder**, **CodeBuddy**, and **WorkBuddy**, alongside the clients shown above.
+The following desktop agents should use Hosted MCP when their remote Streamable HTTP connection is available, with local stdio as the fallback: **ChatGPT (Codex)**, **GitHub Copilot**, **Cline**, **Roo Code**, **Continue**, **Kiro**, **Junie**, **Augment**, **Zed**, **Google Antigravity**, **Qoder**, **CodeBuddy**, and **WorkBuddy**, alongside the clients shown above.
 
 For ChatGPT (Codex), run:
 
@@ -160,7 +182,7 @@ For ChatGPT (Codex), run:
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
 ```
 
-For the other clients, open the product's MCP settings and import the standard configuration below. GitHub Copilot uses the `servers` wrapper in its `mcp.json`; Zed exposes the same name, command, arguments, and environment fields in its Agent panel.
+For local-stdio-only clients, open the product's MCP settings and import the fallback configuration below. GitHub Copilot uses the `servers` wrapper in its `mcp.json`; Zed exposes the same name, command, arguments, and environment fields in its Agent panel.
 
 ```json
 {
@@ -187,9 +209,9 @@ For environment-specific setup guides, see:
 
 ---
 
-## Hosted MCP
+## Hosted MCP details
 
-QVeris provides a remote Streamable HTTP MCP service. It requires no local package or background process. If the endpoint is not yet available, continue using the local stdio package shown above while the hosted service rollout completes.
+QVeris provides a remote Streamable HTTP MCP service. It is the preferred MCP connection for clients that support it because it requires no local package or background process.
 
 ```text
 https://mcp.qveris.ai/mcp

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -133,7 +133,7 @@ qveris mcp validate --target cursor --probe
 
 ### Cherry Studio example
 
-In [Cherry Studio](https://cherryai.com/), open **Settings → MCP Server**, add a server, and enter these values in its configuration fields:
+In [Cherry Studio](https://cherry-ai.com/), open **Settings → MCP Server**, add a server, and enter these values in its configuration fields:
 
 ```json
 {

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -182,11 +182,46 @@ For ChatGPT (Codex), run:
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
 ```
 
-For local-stdio-only clients, open the product's MCP settings and import the fallback configuration below. GitHub Copilot uses the `servers` wrapper in its `mcp.json`; Zed exposes the same name, command, arguments, and environment fields in its Agent panel.
+For local-stdio-only clients other than GitHub Copilot, open the product's MCP settings and import the fallback configuration below. Zed exposes the same name, command, arguments, and environment fields in its Agent panel.
 
 ```json
 {
   "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "your-api-key-here",
+        "QVERIS_BASE_URL": "https://qveris.ai/api/v1"
+      }
+    }
+  }
+}
+```
+
+#### GitHub Copilot in VS Code
+
+GitHub Copilot's `mcp.json` uses a top-level `servers` object, not `mcpServers`. Use this Hosted MCP configuration first:
+
+```json
+{
+  "servers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+If the client environment cannot use remote HTTP, keep the same `servers` wrapper and use the local stdio entry instead:
+
+```json
+{
+  "servers": {
     "qveris": {
       "command": "npx",
       "args": ["-y", "@qverisai/mcp"],

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## What it is
 
-`@qverisai/mcp` is the official QVeris MCP server for MCP-compatible clients such as Cursor, Claude Desktop, Cherry Studio, and other coding agents.
+`@qverisai/mcp` is the official QVeris MCP server for MCP-compatible clients such as ChatGPT (Codex), Cursor, Claude Desktop, Cherry Studio, GitHub Copilot, Cline, Roo Code, Kiro, Qoder, CodeBuddy, WorkBuddy, and other coding agents.
 
 `@qverisai/mcp` v0.14.0 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
 
@@ -21,7 +21,7 @@ In other words, the MCP server is the agent-facing transport for the same core Q
 
 Use the MCP server when:
 
-- You are integrating QVeris into Cursor, Claude Desktop, Cherry Studio, OpenCode, or another MCP client
+- You are integrating QVeris into ChatGPT (Codex), Cursor, Claude Desktop, Cherry Studio, GitHub Copilot, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, WorkBuddy, OpenCode, or another MCP client
 - You want the agent to call QVeris tools directly in chat
 - You want the client to manage tool invocation automatically
 
@@ -149,6 +149,33 @@ In [Cherry Studio](https://cherryai.com/), open **Settings → MCP Server**, add
 ```
 
 Save the server, enable it in the conversation, and confirm that `discover`, `inspect`, `probe`, and `call` are available.
+
+### Desktop agent clients
+
+The following desktop agents support QVeris through a local stdio MCP server: **ChatGPT (Codex)**, **GitHub Copilot**, **Cline**, **Roo Code**, **Continue**, **Kiro**, **Junie**, **Augment**, **Zed**, **Google Antigravity**, **Qoder**, **CodeBuddy**, and **WorkBuddy**, alongside the clients shown above.
+
+For ChatGPT (Codex), run:
+
+```bash
+codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
+```
+
+For the other clients, open the product's MCP settings and import the standard configuration below. GitHub Copilot uses the `servers` wrapper in its `mcp.json`; Zed exposes the same name, command, arguments, and environment fields in its Agent panel.
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "your-api-key-here",
+        "QVERIS_BASE_URL": "https://qveris.ai/api/v1"
+      }
+    }
+  }
+}
+```
 
 For environment-specific setup guides, see:
 

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## What it is
 
-`@qverisai/mcp` is the official QVeris MCP server for MCP-compatible clients such as Cursor, Claude Desktop, and other coding agents.
+`@qverisai/mcp` is the official QVeris MCP server for MCP-compatible clients such as Cursor, Claude Desktop, Cherry Studio, and other coding agents.
 
 `@qverisai/mcp` v0.14.0 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
 
@@ -21,7 +21,7 @@ In other words, the MCP server is the agent-facing transport for the same core Q
 
 Use the MCP server when:
 
-- You are integrating QVeris into Cursor, Claude Desktop, OpenCode, or another MCP client
+- You are integrating QVeris into Cursor, Claude Desktop, Cherry Studio, OpenCode, or another MCP client
 - You want the agent to call QVeris tools directly in chat
 - You want the client to manage tool invocation automatically
 
@@ -130,6 +130,25 @@ qveris mcp validate --target cursor --probe
   }
 }
 ```
+
+### Cherry Studio example
+
+In [Cherry Studio](https://cherryai.com/), open **Settings → MCP Server**, add a server, and enter these values in its configuration fields:
+
+```json
+{
+  "name": "QVeris",
+  "command": "npx",
+  "args": ["-y", "@qverisai/mcp"],
+  "env": {
+    "QVERIS_API_KEY": "your-api-key-here",
+    "QVERIS_BASE_URL": "https://qveris.ai/api/v1"
+  },
+  "disabledTools": []
+}
+```
+
+Save the server, enable it in the conversation, and confirm that `discover`, `inspect`, `probe`, and `call` are available.
 
 For environment-specific setup guides, see:
 

--- a/docs/en-US/opencode-setup.md
+++ b/docs/en-US/opencode-setup.md
@@ -32,6 +32,24 @@ OpenCode supports remote Streamable HTTP MCP servers. Add the following server t
 
 Restart OpenCode and confirm the QVeris tools appear. Use the local stdio fallback below only if remote HTTP is unavailable in the client environment.
 
+This is the OpenCode V2 `mcp.servers` format. If your installed OpenCode instead uses a direct server name below `mcp`, use the compatible direct format below rather than mixing the two shapes:
+
+```json
+{
+  "mcp": {
+    "qveris": {
+      "type": "remote",
+      "url": "https://mcp.qveris.ai/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
 ## 2. Local stdio fallback
 
 You can generate and write the config with QVeris CLI:
@@ -42,6 +60,27 @@ qveris mcp validate --target opencode
 ```
 
 Or configure it manually:
+
+For OpenCode V2, retain the `mcp.servers` object used above and use this local server entry:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "qveris": {
+        "type": "local",
+        "command": ["npx", "-y", "@qverisai/mcp"],
+        "environment": {
+          "QVERIS_API_KEY": "your-api-key-here"
+        }
+      }
+    }
+  }
+}
+```
+
+For the direct-`mcp` format, use the QVeris CLI output or the following manual configuration:
 
 Create or edit the global OpenCode config file:
 
@@ -76,7 +115,7 @@ Add the following content (replace `your-api-key-here` with your actual API key)
 }
 ```
 
-If you already have an `opencode.json` file, merge the `mcp.qveris` and `tools["qveris*"]` sections into your existing config.
+If you already have an `opencode.json` file, merge either the V2 `mcp.servers.qveris` entry or the direct `mcp.qveris` and `tools["qveris*"]` sections into your existing config. Do not nest one form inside the other.
 
 ## 3. Skills Configuration
 

--- a/docs/en-US/opencode-setup.md
+++ b/docs/en-US/opencode-setup.md
@@ -16,26 +16,6 @@ OpenCode supports remote Streamable HTTP MCP servers. Add the following server t
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "qveris": {
-      "type": "remote",
-      "url": "https://mcp.qveris.ai/mcp",
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer your-api-key-here"
-      },
-      "enabled": true
-    }
-  }
-}
-```
-
-Restart OpenCode and confirm the QVeris tools appear. Use the local stdio fallback below only if remote HTTP is unavailable in the client environment.
-
-This is the direct `mcp.qveris` configuration produced by the QVeris CLI. If your installed OpenCode uses the V2 `mcp.servers` format, use this compatible alternative rather than mixing the two shapes:
-
-```json
-{
-  "mcp": {
     "servers": {
       "qveris": {
         "type": "remote",
@@ -50,6 +30,10 @@ This is the direct `mcp.qveris` configuration produced by the QVeris CLI. If you
 }
 ```
 
+Restart OpenCode and confirm the QVeris tools appear. Use the local stdio fallback below only if remote HTTP is unavailable in the client environment.
+
+OpenCode V2 discovers named MCP servers under `mcp.servers` and exposes their tools automatically, so this configuration does not need a separate `tools` allowlist.
+
 ## 2. Local stdio fallback
 
 You can generate and write the config with QVeris CLI:
@@ -59,28 +43,7 @@ qveris mcp configure --target opencode --write --include-key
 qveris mcp validate --target opencode
 ```
 
-Or configure it manually. The QVeris CLI target writes the direct-`mcp` format below:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "qveris": {
-      "type": "local",
-      "command": ["npx", "-y", "@qverisai/mcp"],
-      "environment": {
-        "QVERIS_API_KEY": "your-api-key-here"
-      },
-      "enabled": true
-    }
-  },
-  "tools": {
-    "qveris*": true
-  }
-}
-```
-
-For OpenCode V2, retain the `mcp.servers` object used above and use this local server entry:
+Or configure it manually. The QVeris CLI target writes the OpenCode V2 format below:
 
 ```json
 {
@@ -111,7 +74,7 @@ Create or edit the global OpenCode config file:
 %USERPROFILE%\.config\opencode\opencode.json
 ```
 
-If you already have an `opencode.json` file, merge either the V2 `mcp.servers.qveris` entry or the direct `mcp.qveris` and `tools["qveris*"]` sections into your existing config. Do not nest one form inside the other.
+If you already have an `opencode.json` file, merge the `mcp.servers.qveris` entry into the existing `servers` object.
 
 ## 3. Skills Configuration
 

--- a/docs/en-US/opencode-setup.md
+++ b/docs/en-US/opencode-setup.md
@@ -16,6 +16,26 @@ OpenCode supports remote Streamable HTTP MCP servers. Add the following server t
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
+    "qveris": {
+      "type": "remote",
+      "url": "https://mcp.qveris.ai/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+Restart OpenCode and confirm the QVeris tools appear. Use the local stdio fallback below only if remote HTTP is unavailable in the client environment.
+
+This is the direct `mcp.qveris` configuration produced by the QVeris CLI. If your installed OpenCode uses the V2 `mcp.servers` format, use this compatible alternative rather than mixing the two shapes:
+
+```json
+{
+  "mcp": {
     "servers": {
       "qveris": {
         "type": "remote",
@@ -30,26 +50,6 @@ OpenCode supports remote Streamable HTTP MCP servers. Add the following server t
 }
 ```
 
-Restart OpenCode and confirm the QVeris tools appear. Use the local stdio fallback below only if remote HTTP is unavailable in the client environment.
-
-This is the OpenCode V2 `mcp.servers` format. If your installed OpenCode instead uses a direct server name below `mcp`, use the compatible direct format below rather than mixing the two shapes:
-
-```json
-{
-  "mcp": {
-    "qveris": {
-      "type": "remote",
-      "url": "https://mcp.qveris.ai/mcp",
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer your-api-key-here"
-      },
-      "enabled": true
-    }
-  }
-}
-```
-
 ## 2. Local stdio fallback
 
 You can generate and write the config with QVeris CLI:
@@ -59,7 +59,26 @@ qveris mcp configure --target opencode --write --include-key
 qveris mcp validate --target opencode
 ```
 
-Or configure it manually:
+Or configure it manually. The QVeris CLI target writes the direct-`mcp` format below:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "qveris": {
+      "type": "local",
+      "command": ["npx", "-y", "@qverisai/mcp"],
+      "environment": {
+        "QVERIS_API_KEY": "your-api-key-here"
+      },
+      "enabled": true
+    }
+  },
+  "tools": {
+    "qveris*": true
+  }
+}
+```
 
 For OpenCode V2, retain the `mcp.servers` object used above and use this local server entry:
 
@@ -80,8 +99,6 @@ For OpenCode V2, retain the `mcp.servers` object used above and use this local s
 }
 ```
 
-For the direct-`mcp` format, use the QVeris CLI output or the following manual configuration:
-
 Create or edit the global OpenCode config file:
 
 **Mac/Linux:**
@@ -92,27 +109,6 @@ Create or edit the global OpenCode config file:
 **Windows:**
 ```
 %USERPROFILE%\.config\opencode\opencode.json
-```
-
-Add the following content (replace `your-api-key-here` with your actual API key):
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "qveris": {
-      "type": "local",
-      "command": ["npx", "-y", "@qverisai/mcp"],
-      "environment": {
-        "QVERIS_API_KEY": "your-api-key-here"
-      },
-      "enabled": true
-    }
-  },
-  "tools": {
-    "qveris*": true
-  }
-}
 ```
 
 If you already have an `opencode.json` file, merge either the V2 `mcp.servers.qveris` entry or the direct `mcp.qveris` and `tools["qveris*"]` sections into your existing config. Do not nest one form inside the other.

--- a/docs/en-US/opencode-setup.md
+++ b/docs/en-US/opencode-setup.md
@@ -4,11 +4,35 @@ This guide explains how to configure the QVeris MCP server and skills in [OpenCo
 
 ## Prerequisites
 
-- Node.js installed
+- Node.js installed only for the local stdio fallback
 - OpenCode installed ([installation guide](https://opencode.ai/docs/))
 - QVeris API key (create one in [Dashboard / API Keys](/account?page=api-keys))
 
-## 1. MCP Server Configuration
+## 1. Hosted MCP Configuration (recommended)
+
+OpenCode supports remote Streamable HTTP MCP servers. Add the following server to the global OpenCode configuration; it avoids a local package and Node.js process:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "qveris": {
+        "type": "remote",
+        "url": "https://mcp.qveris.ai/mcp",
+        "oauth": false,
+        "headers": {
+          "Authorization": "Bearer your-api-key-here"
+        }
+      }
+    }
+  }
+}
+```
+
+Restart OpenCode and confirm the QVeris tools appear. Use the local stdio fallback below only if remote HTTP is unavailable in the client environment.
+
+## 2. Local stdio fallback
 
 You can generate and write the config with QVeris CLI:
 
@@ -54,7 +78,7 @@ Add the following content (replace `your-api-key-here` with your actual API key)
 
 If you already have an `opencode.json` file, merge the `mcp.qveris` and `tools["qveris*"]` sections into your existing config.
 
-## 2. Skills Configuration
+## 3. Skills Configuration
 
 Download the QVeris MCP/client skill from the GitHub repository:
 
@@ -98,7 +122,7 @@ OpenCode's agent will automatically discover the QVeris skill and MCP server to 
 
 ## Troubleshooting
 
-**MCP Server Not Connecting:**
+**Local stdio MCP Server Not Connecting:**
 - Verify Node.js is installed: `node --version`
 - Test the MCP server manually: `npx -y @qverisai/mcp`
 - Check your API key is correct

--- a/docs/zh-CN/claude-code-setup.md
+++ b/docs/zh-CN/claude-code-setup.md
@@ -4,11 +4,21 @@
 
 ## 前置条件
 
-- 已安装 Node.js（用于运行 MCP 服务器）
+- 仅使用本地 stdio 备用方案时才需要安装 Node.js
 - 已安装 Claude Code
 - QVeris API 密钥（在[控制台/API密钥](/account?page=api-keys)中创建）
 
-## 1. MCP 服务器配置
+## 1. 托管 MCP 配置（推荐）
+
+Claude Code 支持远程 HTTP MCP 服务器。使用 Bearer 认证将 QVeris 添加为用户级 Streamable HTTP 服务：
+
+```bash
+claude mcp add --transport http qveris https://mcp.qveris.ai/mcp --scope user --header "Authorization: Bearer your-api-key-here"
+```
+
+重启 Claude Code，运行 `/mcp`，确认 QVeris 已连接。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
+
+## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成命令：
 
@@ -37,7 +47,7 @@ claude mcp get qveris    # 查看指定服务器详情
 claude mcp remove qveris # 移除服务器
 ```
 
-## 2. 技能配置
+## 3. 技能配置
 
 从 GitHub 仓库下载 QVeris MCP/客户端技能：
 
@@ -78,7 +88,7 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/QVerisAI/qveris-agent-
 
 ## 故障排查
 
-**MCP 服务器未连接：**
+**本地 stdio MCP 服务器未连接：**
 - 验证 Node.js 是否已安装：`node --version`
 - 手动测试 MCP 服务器：`npx -y @qverisai/mcp`
 - 检查 API 密钥是否正确

--- a/docs/zh-CN/codex-setup.md
+++ b/docs/zh-CN/codex-setup.md
@@ -4,11 +4,25 @@
 
 ## 前置条件
 
-- Node.js 18.2 或更高版本
 - 已安装 ChatGPT 桌面端、Codex CLI 或 Codex IDE 扩展
 - QVeris API 密钥（在[控制台/API 密钥](/account?page=api-keys)中创建）
+- 仅使用本地 stdio 备用方案时才需要 Node.js 18.2 或更高版本
 
-## 1. 添加 QVeris MCP 服务器
+## 1. 添加托管 MCP（推荐）
+
+ChatGPT 桌面端、Codex CLI 和 Codex IDE 扩展支持带 Bearer 认证的 Streamable HTTP MCP 服务器，并共享同一份 Codex MCP 配置。添加一次远程服务后，即可在任一上述本地客户端中使用：
+
+```toml
+[mcp_servers.qveris]
+url = "https://mcp.qveris.ai/mcp"
+http_headers = { Authorization = "Bearer your-api-key-here" }
+```
+
+也可以在 **“设置 → MCP 服务器”** 中交互式添加同一服务：选择 **Streamable HTTP**，填写 `https://mcp.qveris.ai/mcp`，并添加 `Authorization: Bearer your-api-key-here` 请求头。保存后重启客户端。各客户端的具体步骤请参考官方 [MCP 配置文档](https://learn.chatgpt.com/docs/extend/mcp)。
+
+## 2. 本地 stdio 备用方案
+
+仅当客户端环境无法使用托管 MCP 时，才使用该方案。在终端运行以下命令，并将 `your-api-key-here` 替换为你的 API 密钥：
 
 在终端运行以下命令，并将 `your-api-key-here` 替换为你的 API 密钥：
 
@@ -22,7 +36,7 @@ codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here -- npx -y @qverisai/
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
 ```
 
-ChatGPT 桌面端、Codex CLI 和 IDE 扩展都会从 `~/.codex/config.toml` 读取该服务器，因此只需添加一次。也可以在桌面端或 IDE 扩展的 **Settings → MCP servers** 中添加同一个 STDIO 服务器。不同客户端的详细步骤请参考官方 [MCP 配置文档](https://learn.chatgpt.com/docs/extend/mcp)。
+ChatGPT 桌面端、Codex CLI 和 IDE 扩展都会从 `~/.codex/config.toml` 读取该服务器，因此只需添加一次。也可以在桌面端或 IDE 扩展的 **Settings → MCP servers** 中添加同一个 STDIO 服务器。
 
 ### 手动配置
 
@@ -37,7 +51,7 @@ args = ["-y", "@qverisai/mcp"]
 QVERIS_API_KEY = "your-api-key-here"
 ```
 
-## 2. 安装 QVeris 技能
+## 3. 安装 QVeris 技能
 
 为当前用户安装 QVeris 技能：
 
@@ -65,7 +79,7 @@ Codex 会自动发现 `~/.agents/skills` 中的技能。如果技能没有出现
 
 ## 故障排查
 
-**服务器无法启动：**
+**本地 stdio 服务器无法启动：**
 
 - 检查 Node.js：`node --version`
 - 直接运行服务器：`QVERIS_API_KEY=your-api-key-here npx -y @qverisai/mcp`
@@ -78,4 +92,4 @@ Codex 会自动发现 `~/.agents/skills` 中的技能。如果技能没有出现
 
 **ChatGPT 网页版没有显示 QVeris：**
 
-- ChatGPT 网页版无法访问本地 `config.toml` 和 STDIO 服务器。在 QVeris 发布托管插件或远程 MCP 集成前，请使用上文列出的本地客户端。
+- ChatGPT 网页版不会读取本地 `config.toml`。当 ChatGPT Work 中可用 QVeris 插件时使用该插件；否则使用上文配置过的桌面端、Codex CLI 或 IDE 扩展。

--- a/docs/zh-CN/codex-setup.md
+++ b/docs/zh-CN/codex-setup.md
@@ -24,8 +24,6 @@ http_headers = { Authorization = "Bearer your-api-key-here" }
 
 仅当客户端环境无法使用托管 MCP 时，才使用该方案。在终端运行以下命令，并将 `your-api-key-here` 替换为你的 API 密钥：
 
-在终端运行以下命令，并将 `your-api-key-here` 替换为你的 API 密钥：
-
 ```bash
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here -- npx -y @qverisai/mcp
 ```

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -373,7 +373,7 @@ console.log(data);
 
 如果你正在配置 AI 编程助手（Claude Code、Cursor、OpenCode、Trae 等），可以将 [智能体安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给智能体。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
 
-支持的环境：Claude Code、OpenCode、Cursor、Trae、VS Code、OpenClaw。
+支持的环境：Claude Code、OpenCode、Cursor、Cherry Studio、Trae、VS Code、OpenClaw。
 
 ---
 

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -371,9 +371,9 @@ console.log(data);
 
 ### 在 AI 智能体中安装 QVeris
 
-如果你正在配置 AI 编程助手（Claude Code、Cursor、OpenCode、Trae 等），可以将 [智能体安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给智能体。它会自动检测运行环境，并完成 MCP 服务器和技能定义的配置。
+如果你正在配置 AI 编程助手或桌面端智能体（ChatGPT（Codex）、Claude Code、Cursor、GitHub Copilot、Cline、Roo Code、Continue、Kiro、Junie、Augment、Zed、Google Antigravity、Qoder、CodeBuddy、WorkBuddy、OpenCode、TRAE 等），可以将 [智能体安装指南](https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/agent/SETUP.md) 连同你的 API 密钥一起提供给智能体。它会自动检测运行环境，并完成可用 MCP 服务器和技能定义的配置。
 
-支持的环境：Claude Code、OpenCode、Cursor、Cherry Studio、Trae、VS Code、OpenClaw。
+支持 MCP 的桌面端客户端包括：ChatGPT（Codex）、Claude Desktop、Cursor、GitHub Copilot、Cherry Studio、Cline、Roo Code、Continue、Kiro、Junie、Augment、Zed、Google Antigravity、Qoder、CodeBuddy、WorkBuddy、OpenCode、TRAE、Windsurf 和 VS Code。
 
 ---
 

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -45,15 +45,31 @@ CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen 
 
 ### 通过 MCP 使用 QVeris
 
-如果你的客户端支持 **Model Context Protocol (MCP)**，可以添加官方 QVeris MCP 服务器，立即获得：
+如果你的客户端支持 **Model Context Protocol (MCP)** 和远程 Streamable HTTP，应优先使用托管 MCP。它无需本地软件包或 Node.js 进程，立即获得：
 
 - `discover`（发现）
 - `inspect`（检查）
 - `call`（调用）
 
-完整 MCP 参考文档见 [MCP 服务器文档](mcp-server.md)。
+完整 MCP 参考文档见 [MCP 服务器文档](mcp-server.md) 或[托管 MCP 指南](https://qveris.ai/hosted-mcp)。
 
-**配置方式（Cursor / 任意 MCP 客户端）**
+**托管 MCP 配置（首选）**
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+**本地 stdio 备用方案（仅适用于不支持远程 HTTP 的客户端）**
 
 ```json
 {

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## 简介
 
-`@qverisai/mcp` 是面向 Cursor、Claude Desktop 及其他编程智能体等 MCP 兼容客户端的官方 QVeris MCP 服务器。
+`@qverisai/mcp` 是面向 Cursor、Claude Desktop、Cherry Studio 及其他编程智能体等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
 `@qverisai/mcp` v0.14.0 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
 
@@ -21,7 +21,7 @@
 
 **适合使用 MCP 服务器的场景：**
 
-- 将 QVeris 集成到 Cursor、Claude Desktop、OpenCode 或其他 MCP 客户端
+- 将 QVeris 集成到 Cursor、Claude Desktop、Cherry Studio、OpenCode 或其他 MCP 客户端
 - 希望智能体在对话中直接调用 QVeris 工具
 - 希望客户端自动管理工具调用
 
@@ -130,6 +130,25 @@ qveris mcp validate --target cursor --probe
   }
 }
 ```
+
+### Cherry Studio 配置示例
+
+在 [Cherry Studio](https://cherryai.com/) 中打开**设置 → MCP 服务器**，新增服务器后将以下内容填入对应配置字段：
+
+```json
+{
+  "name": "QVeris",
+  "command": "npx",
+  "args": ["-y", "@qverisai/mcp"],
+  "env": {
+    "QVERIS_API_KEY": "your-api-key-here",
+    "QVERIS_BASE_URL": "https://qveris.ai/api/v1"
+  },
+  "disabledTools": []
+}
+```
+
+保存服务器，在对话中启用它，并确认可见 `discover`、`inspect`、`probe` 和 `call`。
 
 各环境的详细配置指南，请参考：
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -182,11 +182,46 @@ ChatGPT（Codex）可运行：
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
 ```
 
-对于仅支持本地 stdio 的客户端，请在 MCP 设置中导入以下备用配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
+对于 GitHub Copilot 以外的仅支持本地 stdio 的客户端，请在 MCP 设置中导入以下备用配置。Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
 
 ```json
 {
   "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "your-api-key-here",
+        "QVERIS_BASE_URL": "https://qveris.ai/api/v1"
+      }
+    }
+  }
+}
+```
+
+#### VS Code 中的 GitHub Copilot
+
+GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServers`。请优先使用以下托管 MCP 配置：
+
+```json
+{
+  "servers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+如果客户端环境不能使用远程 HTTP，请保留同一 `servers` 外层键，改用以下本地 stdio 条目：
+
+```json
+{
+  "servers": {
     "qveris": {
       "command": "npx",
       "args": ["-y", "@qverisai/mcp"],

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## 简介
 
-`@qverisai/mcp` 是面向 Cursor、Claude Desktop、Cherry Studio 及其他编程智能体等 MCP 兼容客户端的官方 QVeris MCP 服务器。
+`@qverisai/mcp` 是面向 ChatGPT（Codex）、Cursor、Claude Desktop、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程智能体等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
 `@qverisai/mcp` v0.14.0 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
 
@@ -21,7 +21,7 @@
 
 **适合使用 MCP 服务器的场景：**
 
-- 将 QVeris 集成到 Cursor、Claude Desktop、Cherry Studio、OpenCode 或其他 MCP 客户端
+- 将 QVeris 集成到 ChatGPT（Codex）、Cursor、Claude Desktop、Cherry Studio、GitHub Copilot、Cline、Roo Code、Continue、Kiro、Junie、Augment、Zed、Google Antigravity、Qoder、CodeBuddy、WorkBuddy、OpenCode 或其他 MCP 客户端
 - 希望智能体在对话中直接调用 QVeris 工具
 - 希望客户端自动管理工具调用
 
@@ -149,6 +149,33 @@ qveris mcp validate --target cursor --probe
 ```
 
 保存服务器，在对话中启用它，并确认可见 `discover`、`inspect`、`probe` 和 `call`。
+
+### 桌面端智能体客户端
+
+除上文客户端外，以下桌面端智能体也可通过本地 stdio MCP 使用 QVeris：**ChatGPT（Codex）**、**GitHub Copilot**、**Cline**、**Roo Code**、**Continue**、**Kiro**、**Junie**、**Augment**、**Zed**、**Google Antigravity**、**Qoder**、**CodeBuddy** 和 **WorkBuddy**。
+
+ChatGPT（Codex）可运行：
+
+```bash
+codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
+```
+
+其余客户端请在 MCP 设置中导入以下标准配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "command": "npx",
+      "args": ["-y", "@qverisai/mcp"],
+      "env": {
+        "QVERIS_API_KEY": "your-api-key-here",
+        "QVERIS_BASE_URL": "https://qveris.ai/api/v1"
+      }
+    }
+  }
+}
+```
 
 各环境的详细配置指南，请参考：
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -48,15 +48,37 @@
 
 ## 环境要求
 
-- Node.js `18+`
 - 有效的 `QVERIS_API_KEY`
 - MCP 兼容客户端
+- 仅在使用本地 stdio 备用方案时需要 Node.js `18+`
 
 ---
 
 ## 快速开始
 
-### 通过 `npx` 安装
+### 托管 MCP（推荐）
+
+只要客户端支持远程 Streamable HTTP，就应优先使用托管 MCP。它使用一个受管端点和 Bearer 认证，无需维护本地软件包、Node.js 进程或服务器生命周期。
+
+```json
+{
+  "mcpServers": {
+    "qveris": {
+      "type": "http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_QVERIS_API_KEY"
+      }
+    }
+  }
+}
+```
+
+可前往[托管 MCP 页面](https://qveris.ai/hosted-mcp)复制端点并查看各客户端的配置说明。只有当客户端不支持远程 Streamable HTTP 时，才使用下方本地 stdio 备用方案。
+
+### 本地 stdio 备用方案
+
+#### 通过 `npx` 安装
 
 ```bash
 npx -y @qverisai/mcp
@@ -69,7 +91,7 @@ QVERIS_API_KEY=your-api-key          # 必填
 QVERIS_BASE_URL=https://qveris.ai/api/v1  # 可选：覆盖 API 地址
 ```
 
-### 使用 QVeris CLI 配置
+#### 使用 QVeris CLI 配置
 
 可以用 CLI 生成客户端配置，无需手写 JSON。默认会打印带有 `YOUR_QVERIS_API_KEY` 占位符的安全配置；占位符输出会故意无法通过 API key 校验，直到你替换占位符或使用 `--include-key`。
 
@@ -152,7 +174,7 @@ qveris mcp validate --target cursor --probe
 
 ### 桌面端智能体客户端
 
-除上文客户端外，以下桌面端智能体也可通过本地 stdio MCP 使用 QVeris：**ChatGPT（Codex）**、**GitHub Copilot**、**Cline**、**Roo Code**、**Continue**、**Kiro**、**Junie**、**Augment**、**Zed**、**Google Antigravity**、**Qoder**、**CodeBuddy** 和 **WorkBuddy**。
+除上文客户端外，以下桌面端智能体在支持远程 Streamable HTTP 时应优先使用托管 MCP，本地 stdio 仅作为备用方案：**ChatGPT（Codex）**、**GitHub Copilot**、**Cline**、**Roo Code**、**Continue**、**Kiro**、**Junie**、**Augment**、**Zed**、**Google Antigravity**、**Qoder**、**CodeBuddy** 和 **WorkBuddy**。
 
 ChatGPT（Codex）可运行：
 
@@ -160,7 +182,7 @@ ChatGPT（Codex）可运行：
 codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_URL=https://qveris.ai/api/v1 -- npx -y @qverisai/mcp
 ```
 
-其余客户端请在 MCP 设置中导入以下标准配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
+对于仅支持本地 stdio 的客户端，请在 MCP 设置中导入以下备用配置。GitHub Copilot 在 `mcp.json` 中使用 `servers` 外层键；Zed 在 Agent 面板中填写相同的名称、命令、参数和环境变量。
 
 ```json
 {
@@ -187,9 +209,9 @@ codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_UR
 
 ---
 
-## Hosted MCP
+## 托管 MCP 详细说明
 
-QVeris 提供远程 Streamable HTTP MCP 托管服务，无需安装本地软件包或运行后台进程。如果端点暂时不可用，请在托管服务发布完成前继续使用上文的本地 stdio 软件包。
+QVeris 提供远程 Streamable HTTP MCP 托管服务。对于支持它的客户端，这是首选 MCP 连接方式：无需安装本地软件包或运行后台进程。
 
 ```text
 https://mcp.qveris.ai/mcp

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -133,7 +133,7 @@ qveris mcp validate --target cursor --probe
 
 ### Cherry Studio 配置示例
 
-在 [Cherry Studio](https://cherryai.com/) 中打开**设置 → MCP 服务器**，新增服务器后将以下内容填入对应配置字段：
+在 [Cherry Studio](https://cherry-ai.com/) 中打开**设置 → MCP 服务器**，新增服务器后将以下内容填入对应配置字段：
 
 ```json
 {

--- a/docs/zh-CN/opencode-setup.md
+++ b/docs/zh-CN/opencode-setup.md
@@ -16,6 +16,26 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
+    "qveris": {
+      "type": "remote",
+      "url": "https://mcp.qveris.ai/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
+
+上例是 QVeris CLI 生成的直接 `mcp.qveris` 配置。如果已安装的 OpenCode 使用 OpenCode V2 的 `mcp.servers` 格式，请使用以下兼容配置，勿混用两种层级：
+
+```json
+{
+  "mcp": {
     "servers": {
       "qveris": {
         "type": "remote",
@@ -30,26 +50,6 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 }
 ```
 
-重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
-
-上例是 OpenCode V2 的 `mcp.servers` 格式。如果已安装的 OpenCode 使用的是直接放在 `mcp` 下的服务名称，请使用下面兼容的直接格式，勿混用两种层级：
-
-```json
-{
-  "mcp": {
-    "qveris": {
-      "type": "remote",
-      "url": "https://mcp.qveris.ai/mcp",
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer your-api-key-here"
-      },
-      "enabled": true
-    }
-  }
-}
-```
-
 ## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成并写入配置：
@@ -59,7 +59,26 @@ qveris mcp configure --target opencode --write --include-key
 qveris mcp validate --target opencode
 ```
 
-也可以手动配置：
+也可以手动配置。QVeris CLI 目标会写入下面的直接 `mcp` 格式：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "qveris": {
+      "type": "local",
+      "command": ["npx", "-y", "@qverisai/mcp"],
+      "environment": {
+        "QVERIS_API_KEY": "your-api-key-here"
+      },
+      "enabled": true
+    }
+  },
+  "tools": {
+    "qveris*": true
+  }
+}
+```
 
 对于 OpenCode V2，请保留上文的 `mcp.servers` 对象，并使用以下本地服务条目：
 
@@ -80,8 +99,6 @@ qveris mcp validate --target opencode
 }
 ```
 
-对于直接 `mcp` 格式，请使用 QVeris CLI 的输出或下列手动配置：
-
 创建或编辑全局 OpenCode 配置文件：
 
 **Mac/Linux：**
@@ -92,27 +109,6 @@ qveris mcp validate --target opencode
 **Windows：**
 ```
 %USERPROFILE%\.config\opencode\opencode.json
-```
-
-添加以下内容（将 `your-api-key-here` 替换为你的实际 API 密钥）：
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "qveris": {
-      "type": "local",
-      "command": ["npx", "-y", "@qverisai/mcp"],
-      "environment": {
-        "QVERIS_API_KEY": "your-api-key-here"
-      },
-      "enabled": true
-    }
-  },
-  "tools": {
-    "qveris*": true
-  }
-}
 ```
 
 如果已有 `opencode.json` 文件，请合并 V2 的 `mcp.servers.qveris` 条目，或直接格式的 `mcp.qveris` 与 `tools["qveris*"]` 部分。不要将一种格式嵌套到另一种格式内。

--- a/docs/zh-CN/opencode-setup.md
+++ b/docs/zh-CN/opencode-setup.md
@@ -16,26 +16,6 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "qveris": {
-      "type": "remote",
-      "url": "https://mcp.qveris.ai/mcp",
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer your-api-key-here"
-      },
-      "enabled": true
-    }
-  }
-}
-```
-
-重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
-
-上例是 QVeris CLI 生成的直接 `mcp.qveris` 配置。如果已安装的 OpenCode 使用 OpenCode V2 的 `mcp.servers` 格式，请使用以下兼容配置，勿混用两种层级：
-
-```json
-{
-  "mcp": {
     "servers": {
       "qveris": {
         "type": "remote",
@@ -50,6 +30,10 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 }
 ```
 
+重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
+
+OpenCode V2 会在 `mcp.servers` 下发现具名 MCP 服务器，并自动暴露其工具，因此不需要额外的 `tools` 允许列表。
+
 ## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成并写入配置：
@@ -59,28 +43,7 @@ qveris mcp configure --target opencode --write --include-key
 qveris mcp validate --target opencode
 ```
 
-也可以手动配置。QVeris CLI 目标会写入下面的直接 `mcp` 格式：
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "qveris": {
-      "type": "local",
-      "command": ["npx", "-y", "@qverisai/mcp"],
-      "environment": {
-        "QVERIS_API_KEY": "your-api-key-here"
-      },
-      "enabled": true
-    }
-  },
-  "tools": {
-    "qveris*": true
-  }
-}
-```
-
-对于 OpenCode V2，请保留上文的 `mcp.servers` 对象，并使用以下本地服务条目：
+也可以手动配置。QVeris CLI 目标会写入下面的 OpenCode V2 格式：
 
 ```json
 {
@@ -111,7 +74,7 @@ qveris mcp validate --target opencode
 %USERPROFILE%\.config\opencode\opencode.json
 ```
 
-如果已有 `opencode.json` 文件，请合并 V2 的 `mcp.servers.qveris` 条目，或直接格式的 `mcp.qveris` 与 `tools["qveris*"]` 部分。不要将一种格式嵌套到另一种格式内。
+如果已有 `opencode.json` 文件，请将 `mcp.servers.qveris` 条目合并到现有的 `servers` 对象中。
 
 ## 3. 技能配置
 

--- a/docs/zh-CN/opencode-setup.md
+++ b/docs/zh-CN/opencode-setup.md
@@ -4,11 +4,35 @@
 
 ## 前置条件
 
-- 已安装 Node.js
+- 仅使用本地 stdio 备用方案时才需要安装 Node.js
 - 已安装 OpenCode（[安装指南](https://opencode.ai/docs/)）
 - QVeris API 密钥（在[控制台/API密钥](/account?page=api-keys)中创建）
 
-## 1. MCP 服务器配置
+## 1. 托管 MCP 配置（推荐）
+
+OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全局 OpenCode 配置；它无需本地软件包或 Node.js 进程：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "qveris": {
+        "type": "remote",
+        "url": "https://mcp.qveris.ai/mcp",
+        "oauth": false,
+        "headers": {
+          "Authorization": "Bearer your-api-key-here"
+        }
+      }
+    }
+  }
+}
+```
+
+重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
+
+## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成并写入配置：
 
@@ -54,7 +78,7 @@ qveris mcp validate --target opencode
 
 如果已有 `opencode.json` 文件，请将 `mcp.qveris` 和 `tools["qveris*"]` 部分合并到现有配置中。
 
-## 2. 技能配置
+## 3. 技能配置
 
 从 GitHub 仓库下载 QVeris MCP/客户端技能：
 
@@ -98,7 +122,7 @@ OpenCode 的智能体会自动发现 QVeris 技能和 MCP 服务器，找到并�
 
 ## 故障排查
 
-**MCP 服务器未连接：**
+**本地 stdio MCP 服务器未连接：**
 - 验证 Node.js 是否已安装：`node --version`
 - 手动测试 MCP 服务器：`npx -y @qverisai/mcp`
 - 检查 API 密钥是否正确

--- a/docs/zh-CN/opencode-setup.md
+++ b/docs/zh-CN/opencode-setup.md
@@ -32,6 +32,24 @@ OpenCode 支持远程 Streamable HTTP MCP 服务器。将以下服务加入全�
 
 重启 OpenCode，确认 QVeris 工具已出现。仅当客户端环境无法使用远程 HTTP 时，才使用下方本地 stdio 备用方案。
 
+上例是 OpenCode V2 的 `mcp.servers` 格式。如果已安装的 OpenCode 使用的是直接放在 `mcp` 下的服务名称，请使用下面兼容的直接格式，勿混用两种层级：
+
+```json
+{
+  "mcp": {
+    "qveris": {
+      "type": "remote",
+      "url": "https://mcp.qveris.ai/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
 ## 2. 本地 stdio 备用方案
 
 可以用 QVeris CLI 生成并写入配置：
@@ -42,6 +60,27 @@ qveris mcp validate --target opencode
 ```
 
 也可以手动配置：
+
+对于 OpenCode V2，请保留上文的 `mcp.servers` 对象，并使用以下本地服务条目：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "qveris": {
+        "type": "local",
+        "command": ["npx", "-y", "@qverisai/mcp"],
+        "environment": {
+          "QVERIS_API_KEY": "your-api-key-here"
+        }
+      }
+    }
+  }
+}
+```
+
+对于直接 `mcp` 格式，请使用 QVeris CLI 的输出或下列手动配置：
 
 创建或编辑全局 OpenCode 配置文件：
 
@@ -76,7 +115,7 @@ qveris mcp validate --target opencode
 }
 ```
 
-如果已有 `opencode.json` 文件，请将 `mcp.qveris` 和 `tools["qveris*"]` 部分合并到现有配置中。
+如果已有 `opencode.json` 文件，请合并 V2 的 `mcp.servers.qveris` 条目，或直接格式的 `mcp.qveris` 与 `tools["qveris*"]` 部分。不要将一种格式嵌套到另一种格式内。
 
 ## 3. 技能配置
 

--- a/packages/cli/src/commands/mcp.mjs
+++ b/packages/cli/src/commands/mcp.mjs
@@ -130,14 +130,14 @@ function buildTargetFragment(target, { apiKey, baseUrl, includeBaseUrl }) {
   if (target === "opencode") {
     return {
       mcp: {
-        qveris: {
-          type: "local",
-          command: ["npx", "-y", "@qverisai/mcp"],
-          environment: env,
-          enabled: true,
+        servers: {
+          qveris: {
+            type: "local",
+            command: ["npx", "-y", "@qverisai/mcp"],
+            environment: env,
+          },
         },
       },
-      tools: { "qveris*": true },
     };
   }
 
@@ -206,15 +206,15 @@ function mergeConfig(target, existing, fragment) {
     };
   }
   if (target === "opencode") {
+    const { qveris: _legacyQveris, ...existingMcp } = existing.mcp || {};
     return {
       ...existing,
       mcp: {
-        ...(existing.mcp || {}),
-        qveris: fragment.mcp.qveris,
-      },
-      tools: {
-        ...(existing.tools || {}),
-        ...fragment.tools,
+        ...existingMcp,
+        servers: {
+          ...(existing.mcp?.servers || {}),
+          qveris: fragment.mcp.servers.qveris,
+        },
       },
     };
   }
@@ -254,10 +254,6 @@ function validateConfigObject(target, config) {
   checks.push(
     check("api_key_env", hasUsableApiKey(server, target), "QVERIS_API_KEY is configured and is not a placeholder"),
   );
-
-  if (target === "opencode") {
-    checks.push(check("tools_enabled", config?.tools?.["qveris*"] === true, "OpenCode qveris tools are enabled"));
-  }
 
   const ok = checks.every((item) => item.ok);
   return { ok, checks, expected_tools: EXPECTED_TOOLS };
@@ -536,7 +532,7 @@ function quoteWindowsCommandArgument(value, escapePercent = false) {
 
 function extractServer(target, config) {
   if (target === "cursor" || target === "claude-desktop") return config?.mcpServers?.qveris;
-  if (target === "opencode") return config?.mcp?.qveris;
+  if (target === "opencode") return config?.mcp?.servers?.qveris;
   if (target === "openclaw") return config?.plugins?.entries?.qveris;
   if (target === "generic") return config;
   return null;

--- a/packages/cli/test/mcp.test.mjs
+++ b/packages/cli/test/mcp.test.mjs
@@ -197,9 +197,9 @@ test("mcp configure emits valid JSON fragments for each supported target", () =>
       assert.deepEqual(payload.config.mcpServers.qveris.args, ["-y", "@qverisai/mcp"]);
       assert.equal(payload.config.mcpServers.qveris.env.QVERIS_API_KEY, "sk-test");
     } else if (target === "opencode") {
-      assert.deepEqual(payload.config.mcp.qveris.command, ["npx", "-y", "@qverisai/mcp"]);
-      assert.equal(payload.config.mcp.qveris.environment.QVERIS_API_KEY, "sk-test");
-      assert.equal(payload.config.tools["qveris*"], true);
+      assert.deepEqual(payload.config.mcp.servers.qveris.command, ["npx", "-y", "@qverisai/mcp"]);
+      assert.equal(payload.config.mcp.servers.qveris.environment.QVERIS_API_KEY, "sk-test");
+      assert.equal(payload.config.mcp.servers.qveris.enabled, undefined);
     } else if (target === "openclaw") {
       assert.deepEqual(payload.config.plugins.allow, ["qveris"]);
       assert.equal(payload.config.plugins.entries.qveris.config.apiKey, "sk-test");
@@ -297,6 +297,53 @@ test("mcp configure write merges cursor config and validate reads it back", () =
         ["api_key_env", true],
       ],
     );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("mcp configure migrates OpenCode QVeris config to mcp.servers", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qveris-cli-mcp-"));
+  try {
+    const path = join(dir, "opencode-mcp.json");
+    writeFileSync(
+      path,
+      JSON.stringify(
+        {
+          mcp: {
+            qveris: { type: "local", command: ["old-qveris"] },
+            servers: { existing: { type: "local", command: ["existing-server"] } },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const configureResult = runCli([
+      "mcp",
+      "configure",
+      "--target",
+      "opencode",
+      "--output",
+      path,
+      "--write",
+      "--include-key",
+      "--api-key",
+      "sk-test",
+      "--json",
+    ]);
+    assert.equal(configureResult.status, 0, configureResult.stderr);
+    const fileConfig = JSON.parse(readFileSync(path, "utf8"));
+
+    assert.equal(fileConfig.mcp.qveris, undefined);
+    assert.deepEqual(fileConfig.mcp.servers.existing.command, ["existing-server"]);
+    assert.deepEqual(fileConfig.mcp.servers.qveris.command, ["npx", "-y", "@qverisai/mcp"]);
+    assert.equal(fileConfig.mcp.servers.qveris.environment.QVERIS_API_KEY, "sk-test");
+
+    const validateResult = runCli(["mcp", "validate", "--target", "opencode", "--output", path, "--json"]);
+    assert.equal(validateResult.status, 0, validateResult.stderr);
+    assert.equal(parseCliJson(validateResult).ok, true);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Synchronizes the canonical toolkit guidance with Hosted MCP as the preferred connection for remote-capable MCP clients.

- Promotes Hosted MCP ahead of local stdio in `agent/SETUP.md` and machine-readable agent guidance.
- Adds Hosted MCP setup to the English, global Chinese, and China-facing MCP and getting-started guides.
- Adds client-native remote configurations for ChatGPT desktop / Codex, Claude Code, and OpenCode.
- Retains local stdio as an explicit fallback and preserves each localized guide's deployment-specific endpoint.

## Validation

- `git diff --check`
- `npm run test:release-clients` — 42 tests passed
- Website setup and documentation regression suite: 9 files, 91 tests passed