### PR TITLE
fix: harden website docs sync

### DIFF
--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -54,7 +54,7 @@ CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen 
 
 完整 MCP 参考文档见 [MCP 服务器文档](mcp-server.md) 或[托管 MCP 指南](https://qveris.cn/hosted-mcp)。
 
-**托管 MCP 配置（首选）**
+#### 托管 MCP 配置（首选）
 
 ```json
 {
@@ -70,7 +70,7 @@ CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen 
 }
 ```
 
-**本地 stdio 备用方案（仅适用于不支持远程 HTTP 的客户端）**
+#### 本地 stdio 备用方案（仅适用于不支持远程 HTTP 的客户端）
 
 ```json
 {

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -178,7 +178,9 @@ qveris mcp validate --target cursor --probe
 
 #### VS Code 中的 GitHub Copilot
 
-GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServers`。请优先使用以下托管 MCP 配置：
+GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServers`。
+
+##### 托管 MCP 配置
 
 ```json
 {
@@ -193,6 +195,8 @@ GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServ
   }
 }
 ```
+
+##### 本地 stdio 备用方案
 
 如果客户端环境不能使用远程 HTTP，请保留同一 `servers` 外层键，改用以下本地 stdio 条目：
 

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -53,7 +53,7 @@ If your client supports **Model Context Protocol (MCP)** and remote Streamable H
 
 For the full MCP reference, see [MCP Server documentation](mcp-server.md) or the [Hosted MCP guide](https://qveris.ai/hosted-mcp).
 
-**Hosted MCP configuration (preferred)**
+#### Hosted MCP configuration (preferred)
 
 ```json
 {
@@ -69,7 +69,7 @@ For the full MCP reference, see [MCP Server documentation](mcp-server.md) or the
 }
 ```
 
-**Local stdio fallback (for clients without remote HTTP support)**
+#### Local stdio fallback (for clients without remote HTTP support)
 
 ```json
 {

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -201,7 +201,9 @@ For local-stdio-only clients other than GitHub Copilot, open the product's MCP s
 
 #### GitHub Copilot in VS Code
 
-GitHub Copilot's `mcp.json` uses a top-level `servers` object, not `mcpServers`. Use this Hosted MCP configuration first:
+GitHub Copilot's `mcp.json` uses a top-level `servers` object, not `mcpServers`.
+
+##### Hosted MCP configuration
 
 ```json
 {
@@ -216,6 +218,8 @@ GitHub Copilot's `mcp.json` uses a top-level `servers` object, not `mcpServers`.
   }
 }
 ```
+
+##### Local stdio fallback
 
 If the client environment cannot use remote HTTP, keep the same `servers` wrapper and use the local stdio entry instead:
 

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -53,7 +53,7 @@ CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen 
 
 完整 MCP 参考文档见 [MCP 服务器文档](mcp-server.md) 或[托管 MCP 指南](https://qveris.ai/hosted-mcp)。
 
-**托管 MCP 配置（首选）**
+#### 托管 MCP 配置（首选）
 
 ```json
 {
@@ -69,7 +69,7 @@ CLI 还支持交互模式（`qveris interactive`）、代码生成（`--codegen 
 }
 ```
 
-**本地 stdio 备用方案（仅适用于不支持远程 HTTP 的客户端）**
+#### 本地 stdio 备用方案（仅适用于不支持远程 HTTP 的客户端）
 
 ```json
 {

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -201,7 +201,9 @@ codex mcp add qveris --env QVERIS_API_KEY=your-api-key-here --env QVERIS_BASE_UR
 
 #### VS Code 中的 GitHub Copilot
 
-GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServers`。请优先使用以下托管 MCP 配置：
+GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServers`。
+
+##### 托管 MCP 配置
 
 ```json
 {
@@ -216,6 +218,8 @@ GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServ
   }
 }
 ```
+
+##### 本地 stdio 备用方案
 
 如果客户端环境不能使用远程 HTTP，请保留同一 `servers` 外层键，改用以下本地 stdio 条目：
 

--- a/scripts/prepare-website-docs.mjs
+++ b/scripts/prepare-website-docs.mjs
@@ -40,6 +40,10 @@ const MAIN_GUIDE_RELEASES = [
 ]
 
 const RELEASE_MARKER = /^<!-- qveris-sdk-release: ([^ ]+) -->\n?/
+const WEBSITE_LOCAL_PAGE_LINKS = [
+  "https://qveris.ai/hosted-mcp",
+  "https://qveris.cn/hosted-mcp",
+]
 
 function parseArgs(argv) {
   const args = { toolkitDir: "", websiteDir: "", outputDir: "" }
@@ -124,6 +128,13 @@ function markedRelease(content) {
 
 function withReleaseMarker(content, tag) {
   return `<!-- qveris-sdk-release: ${tag} -->\n${content.replace(RELEASE_MARKER, "")}`
+}
+
+function localizeWebsitePageLinks(content) {
+  return WEBSITE_LOCAL_PAGE_LINKS.reduce(
+    (localized, absoluteUrl) => localized.replaceAll(absoluteUrl, "/hosted-mcp"),
+    content,
+  )
 }
 
 function withPinnedGuideVersion(content, release, tag, relPath) {
@@ -268,6 +279,14 @@ async function main() {
         withReleaseMarker(withPinnedGuideVersion(taggedContent, release, tag, relPath), tag),
       )
     }
+  }
+
+  // Toolkit docs are also rendered on GitHub, where their deployment-specific
+  // links are useful. The website mirror must instead keep its own origin so
+  // preview and test deployments do not navigate visitors to production.
+  for (const relPath of toolkitOwnedPaths) {
+    const content = await fs.readFile(path.join(outputDir, relPath), "utf8")
+    await writeFile(outputDir, relPath, localizeWebsitePageLinks(content))
   }
 
   if (process.env.GITHUB_OUTPUT) {

--- a/scripts/prepare-website-docs.test.mjs
+++ b/scripts/prepare-website-docs.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test"
 import { fileURLToPath } from "node:url"
 
 const SCRIPT = fileURLToPath(new URL("./prepare-website-docs.mjs", import.meta.url))
+const REPOSITORY_ROOT = path.resolve(path.dirname(SCRIPT), "..")
 
 const PYTHON_PATHS = [
   "docs/en-US/python-sdk.md",
@@ -29,6 +30,53 @@ async function write(root, relPath, content) {
 function git(cwd, ...args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" })
 }
+
+function redactUnavailableHostedMcp(content) {
+  const output = []
+  let skippedHeadingLevel = null
+
+  for (const line of content.split("\n")) {
+    const heading = /^(#{1,6})\s+/.exec(line)
+    const headingLevel = heading?.[1].length ?? null
+
+    if (skippedHeadingLevel !== null) {
+      if (headingLevel === null || headingLevel > skippedHeadingLevel) continue
+      skippedHeadingLevel = null
+    }
+
+    if (headingLevel !== null && /hosted mcp/i.test(line)) {
+      skippedHeadingLevel = headingLevel
+      continue
+    }
+    if (/hosted mcp|\/hosted-mcp/i.test(line)) continue
+
+    output.push(line)
+  }
+
+  return output.join("\n")
+}
+
+test("hosted-MCP source sections remain removable when the website feature is disabled", async () => {
+  const sources = [
+    "agent/llms.txt",
+    "agent/llms-full.txt",
+    "docs/en-US/getting-started.md",
+    "docs/en-US/mcp-server.md",
+    "docs/en-US/codex-setup.md",
+    "docs/en-US/claude-code-setup.md",
+    "docs/en-US/opencode-setup.md",
+  ]
+
+  for (const relPath of sources) {
+    const source = await fs.readFile(path.join(REPOSITORY_ROOT, relPath), "utf8")
+    const redacted = redactUnavailableHostedMcp(source)
+    assert.doesNotMatch(
+      redacted,
+      /Hosted MCP|\/hosted-mcp|https:\/\/mcp\.qveris\.ai\/mcp/i,
+      `${relPath} leaves a hosted-MCP reference outside a removable section`,
+    )
+  }
+})
 
 test("website staging holds published docs between releases and advances on new SDK tags", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "qveris-docs-source-"))
@@ -55,7 +103,11 @@ test("website staging holds published docs between releases and advances on new 
     git(toolkit, "tag", "js-sdk-v0.4.0-rc.1")
     git(toolkit, "tag", "js-sdk-v0.4.0")
 
-    await write(toolkit, "docs/en-US/getting-started.md", "main setup v2\n")
+    await write(
+      toolkit,
+      "docs/en-US/getting-started.md",
+      "[Global hosted MCP](https://qveris.ai/hosted-mcp)\n[China hosted MCP](https://qveris.cn/hosted-mcp)\n",
+    )
     await write(
       toolkit,
       "docs/en-US/cli.md",
@@ -105,7 +157,10 @@ test("website staging holds published docs between releases and advances on new 
     )
     assert.equal(result.status, 0, result.stderr)
 
-    assert.equal(await fs.readFile(path.join(output, "docs/en-US/getting-started.md"), "utf8"), "main setup v2\n")
+    assert.equal(
+      await fs.readFile(path.join(output, "docs/en-US/getting-started.md"), "utf8"),
+      "[Global hosted MCP](/hosted-mcp)\n[China hosted MCP](/hosted-mcp)\n",
+    )
     assert.equal(
       await fs.readFile(path.join(output, "docs/en-US/cli.md"), "utf8"),
       "`@qverisai/cli` v0.8.0 is the latest tested release.\n",


### PR DESCRIPTION
## Summary
- preserve deployment-specific links in toolkit source while staging site-local links for synced docs
- structure remote and local MCP configurations as independently removable sections
- add staging and disabled-feature regression coverage

## Verification
- `node --test scripts/prepare-website-docs.test.mjs`
- `npm run test:release-clients`
- `node scripts/check-doc-locales.mjs`

`npm run lint` could not run because package-local dependencies are not installed in this isolated worktree.