### PR TITLE
docs: sync API docs from website

### DIFF
--- a/docs/cn/zh-CN/rest-api.md
+++ b/docs/cn/zh-CN/rest-api.md
@@ -1,6 +1,6 @@
 # QVeris REST API 文档
 
-版本：2026-08-13.1
+版本：2026-08-21.1
 
 公开 REST API 暴露核心 Agent 路径：
 

--- a/docs/en-US/rest-api.md
+++ b/docs/en-US/rest-api.md
@@ -1,6 +1,6 @@
 # QVeris REST API Documentation
 
-Version: 2026-08-13.1
+Version: 2026-08-21.1
 
 The public REST API exposes the core agent path:
 

--- a/docs/openapi/qveris-cn-public-api.openapi.json
+++ b/docs/openapi/qveris-cn-public-api.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "QVeris Public REST API",
-    "version": "2026-08-13.1",
+    "version": "2026-08-21.1",
     "summary": "External REST API for enterprise integration.",
     "description": "OpenAPI 3.1 schema for the formally released public `/api/v1` REST API surface. It covers search, provider discovery, tool metadata lookup/execution, credits, and account audit endpoints. Unreleased API families are intentionally excluded from this customer-facing schema."
   },
@@ -118,7 +118,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -138,7 +138,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -172,7 +172,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -185,7 +185,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -464,7 +464,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -484,7 +484,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -510,7 +510,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -587,7 +587,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -607,7 +607,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -704,7 +704,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -754,7 +754,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -774,7 +774,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -887,7 +887,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -907,7 +907,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1369,7 +1369,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1389,7 +1389,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1415,7 +1415,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1710,7 +1710,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2036,7 +2036,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2056,7 +2056,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2107,7 +2107,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2127,7 +2127,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2161,7 +2161,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2218,7 +2218,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2242,7 +2242,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2266,7 +2266,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2290,7 +2290,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2314,7 +2314,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2338,7 +2338,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2362,7 +2362,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2386,7 +2386,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2410,7 +2410,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2510,7 +2510,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2530,7 +2530,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2554,7 +2554,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2578,7 +2578,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2602,7 +2602,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2626,7 +2626,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2650,7 +2650,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2674,7 +2674,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2708,7 +2708,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2747,7 +2747,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2823,7 +2823,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2843,7 +2843,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2863,7 +2863,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2883,7 +2883,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2920,7 +2920,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -2947,7 +2947,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3031,7 +3031,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3051,7 +3051,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3071,7 +3071,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3091,7 +3091,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3111,7 +3111,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3211,7 +3211,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3231,7 +3231,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3251,7 +3251,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3271,7 +3271,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3291,7 +3291,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3478,7 +3478,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3498,7 +3498,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3518,7 +3518,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3538,7 +3538,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3558,7 +3558,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3681,7 +3681,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3701,7 +3701,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3733,7 +3733,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3789,7 +3789,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -3865,7 +3865,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -3914,7 +3914,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -3966,7 +3966,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4049,7 +4049,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4128,7 +4128,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4177,7 +4177,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4210,7 +4210,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4273,6 +4273,24 @@
               "title": "Tool Id"
             },
             "description": "Tool ID (optional if provided in request body)"
+          },
+          {
+            "name": "X-QVeris-Cache-Mode",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "缓存策略：default（默认）或 bypass（跳过provider缓存）",
+              "title": "X-Qveris-Cache-Mode"
+            },
+            "description": "缓存策略：default（默认）或 bypass（跳过provider缓存）"
           }
         ],
         "responses": {
@@ -4333,7 +4351,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4370,7 +4388,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4423,7 +4441,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4477,7 +4495,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4529,7 +4547,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4635,7 +4653,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4672,7 +4690,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4721,7 +4739,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4754,7 +4772,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4778,7 +4796,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4803,7 +4821,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4828,7 +4846,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4848,7 +4866,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -6277,7 +6295,7 @@
             "title": "Contract Version",
             "description": "Version of the published QVeris REST API contract.",
             "examples": [
-              "2026-08-13.1"
+              "2026-08-21.1"
             ]
           }
         },

