### PR TITLE
feat(mcp): annotate tool safety

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -86,6 +86,15 @@ jobs:
           fi
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
+      - name: Resolve npm dist-tag
+        run: |
+          NPM_DIST_TAG=$(node -p "require('./package.json').publishConfig?.tag || 'latest'")
+          if ! [[ "$NPM_DIST_TAG" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            echo "::error::Invalid npm dist-tag: $NPM_DIST_TAG"
+            exit 1
+          fi
+          echo "NPM_DIST_TAG=$NPM_DIST_TAG" >> "$GITHUB_ENV"
+
       - name: Verify CHANGELOG has an entry for this version
         run: |
           if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
@@ -100,7 +109,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "$NPM_DIST_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added complete MCP tool annotations (`title`, read-only, destructive, idempotent, and open-world hints) for every canonical tool and deprecated alias. The `call` family is conservatively marked as non-idempotent, destructive, and open-world. ([#316])
+
 ## [0.14.0] - 2026-08-10
 
 ### Added

--- a/packages/mcp/src/full-spec.test.ts
+++ b/packages/mcp/src/full-spec.test.ts
@@ -66,17 +66,6 @@ describe('output schemas + structured content', () => {
     await c.close();
   });
 
-  it('deprecated aliases declare the same outputSchema as their canonical tools', async () => {
-    const c = await connect();
-    const { tools } = await c.listTools();
-    const byName = new Map(tools.map((t) => [t.name, t]));
-    const aliases = { search_tools: 'discover', get_tools_by_ids: 'inspect', execute_tool: 'call' };
-    for (const [alias, canonical] of Object.entries(aliases)) {
-      expect(byName.get(alias)?.outputSchema, `${alias} outputSchema`).toEqual(byName.get(canonical)?.outputSchema);
-    }
-    await c.close();
-  });
-
   it('returns complete safety annotations from tools/list', async () => {
     const c = await connect();
     const { tools } = await c.listTools();

--- a/packages/mcp/src/full-spec.test.ts
+++ b/packages/mcp/src/full-spec.test.ts
@@ -3,7 +3,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createQverisServer } from './index.js';
+import { createQverisServer, QVERIS_MCP_TOOL_ANNOTATIONS } from './index.js';
 import type { QverisClient } from './api/client.js';
 
 /** Client-shaped fake covering the methods the tool executors use. */
@@ -73,6 +73,21 @@ describe('output schemas + structured content', () => {
     const aliases = { search_tools: 'discover', get_tools_by_ids: 'inspect', execute_tool: 'call' };
     for (const [alias, canonical] of Object.entries(aliases)) {
       expect(byName.get(alias)?.outputSchema, `${alias} outputSchema`).toEqual(byName.get(canonical)?.outputSchema);
+    }
+    await c.close();
+  });
+
+  it('returns complete safety annotations from tools/list', async () => {
+    const c = await connect();
+    const { tools } = await c.listTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+    const aliases = { search_tools: 'discover', get_tools_by_ids: 'inspect', execute_tool: 'call' } as const;
+
+    for (const [name, annotations] of Object.entries(QVERIS_MCP_TOOL_ANNOTATIONS)) {
+      expect(byName.get(name)?.annotations, `${name} annotations`).toEqual(annotations);
+    }
+    for (const [alias, canonical] of Object.entries(aliases)) {
+      expect(byName.get(alias)?.annotations, `${alias} annotations`).toEqual(byName.get(canonical)?.annotations);
     }
     await c.close();
   });

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -126,6 +126,51 @@ describe('MCP public tool interface', () => {
       execute_tool: 'call',
     } as const;
 
+    expect(QVERIS_MCP_TOOL_ANNOTATIONS).toEqual({
+      discover: {
+        title: 'Discover QVeris capabilities',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      inspect: {
+        title: 'Inspect QVeris capabilities',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      probe: {
+        title: 'Probe a QVeris capability',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      call: {
+        title: 'Call a third-party capability',
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+      usage_history: {
+        title: 'Query QVeris usage history',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      credits_ledger: {
+        title: 'Query QVeris credits ledger',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    });
+
     for (const name of canonicalTools) {
       expect(byName.get(name)?.annotations).toEqual(QVERIS_MCP_TOOL_ANNOTATIONS[name]);
     }

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -4,7 +4,13 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { executeQverisMcpTool, initializeQverisClient, isEntrypoint, listQverisMcpTools } from './index.js';
+import {
+  executeQverisMcpTool,
+  initializeQverisClient,
+  isEntrypoint,
+  listQverisMcpTools,
+  QVERIS_MCP_TOOL_ANNOTATIONS,
+} from './index.js';
 import type { QverisClient } from './api/client.js';
 import { creditsLedgerSchema } from './tools/credits-ledger.js';
 import { executeToolSchema } from './tools/execute.js';
@@ -109,6 +115,24 @@ describe('MCP public tool interface', () => {
     expect(byName.get('search_tools')?.description).toContain('Deprecated');
     expect(byName.get('get_tools_by_ids')?.description).toContain('Deprecated');
     expect(byName.get('execute_tool')?.description).toContain('Deprecated');
+  });
+
+  it('declares complete, conservative annotations for every tool', () => {
+    const byName = new Map(listQverisMcpTools().map((tool) => [tool.name, tool]));
+    const canonicalTools = ['discover', 'inspect', 'probe', 'call', 'usage_history', 'credits_ledger'] as const;
+    const aliases = {
+      search_tools: 'discover',
+      get_tools_by_ids: 'inspect',
+      execute_tool: 'call',
+    } as const;
+
+    for (const name of canonicalTools) {
+      expect(byName.get(name)?.annotations).toEqual(QVERIS_MCP_TOOL_ANNOTATIONS[name]);
+    }
+    for (const [alias, canonical] of Object.entries(aliases)) {
+      expect(byName.get(alias)?.annotations).toEqual(QVERIS_MCP_TOOL_ANNOTATIONS[canonical]);
+      expect(byName.get(alias)?.annotations).toEqual(byName.get(canonical)?.annotations);
+    }
   });
 
   it('routes canonical and deprecated tool calls through the server-level dispatcher', async () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -62,6 +62,56 @@ const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
 export const SERVER_VERSION: string = pkg.version;
 
+/**
+ * Client-facing MCP safety metadata. Registries use these hints to describe
+ * approval expectations before a tool is called, so aliases deliberately
+ * reuse the canonical entry rather than duplicating a second classification.
+ */
+export const QVERIS_MCP_TOOL_ANNOTATIONS = {
+  discover: {
+    title: 'Discover QVeris capabilities',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inspect: {
+    title: 'Inspect QVeris capabilities',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  probe: {
+    title: 'Probe a QVeris capability',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  call: {
+    title: 'Call a third-party capability',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  usage_history: {
+    title: 'Query QVeris usage history',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  credits_ledger: {
+    title: 'Query QVeris credits ledger',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+} as const;
+
 /** Discovery metadata (Server Card + Catalog) derived from package.json. */
 export function getQverisServerCardInfo(): ServerCardInfo {
   const repoUrl: string | undefined = pkg.repository?.url?.replace(/^git\+/, '').replace(/\.git$/, '');
@@ -94,6 +144,7 @@ export function listQverisMcpTools() {
         'Results may include billing_rule metadata for rule-level pricing.',
       inputSchema: searchToolsSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.discover,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.discover,
     },
     {
       name: 'inspect',
@@ -103,6 +154,7 @@ export function listQverisMcpTools() {
         'Use tool_ids from a previous discover call.',
       inputSchema: getToolsByIdsSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.inspect,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.inspect,
     },
     {
       name: 'probe',
@@ -111,6 +163,7 @@ export function listQverisMcpTools() {
         'Schema and quote are implemented; coverage and sample may return an explicit unknown verdict.',
       inputSchema: probeToolSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.probe,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.probe,
     },
     {
       name: 'call',
@@ -121,6 +174,7 @@ export function listQverisMcpTools() {
         'The response may include pre-settlement billing; use usage_history or credits_ledger for final charge status.',
       inputSchema: executeToolSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.call,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.call,
     },
     {
       name: 'usage_history',
@@ -128,6 +182,7 @@ export function listQverisMcpTools() {
         'Context-safe usage audit query. Defaults to aggregated summary, supports precise search by execution_id/search_id/charge_outcome/credit range, and writes large exports to a local JSONL file instead of returning all rows.',
       inputSchema: usageHistorySchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.usage_history,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.usage_history,
     },
     {
       name: 'credits_ledger',
@@ -135,6 +190,7 @@ export function listQverisMcpTools() {
         'Context-safe final credits ledger query. Defaults to aggregated summary, supports precise search by entry type/direction/credit range, and writes large exports to a local JSONL file instead of returning all rows.',
       inputSchema: creditsLedgerSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.credits_ledger,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.credits_ledger,
     },
     // Deprecated aliases (backward compatibility)
     {
@@ -142,18 +198,21 @@ export function listQverisMcpTools() {
       description: '[Deprecated: use "discover" instead] Search for available tools based on natural language queries.',
       inputSchema: searchToolsSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.discover,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.discover,
     },
     {
       name: 'get_tools_by_ids',
       description: '[Deprecated: use "inspect" instead] Get descriptions of tools based on their tool IDs.',
       inputSchema: getToolsByIdsSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.inspect,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.inspect,
     },
     {
       name: 'execute_tool',
       description: '[Deprecated: use "call" instead] Execute a specific remote tool with provided parameters.',
       inputSchema: executeToolSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.call,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.call,
     },
   ];
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -34,6 +34,7 @@ import {
   ReadResourceRequestSchema,
   SUPPORTED_PROTOCOL_VERSIONS,
   type CallToolResult,
+  type ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js';
 import { resolveTransportConfig, startHttpServer } from './http.js';
 import { buildServerCard, type ServerCardInfo } from './server-card.js';
@@ -67,6 +68,10 @@ export const SERVER_VERSION: string = pkg.version;
  * approval expectations before a tool is called, so aliases deliberately
  * reuse the canonical entry rather than duplicating a second classification.
  */
+type CompleteToolAnnotations = Required<
+  Pick<ToolAnnotations, 'title' | 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>
+>;
+
 export const QVERIS_MCP_TOOL_ANNOTATIONS = {
   discover: {
     title: 'Discover QVeris capabilities',
@@ -110,7 +115,7 @@ export const QVERIS_MCP_TOOL_ANNOTATIONS = {
     idempotentHint: true,
     openWorldHint: false,
   },
-} as const;
+} as const satisfies Record<string, CompleteToolAnnotations>;
 
 /** Discovery metadata (Server Card + Catalog) derived from package.json. */
 export function getQverisServerCardInfo(): ServerCardInfo {
@@ -197,21 +202,18 @@ export function listQverisMcpTools() {
       name: 'search_tools',
       description: '[Deprecated: use "discover" instead] Search for available tools based on natural language queries.',
       inputSchema: searchToolsSchema,
-      outputSchema: TOOL_OUTPUT_SCHEMAS.discover,
       annotations: QVERIS_MCP_TOOL_ANNOTATIONS.discover,
     },
     {
       name: 'get_tools_by_ids',
       description: '[Deprecated: use "inspect" instead] Get descriptions of tools based on their tool IDs.',
       inputSchema: getToolsByIdsSchema,
-      outputSchema: TOOL_OUTPUT_SCHEMAS.inspect,
       annotations: QVERIS_MCP_TOOL_ANNOTATIONS.inspect,
     },
     {
       name: 'execute_tool',
       description: '[Deprecated: use "call" instead] Execute a specific remote tool with provided parameters.',
       inputSchema: executeToolSchema,
-      outputSchema: TOOL_OUTPUT_SCHEMAS.call,
       annotations: QVERIS_MCP_TOOL_ANNOTATIONS.call,
     },
   ];

--- a/scripts/release-client-packages.test.mjs
+++ b/scripts/release-client-packages.test.mjs
@@ -151,6 +151,14 @@ test("repository publish workflows exist and listen for every coordinated tag", 
   );
 });
 
+test("MCP publishing validates and passes through its package-configured npm dist-tag", () => {
+  const workflow = readFileSync(join(REPOSITORY_ROOT, ".github/workflows", "mcp-publish.yml"), "utf8");
+
+  assert.match(workflow, /NPM_DIST_TAG=\$\(node -p "require\('\.\/package\.json'\)\.publishConfig\?\.tag \|\| 'latest'"\)/);
+  assert.match(workflow, /Invalid npm dist-tag: \$NPM_DIST_TAG/);
+  assert.match(workflow, /npm publish --provenance --access public --tag "\$NPM_DIST_TAG"/);
+});
+
 test("repository cadence workflow passes the task set to the reference adapter and verifies the exact CLI version", () => {
   const workflow = readFileSync(
     join(REPOSITORY_ROOT, ".github/workflows", BENCHMARK_CADENCE_WORKFLOW),


### PR DESCRIPTION
## Summary

Implements #316 on the current MCP line.

- Adds complete MCP annotations (`title`, read-only, destructive, idempotent, and open-world hints) to every canonical tool returned by `tools/list`.
- Gives every deprecated alias the exact annotation object of its canonical counterpart.
- Adds both unit-level and protocol-level `tools/list` contract coverage.
- Makes the publish workflow resolve and validate an explicit npm dist-tag; default releases remain on `latest`, while a reviewed maintenance release can publish under a non-default tag without moving `latest` backward.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` (185 tests)

The minimal 0.10 compatibility backport is tracked separately in #318.