### PR TITLE
fix: serialize coordinated release workflows

### DIFF
--- a/scripts/release-client-packages.mjs
+++ b/scripts/release-client-packages.mjs
@@ -584,16 +584,19 @@ export async function publishReleasePlan(releases, operations) {
       await operations.pushTag(release);
     }
 
-    // Confirm this event exists before sending the next tag push. This makes
-    // the four-package release immune to GitHub's >3-tags-per-push limit.
-    runs.push({ release, run: await operations.waitForRun(release, { excludeRunIds }) });
-  }
-
-  if (operations.watch) {
-    for (const { release, run } of runs) {
+    // Wait for the complete publish workflow before sending the next tag.
+    // Beyond avoiding GitHub's >3-tags-per-push limit, this prevents a
+    // failure in a later workflow step (such as registry publication) from
+    // publishing the remaining packages.
+    const run = await operations.waitForRun(release, { excludeRunIds });
+    runs.push({ release, run });
+    if (operations.watch) {
       log(`\n${release.tag}: waiting for ${release.workflow}`);
       await operations.watchRun(run);
     }
+  }
+
+  if (operations.watch) {
     if (operations.dispatchCadence) {
       log("\nAll publish workflows succeeded; dispatching the protected benchmark cadence");
       await operations.dispatchCadence(operations.head, releases);

--- a/scripts/release-client-packages.test.mjs
+++ b/scripts/release-client-packages.test.mjs
@@ -243,7 +243,7 @@ test("readReleasePlan rejects a missing or mismatched publish workflow before ta
   );
 });
 
-test("publishReleasePlan pushes one tag at a time and confirms each run before the next push", async () => {
+test("publishReleasePlan waits for each workflow to succeed before pushing the next tag", async () => {
   const releases = readReleasePlan(fixtureRoot());
   const events = [];
 
@@ -276,6 +276,10 @@ test("publishReleasePlan pushes one tag at a time and confirms each run before t
       events.indexOf(`registered:${releases[index].tag}`) < events.indexOf(`push:${releases[index + 1].tag}`),
       `${releases[index].tag} must register before the next tag push`,
     );
+    assert.ok(
+      events.indexOf(`watch:${releases[index].tag}`) < events.indexOf(`push:${releases[index + 1].tag}`),
+      `${releases[index].tag} must succeed before the next tag push`,
+    );
   }
   for (const release of releases) {
     assert.ok(
@@ -287,10 +291,7 @@ test("publishReleasePlan pushes one tag at a time and confirms each run before t
     events.filter((event) => event.startsWith("push:")),
     releases.map((release) => `push:${release.tag}`),
   );
-  assert.deepEqual(
-    events.slice(-5),
-    [...releases.map((release) => `watch:${release.tag}`), "cadence:release-head"],
-  );
+  assert.deepEqual(events.slice(-2), [`watch:${releases.at(-1).tag}`, "cadence:release-head"]);
 });
 
 test("publishReleasePlan fault injection stops at each asynchronous boundary", async (t) => {
@@ -335,7 +336,8 @@ test("publishReleasePlan fault injection stops at each asynchronous boundary", a
         failurePoint === "snapshot" ||
         failurePoint === "create" ||
         failurePoint === "push" ||
-        failurePoint === "register"
+        failurePoint === "register" ||
+        failurePoint === "watch"
       ) {
         assert.equal(
           events.some((event) => event.includes(releases[1].tag)),


### PR DESCRIPTION
## Summary

Make coordinated client releases strictly sequential: after each tag is pushed, the coordinator waits for that package's entire publish workflow to succeed before it can create the next tag.

## Root cause

The coordinator previously confirmed only that each workflow had registered, then pushed every remaining tag before waiting for final workflow results. A late failure, such as MCP Registry publication, could therefore leave later packages released.

## Impact

A failed publish workflow now stops the release before any subsequent package tag is created. The protected benchmark cadence still runs only after all four workflows succeed.

## Validation

- `npm run test:release-clients` (42 passing)
- `npm run release:clients:check`
- `npm run lint`