--- a/docs/openapi/qveris-cn-public-api.projection-fixtures.json
+++ b/docs/openapi/qveris-cn-public-api.projection-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": "2026-08-13.1",
+  "contract_version": "2026-08-21.1",
   "compatibility": {
     "legacy_service_ignores_projection": {
       "request": {"query": "查询当前天气", "view": "routing"},

--- a/docs/openapi/qveris-public-api.openapi.json
+++ b/docs/openapi/qveris-public-api.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "QVeris Public REST API",
-    "version": "2026-08-13.1",
+    "version": "2026-08-21.1",
     "summary": "External REST API for enterprise integration.",
     "description": "OpenAPI 3.1 schema for the formally released public `/api/v1` REST API surface. It covers search, provider discovery, tool metadata lookup/execution, credits, and account audit endpoints. Unreleased API families are intentionally excluded from this customer-facing schema."
   },
@@ -118,7 +118,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -138,7 +138,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -172,7 +172,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -185,7 +185,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -464,7 +464,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -484,7 +484,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -510,7 +510,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -587,7 +587,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -607,7 +607,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -704,7 +704,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -754,7 +754,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -774,7 +774,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -887,7 +887,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -907,7 +907,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1369,7 +1369,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1389,7 +1389,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1415,7 +1415,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -1710,7 +1710,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2036,7 +2036,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2056,7 +2056,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2107,7 +2107,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2127,7 +2127,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2161,7 +2161,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2218,7 +2218,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2242,7 +2242,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2266,7 +2266,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2290,7 +2290,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2314,7 +2314,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2338,7 +2338,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2362,7 +2362,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2386,7 +2386,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2410,7 +2410,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2510,7 +2510,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2530,7 +2530,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2554,7 +2554,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2578,7 +2578,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2602,7 +2602,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2626,7 +2626,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2650,7 +2650,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2674,7 +2674,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2708,7 +2708,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2747,7 +2747,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2823,7 +2823,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2843,7 +2843,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2863,7 +2863,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2883,7 +2883,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -2920,7 +2920,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -2947,7 +2947,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3031,7 +3031,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3051,7 +3051,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3071,7 +3071,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3091,7 +3091,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3111,7 +3111,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3211,7 +3211,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3231,7 +3231,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3251,7 +3251,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3271,7 +3271,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3291,7 +3291,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3478,7 +3478,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3498,7 +3498,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3518,7 +3518,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3538,7 +3538,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3558,7 +3558,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3681,7 +3681,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3701,7 +3701,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3733,7 +3733,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -3789,7 +3789,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -3865,7 +3865,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -3914,7 +3914,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -3966,7 +3966,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4049,7 +4049,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4128,7 +4128,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4177,7 +4177,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4210,7 +4210,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4273,6 +4273,24 @@
               "title": "Tool Id"
             },
             "description": "Tool ID (optional if provided in request body)"
+          },
+          {
+            "name": "X-QVeris-Cache-Mode",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "缓存策略：default（默认）或 bypass（跳过provider缓存）",
+              "title": "X-Qveris-Cache-Mode"
+            },
+            "description": "缓存策略：default（默认）或 bypass（跳过provider缓存）"
           }
         ],
         "responses": {
@@ -4333,7 +4351,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4370,7 +4388,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4423,7 +4441,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4477,7 +4495,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4529,7 +4547,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4635,7 +4653,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4672,7 +4690,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4721,7 +4739,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             },
@@ -4754,7 +4772,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4778,7 +4796,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4803,7 +4821,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4828,7 +4846,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -4848,7 +4866,7 @@
                 "required": true,
                 "schema": {
                   "type": "string",
-                  "const": "2026-08-13.1"
+                  "const": "2026-08-21.1"
                 }
               }
             }
@@ -6277,7 +6295,7 @@
             "title": "Contract Version",
             "description": "Version of the published QVeris REST API contract.",
             "examples": [
-              "2026-08-13.1"
+              "2026-08-21.1"
             ]
           }
         },

