### PR TITLE
docs: clarify SDK credential requirements

### DIFF
--- a/docs/cn/zh-CN/js-sdk.md
+++ b/docs/cn/zh-CN/js-sdk.md
@@ -82,7 +82,7 @@ console.log(usage.total, ledger.total);
 
 | 字段 | 环境变量 | 默认值 | 说明 |
 |------|---------|--------|------|
-| `apiKey` | `QVERIS_API_KEY` | —（必填） | API 密钥，以 `Authorization: Bearer ...` 发送 |
+| `apiKey` | `QVERIS_API_KEY` | —（未提供 `credentialProvider` 时必填） | API 密钥，以 `Authorization: Bearer ...` 发送 |
 | `credentialProvider` | — | — | 异步 Bearer 凭证提供器；与 `apiKey` 互斥 |
 | `credentialAudience` | — | — | 传给凭证提供器的 audience |
 | `credentialScopes` | — | `[]` | 传给凭证提供器的 OAuth scopes |

--- a/docs/en-US/js-sdk.md
+++ b/docs/en-US/js-sdk.md
@@ -82,7 +82,7 @@ There is no connection to close — the client is stateless over `fetch`.
 
 | Field | Env var | Default | Description |
 |-------|---------|---------|-------------|
-| `apiKey` | `QVERIS_API_KEY` | — (required) | API key, sent as `Authorization: Bearer ...` |
+| `apiKey` | `QVERIS_API_KEY` | — (required without `credentialProvider`) | API key, sent as `Authorization: Bearer ...` |
 | `credentialProvider` | — | — | Async bearer provider; mutually exclusive with `apiKey` |
 | `credentialAudience` | — | — | Audience forwarded to the credential provider |
 | `credentialScopes` | — | `[]` | OAuth scopes forwarded to the credential provider |

--- a/docs/zh-CN/js-sdk.md
+++ b/docs/zh-CN/js-sdk.md
@@ -82,7 +82,7 @@ console.log(usage.total, ledger.total);
 
 | 字段 | 环境变量 | 默认值 | 说明 |
 |------|---------|--------|------|
-| `apiKey` | `QVERIS_API_KEY` | —（必填） | API 密钥，以 `Authorization: Bearer ...` 发送 |
+| `apiKey` | `QVERIS_API_KEY` | —（未提供 `credentialProvider` 时必填） | API 密钥，以 `Authorization: Bearer ...` 发送 |
 | `credentialProvider` | — | — | 异步 Bearer 凭证提供器；与 `apiKey` 互斥 |
 | `credentialAudience` | — | — | 传给凭证提供器的 audience |
 | `credentialScopes` | — | `[]` | 传给凭证提供器的 OAuth scopes |

--- a/scripts/sdk-guide-contracts.test.mjs
+++ b/scripts/sdk-guide-contracts.test.mjs
@@ -58,6 +58,22 @@ test("all TypeScript SDK guides document Probe and strict paid calls", () => {
   }
 });
 
+test("all TypeScript SDK guides describe API key authentication as conditional", () => {
+  const requiredWithoutCredentialProvider = {
+    "docs/en-US/js-sdk.md": "— (required without `credentialProvider`)",
+    "docs/zh-CN/js-sdk.md": "—（未提供 `credentialProvider` 时必填）",
+    "docs/cn/zh-CN/js-sdk.md": "—（未提供 `credentialProvider` 时必填）",
+  };
+
+  for (const [path, expectation] of Object.entries(requiredWithoutCredentialProvider)) {
+    const guide = read(path);
+    assert.ok(
+      guide.includes(`| \`apiKey\` | \`QVERIS_API_KEY\` | ${expectation} |`),
+      `${path} must describe apiKey as conditional on credentialProvider`,
+    );
+  }
+});
+
 test("generated Python API references document public Probe response models", () => {
   for (const path of PYTHON_API_REFERENCES) {
     const reference = read(path);


### PR DESCRIPTION
## Summary

Clarify in the English and Chinese TypeScript SDK guides that `apiKey` is required only when no `credentialProvider` is configured.

## Validation

Add a cross-guide contract test for this authentication invariant.

- `npm run test:release-clients`
- `npm run lint`
- release-aware docs staging and locale checks