### PR TITLE
fix(mcp): backport tool annotations

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -86,6 +86,15 @@ jobs:
           fi
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
 
+      - name: Resolve npm dist-tag
+        run: |
+          NPM_DIST_TAG=$(node -p "require('./package.json').publishConfig?.tag || 'latest'")
+          if ! [[ "$NPM_DIST_TAG" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            echo "::error::Invalid npm dist-tag: $NPM_DIST_TAG"
+            exit 1
+          fi
+          echo "NPM_DIST_TAG=$NPM_DIST_TAG" >> "$GITHUB_ENV"
+
       - name: Verify CHANGELOG has an entry for this version
         run: |
           if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
@@ -100,7 +109,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "$NPM_DIST_TAG"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-26
+
+### Added
+
+- Added complete MCP tool annotations (`title`, read-only, destructive, idempotent, and open-world hints) for every tool returned by `tools/list`. Deprecated aliases reuse their canonical tool annotations; `call` / `execute_tool` remain conservatively classified as destructive, non-idempotent, and open-world. ([#316])
+
 ## [0.10.0] - 2026-07-14
 
 ### Changed
@@ -115,7 +121,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Handle empty/non-JSON success responses gracefully; `params_to_tool` documented as an object.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.10.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.10.1...HEAD
+[0.10.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.10.0...mcp-v0.10.1
 [0.10.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.9.0...mcp-v0.10.0
 [0.9.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.8.0...mcp-v0.9.0
 [0.8.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.7.5...mcp-v0.8.0

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.QVerisAI/mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",
@@ -32,6 +32,10 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "legacy-0.10"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "subfolder": "packages/mcp"
   },
   "websiteUrl": "https://qveris.ai",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp/src/full-spec.test.ts
+++ b/packages/mcp/src/full-spec.test.ts
@@ -3,7 +3,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createQverisServer } from './index.js';
+import { createQverisServer, QVERIS_MCP_TOOL_ANNOTATIONS } from './index.js';
 import type { QverisClient } from './api/client.js';
 
 /** Client-shaped fake covering the methods the tool executors use. */
@@ -59,6 +59,21 @@ describe('output schemas + structured content', () => {
     expect(result.structuredContent).toMatchObject({ search_id: 's1' });
     const text = (result.content as Array<{ text: string }>)[0].text;
     expect(JSON.parse(text).search_id).toBe('s1');
+    await c.close();
+  });
+
+  it('returns complete annotations from tools/list', async () => {
+    const c = await connect();
+    const { tools } = await c.listTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+    const aliases = { search_tools: 'discover', get_tools_by_ids: 'inspect', execute_tool: 'call' } as const;
+
+    for (const [name, annotations] of Object.entries(QVERIS_MCP_TOOL_ANNOTATIONS)) {
+      expect(byName.get(name)?.annotations, `${name} annotations`).toEqual(annotations);
+    }
+    for (const [alias, canonical] of Object.entries(aliases)) {
+      expect(byName.get(alias)?.annotations, `${alias} annotations`).toEqual(byName.get(canonical)?.annotations);
+    }
     await c.close();
   });
 });

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -4,7 +4,13 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { executeQverisMcpTool, initializeQverisClient, isEntrypoint, listQverisMcpTools } from './index.js';
+import {
+  executeQverisMcpTool,
+  initializeQverisClient,
+  isEntrypoint,
+  listQverisMcpTools,
+  QVERIS_MCP_TOOL_ANNOTATIONS,
+} from './index.js';
 import type { QverisClient } from './api/client.js';
 import { creditsLedgerSchema } from './tools/credits-ledger.js';
 import { executeToolSchema } from './tools/execute.js';
@@ -106,6 +112,23 @@ describe('MCP public tool interface', () => {
     expect(byName.get('search_tools')?.description).toContain('Deprecated');
     expect(byName.get('get_tools_by_ids')?.description).toContain('Deprecated');
     expect(byName.get('execute_tool')?.description).toContain('Deprecated');
+  });
+
+  it('declares complete annotations and keeps aliases identical to canonical tools', () => {
+    const byName = new Map(listQverisMcpTools().map((tool) => [tool.name, tool]));
+    const aliases = {
+      search_tools: 'discover',
+      get_tools_by_ids: 'inspect',
+      execute_tool: 'call',
+    } as const;
+
+    for (const [name, annotations] of Object.entries(QVERIS_MCP_TOOL_ANNOTATIONS)) {
+      expect(byName.get(name)?.annotations).toEqual(annotations);
+    }
+    for (const [alias, canonical] of Object.entries(aliases)) {
+      expect(byName.get(alias)?.annotations).toEqual(QVERIS_MCP_TOOL_ANNOTATIONS[canonical]);
+      expect(byName.get(alias)?.annotations).toEqual(byName.get(canonical)?.annotations);
+    }
   });
 
   it('routes canonical and deprecated tool calls through the server-level dispatcher', async () => {

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -116,14 +116,53 @@ describe('MCP public tool interface', () => {
 
   it('declares complete annotations and keeps aliases identical to canonical tools', () => {
     const byName = new Map(listQverisMcpTools().map((tool) => [tool.name, tool]));
+    const canonicalTools = ['discover', 'inspect', 'call', 'usage_history', 'credits_ledger'] as const;
     const aliases = {
       search_tools: 'discover',
       get_tools_by_ids: 'inspect',
       execute_tool: 'call',
     } as const;
 
-    for (const [name, annotations] of Object.entries(QVERIS_MCP_TOOL_ANNOTATIONS)) {
-      expect(byName.get(name)?.annotations).toEqual(annotations);
+    expect(QVERIS_MCP_TOOL_ANNOTATIONS).toEqual({
+      discover: {
+        title: 'Discover QVeris capabilities',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      inspect: {
+        title: 'Inspect QVeris capabilities',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      call: {
+        title: 'Call a third-party capability',
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+      usage_history: {
+        title: 'Query QVeris usage history',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      credits_ledger: {
+        title: 'Query QVeris credits ledger',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    });
+
+    for (const name of canonicalTools) {
+      expect(byName.get(name)?.annotations).toEqual(QVERIS_MCP_TOOL_ANNOTATIONS[name]);
     }
     for (const [alias, canonical] of Object.entries(aliases)) {
       expect(byName.get(alias)?.annotations).toEqual(QVERIS_MCP_TOOL_ANNOTATIONS[canonical]);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -34,6 +34,7 @@ import {
   ReadResourceRequestSchema,
   SUPPORTED_PROTOCOL_VERSIONS,
   type CallToolResult,
+  type ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js';
 import { resolveTransportConfig, startHttpServer } from './http.js';
 import { buildServerCard, type ServerCardInfo } from './server-card.js';
@@ -65,6 +66,10 @@ export const SERVER_VERSION: string = pkg.version;
  * Client-facing MCP safety metadata. Deprecated aliases reuse the canonical
  * classification so directory and approval behavior cannot drift by name.
  */
+type CompleteToolAnnotations = Required<
+  Pick<ToolAnnotations, 'title' | 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint'>
+>;
+
 export const QVERIS_MCP_TOOL_ANNOTATIONS = {
   discover: {
     title: 'Discover QVeris capabilities',
@@ -101,7 +106,7 @@ export const QVERIS_MCP_TOOL_ANNOTATIONS = {
     idempotentHint: true,
     openWorldHint: false,
   },
-} as const;
+} as const satisfies Record<string, CompleteToolAnnotations>;
 
 /** Discovery metadata (Server Card + Catalog) derived from package.json. */
 export function getQverisServerCardInfo(): ServerCardInfo {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -61,6 +61,48 @@ const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
 export const SERVER_VERSION: string = pkg.version;
 
+/**
+ * Client-facing MCP safety metadata. Deprecated aliases reuse the canonical
+ * classification so directory and approval behavior cannot drift by name.
+ */
+export const QVERIS_MCP_TOOL_ANNOTATIONS = {
+  discover: {
+    title: 'Discover QVeris capabilities',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inspect: {
+    title: 'Inspect QVeris capabilities',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  call: {
+    title: 'Call a third-party capability',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  usage_history: {
+    title: 'Query QVeris usage history',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  credits_ledger: {
+    title: 'Query QVeris credits ledger',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+} as const;
+
 /** Discovery metadata (Server Card + Catalog) derived from package.json. */
 export function getQverisServerCardInfo(): ServerCardInfo {
   const repoUrl: string | undefined = pkg.repository?.url?.replace(/^git\+/, '').replace(/\.git$/, '');
@@ -93,6 +135,7 @@ export function listQverisMcpTools() {
         'Results may include billing_rule metadata for rule-level pricing.',
       inputSchema: searchToolsSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.discover,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.discover,
     },
     {
       name: 'inspect',
@@ -102,6 +145,7 @@ export function listQverisMcpTools() {
         'Use tool_ids from a previous discover call.',
       inputSchema: getToolsByIdsSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.inspect,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.inspect,
     },
     {
       name: 'call',
@@ -112,6 +156,7 @@ export function listQverisMcpTools() {
         'The response may include pre-settlement billing; use usage_history or credits_ledger for final charge status.',
       inputSchema: executeToolSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.call,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.call,
     },
     {
       name: 'usage_history',
@@ -119,6 +164,7 @@ export function listQverisMcpTools() {
         'Context-safe usage audit query. Defaults to aggregated summary, supports precise search by execution_id/search_id/charge_outcome/credit range, and writes large exports to a local JSONL file instead of returning all rows.',
       inputSchema: usageHistorySchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.usage_history,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.usage_history,
     },
     {
       name: 'credits_ledger',
@@ -126,22 +172,26 @@ export function listQverisMcpTools() {
         'Context-safe final credits ledger query. Defaults to aggregated summary, supports precise search by entry type/direction/credit range, and writes large exports to a local JSONL file instead of returning all rows.',
       inputSchema: creditsLedgerSchema,
       outputSchema: TOOL_OUTPUT_SCHEMAS.credits_ledger,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.credits_ledger,
     },
     // Deprecated aliases (backward compatibility)
     {
       name: 'search_tools',
       description: '[Deprecated: use "discover" instead] Search for available tools based on natural language queries.',
       inputSchema: searchToolsSchema,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.discover,
     },
     {
       name: 'get_tools_by_ids',
       description: '[Deprecated: use "inspect" instead] Get descriptions of tools based on their tool IDs.',
       inputSchema: getToolsByIdsSchema,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.inspect,
     },
     {
       name: 'execute_tool',
       description: '[Deprecated: use "call" instead] Execute a specific remote tool with provided parameters.',
       inputSchema: executeToolSchema,
+      annotations: QVERIS_MCP_TOOL_ANNOTATIONS.call,
     },
   ];
 }


### PR DESCRIPTION
## Summary

Backports the tool annotations required by #316 to the maintained 0.10 line as `@qverisai/mcp@0.10.1`.

- Adds complete MCP annotations (`title`, read-only, destructive, idempotent, and open-world hints) to every `tools/list` entry.
- Keeps each deprecated alias exactly aligned with its canonical tool.
- Preserves the 0.10 tool surface and existing alias schemas; this patch does not add newer tools.
- Publishes this maintenance release with the `legacy-0.10` npm dist-tag, so it remains exactly pinnable without moving npm `latest` backward.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` (148 tests)
- Manifest, package version, and dist-tag consistency check