--- a/docs/openapi/qveris-public-api.projection-fixtures.json
+++ b/docs/openapi/qveris-public-api.projection-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": "2026-08-13.1",
+  "contract_version": "2026-08-21.1",
   "compatibility": {
     "legacy_service_ignores_projection": {
       "request": {"query": "current weather", "view": "routing"},

--- a/docs/zh-CN/rest-api.md
+++ b/docs/zh-CN/rest-api.md
@@ -1,6 +1,6 @@
 # QVeris REST API 文档
 
-版本：2026-08-13.1
+版本：2026-08-21.1
 
 公开 REST API 暴露核心 Agent 路径：
 

--- a/packages/mcp/src/generated/openapi.d.ts
+++ b/packages/mcp/src/generated/openapi.d.ts
@@ -1894,7 +1894,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -1905,7 +1905,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -1927,7 +1927,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -1938,7 +1938,7 @@ export interface operations {
             401: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content?: never;
@@ -2001,7 +2001,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2012,7 +2012,7 @@ export interface operations {
             400: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2023,7 +2023,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2050,7 +2050,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2061,7 +2061,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2090,7 +2090,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2114,7 +2114,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2125,7 +2125,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2156,7 +2156,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2167,7 +2167,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2279,7 +2279,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2290,7 +2290,7 @@ export interface operations {
             400: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2301,7 +2301,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2352,7 +2352,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2407,7 +2407,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2418,7 +2418,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2442,7 +2442,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2453,7 +2453,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2475,7 +2475,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2508,7 +2508,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2519,7 +2519,7 @@ export interface operations {
             401: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2530,7 +2530,7 @@ export interface operations {
             402: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2541,7 +2541,7 @@ export interface operations {
             403: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2552,7 +2552,7 @@ export interface operations {
             404: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2563,7 +2563,7 @@ export interface operations {
             408: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2574,7 +2574,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2585,7 +2585,7 @@ export interface operations {
             500: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2596,7 +2596,7 @@ export interface operations {
             503: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2625,7 +2625,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2636,7 +2636,7 @@ export interface operations {
             401: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2647,7 +2647,7 @@ export interface operations {
             402: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2658,7 +2658,7 @@ export interface operations {
             403: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2669,7 +2669,7 @@ export interface operations {
             404: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2680,7 +2680,7 @@ export interface operations {
             408: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2691,7 +2691,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2702,7 +2702,7 @@ export interface operations {
             500: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2724,7 +2724,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2746,7 +2746,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2779,7 +2779,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2790,7 +2790,7 @@ export interface operations {
             400: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2801,7 +2801,7 @@ export interface operations {
             401: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2812,7 +2812,7 @@ export interface operations {
             403: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2823,7 +2823,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2842,7 +2842,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2875,7 +2875,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2886,7 +2886,7 @@ export interface operations {
             400: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2897,7 +2897,7 @@ export interface operations {
             401: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2908,7 +2908,7 @@ export interface operations {
             403: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2919,7 +2919,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2956,7 +2956,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2967,7 +2967,7 @@ export interface operations {
             400: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2978,7 +2978,7 @@ export interface operations {
             401: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -2989,7 +2989,7 @@ export interface operations {
             403: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3000,7 +3000,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3060,7 +3060,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3071,7 +3071,7 @@ export interface operations {
             400: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3082,7 +3082,7 @@ export interface operations {
             401: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3093,7 +3093,7 @@ export interface operations {
             403: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3104,7 +3104,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3133,7 +3133,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3144,7 +3144,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3166,7 +3166,7 @@ export interface operations {
             200: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3205,7 +3205,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3224,7 +3224,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3243,7 +3243,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3262,7 +3262,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3303,7 +3303,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3322,7 +3322,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3341,7 +3341,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3352,7 +3352,7 @@ export interface operations {
             504: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3367,7 +3367,10 @@ export interface operations {
                 /** @description Tool ID (optional if provided in request body) */
                 tool_id?: string | null;
             };
-            header?: never;
+            header?: {
+                /** @description 缓存策略：default（默认）或 bypass（跳过provider缓存） */
+                "X-QVeris-Cache-Mode"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -3397,7 +3400,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3416,7 +3419,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3435,7 +3438,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3446,7 +3449,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3465,7 +3468,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3512,7 +3515,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3523,7 +3526,7 @@ export interface operations {
             400: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3542,7 +3545,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3553,7 +3556,7 @@ export interface operations {
             404: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3564,7 +3567,7 @@ export interface operations {
             422: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3583,7 +3586,7 @@ export interface operations {
                     /** @description Seconds until the client should retry after a rate-limit response. */
                     "Retry-After"?: number;
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3594,7 +3597,7 @@ export interface operations {
             502: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {
@@ -3605,7 +3608,7 @@ export interface operations {
             504: {
                 headers: {
                     /** @description Version of the published QVeris REST API contract. */
-                    "X-Qveris-Api-Version": "2026-08-13.1";
+                    "X-Qveris-Api-Version": "2026-08-21.1";
                     [name: string]: unknown;
                 };
                 content: {

--- a/packages/python-sdk/qveris/generated/openapi_models.py
+++ b/packages/python-sdk/qveris/generated/openapi_models.py
@@ -252,7 +252,7 @@ class PublicApiMetadata(BaseModel):
     contract_version: str = Field(
         ...,
         description='Version of the published QVeris REST API contract.',
-        examples=['2026-08-13.1'],
+        examples=['2026-08-21.1'],
         title='Contract Version',
     )
 


### PR DESCRIPTION
Mirrors website-owned REST API, Cookbook, and OpenAPI docs after qveris-website release/online OpenAPI documents changed. Source run: https://github.com/WonderfulValley/qveris-website/actions/runs/32720538146.