### PR TITLE
test(python-sdk): exercise agents runner

### DIFF
--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "python-dotenv",
     "rich>=13.0.0",
     "langchain-core>=0.3.0; python_version >= '3.9'",  # for the LangChain integration tests
-    "openai-agents>=0.1.0; python_version >= '3.10'",  # for the OpenAI Agents integration tests
+    "openai-agents>=0.20.0; python_version >= '3.10'",  # for the OpenAI Agents integration tests
     "autogen-core>=0.7.5; python_version >= '3.10'",  # for the AutoGen integration tests
     "llama-index-core>=0.14.23; python_version >= '3.10'",  # for the LlamaIndex integration tests
     "pydantic-ai-slim>=2.11.0; python_version >= '3.10'",  # for the Pydantic AI integration tests

--- a/packages/python-sdk/tests/test_openai_agents_integration.py
+++ b/packages/python-sdk/tests/test_openai_agents_integration.py
@@ -1,15 +1,118 @@
 import json
+from collections.abc import AsyncIterator
 from typing import Any, Dict, List, Optional
 
 import pytest
 
 pytest.importorskip("agents", reason="OpenAI Agents integration requires openai-agents (Python >=3.10)")
 
+from agents import Agent, Model, ModelResponse, RunConfig, Runner, Usage  # noqa: E402
 from agents.tool_context import ToolContext  # noqa: E402
+from openai.types.responses import (  # noqa: E402
+    Response,
+    ResponseCompletedEvent,
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
 
 from qveris.integrations.openai_agents import get_qveris_tools  # noqa: E402
 
 from adapter_conformance import AdapterConformance, FakeClient, run  # noqa: E402
+
+
+class ScriptedRunnerModel(Model):
+    """Minimal provider-free model that drives the public Runner contract.
+
+    ``agents.testing.ScriptedModel`` is not available in the supported 0.20
+    SDK line. This uses its public ``Model`` interface instead of introducing
+    a third-party test dependency.
+    """
+
+    def __init__(self, outputs: List[Any]) -> None:
+        self._outputs = list(outputs)
+        self.inputs: List[Any] = []
+
+    def _next_response(self) -> ModelResponse:
+        if not self._outputs:
+            raise AssertionError("Runner made more model calls than scripted")
+        return ModelResponse(output=[self._outputs.pop(0)], usage=Usage(), response_id="scripted-response")
+
+    async def get_response(self, system_instructions: Any, input: Any, *_args: Any, **_kwargs: Any) -> ModelResponse:
+        del system_instructions
+        self.inputs.append(input)
+        return self._next_response()
+
+    def stream_response(self, system_instructions: Any, input: Any, *_args: Any, **_kwargs: Any) -> AsyncIterator[Any]:
+        del system_instructions
+
+        async def stream() -> AsyncIterator[Any]:
+            self.inputs.append(input)
+            response = self._next_response()
+            yield ResponseCompletedEvent(
+                type="response.completed",
+                sequence_number=0,
+                response=Response(
+                    id=response.response_id or "scripted-response",
+                    created_at=0,
+                    model="scripted",
+                    object="response",
+                    output=response.output,
+                    parallel_tool_calls=False,
+                    tool_choice="auto",
+                    tools=[],
+                ),
+            )
+
+        return stream()
+
+    def assert_complete(self) -> None:
+        assert not self._outputs, "Runner did not consume the complete model script"
+
+
+def _scripted_discover_call() -> ResponseFunctionToolCall:
+    return ResponseFunctionToolCall(
+        id="fc_discover",
+        call_id="call_discover",
+        name="qveris_discover",
+        arguments=json.dumps({"query": "weather forecast API", "limit": 1}),
+        status="completed",
+        type="function_call",
+    )
+
+
+def _scripted_final_message() -> ResponseOutputMessage:
+    return ResponseOutputMessage(
+        id="msg_final",
+        content=[
+            ResponseOutputText(
+                annotations=[],
+                text="Found the weather capability.",
+                type="output_text",
+            )
+        ],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+
+
+def _assert_runner_contract(client: FakeClient, model: ScriptedRunnerModel, final_output: str) -> None:
+    assert final_output == "Found the weather capability."
+    assert client.calls == [
+        {
+            "name": "discover",
+            "args": {"query": "weather forecast API", "limit": 1},
+            "session_id": "runner-session",
+        }
+    ]
+    assert len(model.inputs) == 2
+    assert any(
+        item.get("type") == "function_call_output" and item.get("call_id") == "call_discover"
+        for item in model.inputs[1]
+        if isinstance(item, dict)
+    )
+    model.assert_complete()
 
 
 class TestOpenAIAgentsAdapterConformance(AdapterConformance):
@@ -41,3 +144,35 @@ def test_discover_is_strict_but_dict_taking_tools_are_not() -> None:
     assert tools["qveris_discover"].strict_json_schema is True
     assert tools["qveris_inspect"].strict_json_schema is False
     assert tools["qveris_call"].strict_json_schema is False
+
+
+@pytest.mark.asyncio
+async def test_runner_executes_discover_once_and_links_its_output() -> None:
+    client = FakeClient()
+    model = ScriptedRunnerModel([_scripted_discover_call(), _scripted_final_message()])
+    agent = Agent(
+        name="QVeris test agent",
+        model=model,
+        tools=get_qveris_tools(client, session_id="runner-session"),
+    )
+
+    result = await Runner.run(agent, "Find a weather capability.", run_config=RunConfig(tracing_disabled=True))
+
+    _assert_runner_contract(client, model, result.final_output)
+
+
+@pytest.mark.asyncio
+async def test_streamed_runner_matches_non_streaming_tool_execution() -> None:
+    client = FakeClient()
+    model = ScriptedRunnerModel([_scripted_discover_call(), _scripted_final_message()])
+    agent = Agent(
+        name="QVeris test agent",
+        model=model,
+        tools=get_qveris_tools(client, session_id="runner-session"),
+    )
+
+    result = Runner.run_streamed(agent, "Find a weather capability.", run_config=RunConfig(tracing_disabled=True))
+    events = [event async for event in result.stream_events()]
+
+    assert events
+    _assert_runner_contract(client, model, result.final_output)

--- a/packages/python-sdk/uv.lock
+++ b/packages/python-sdk/uv.lock
@@ -3965,7 +3965,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.18.2"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib", marker = "python_full_version >= '3.10'" },
@@ -3976,9 +3976,9 @@ dependencies = [
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "websockets", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/0c/52e9aeff5549b225d5666a0eb84a8a22b4c47db08b6f44dbd45876fcfba3/openai_agents-0.18.2.tar.gz", hash = "sha256:9f418bb563eddff1e01f245ae8a4964b7649396f444b569b4113d105e41ca1d3", size = 5546139, upload-time = "2026-07-11T01:08:18.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/18/1204bde976436ad85498b759d5297843ebd2e0a214f729eb2dc4423cdfc7/openai_agents-0.20.0.tar.gz", hash = "sha256:a6b37954877868ac233876a27dab1e2a461c53ecbd5fcf6e19e2d276d3e848cd", size = 6146452, upload-time = "2026-08-11T03:12:49.556Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/23/b5b6b80a3e36f021ca2a8c4637684f0d722d646b19d3616768a68802c302/openai_agents-0.18.2-py3-none-any.whl", hash = "sha256:c7aea341b256a90b87b17b7e444bab29a12655864a2f0094f65561223d867185", size = 874310, upload-time = "2026-07-11T01:08:16.851Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/8b/18528f00cb1a5d0b8e00f457f7dc88e7b17439bc520861aae2b638b88710/openai_agents-0.20.0-py3-none-any.whl", hash = "sha256:aaff662b802fa90762ad539e131b9ea387e12e3664b87bc75157ad1b3fc88850", size = 1064338, upload-time = "2026-08-11T03:12:47.615Z" },
 ]
 
 [[package]]
@@ -6107,7 +6107,7 @@ requires-dist = [
     { name = "llama-index-core", marker = "python_full_version >= '3.10' and extra == 'dev'", specifier = ">=0.14.23" },
     { name = "llama-index-core", marker = "python_full_version >= '3.10' and extra == 'llamaindex'", specifier = ">=0.14.23" },
     { name = "openai", specifier = ">=1.0.0" },
-    { name = "openai-agents", marker = "python_full_version >= '3.10' and extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "openai-agents", marker = "python_full_version >= '3.10' and extra == 'dev'", specifier = ">=0.20.0" },
     { name = "openai-agents", marker = "python_full_version >= '3.10' and extra == 'openai-agents'", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.20.0" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
@@ -6123,7 +6123,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'dev'", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "sphinx", marker = "python_full_version >= '3.10' and extra == 'dev'", specifier = "==8.1.3" },
-    { name = "sphinx-markdown-builder", marker = "python_full_version >= '3.10' and extra == 'dev'", specifier = "==0.6.10" },
+    { name = "sphinx-markdown-builder", marker = "python_full_version >= '3.10' and extra == 'dev'", specifier = "==0.6.11" },
 ]
 provides-extras = ["langchain", "openai-agents", "crewai", "autogen", "llamaindex", "pydantic-ai", "otel", "dev"]
 
@@ -6716,16 +6716,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-markdown-builder"
-version = "0.6.10"
+version = "0.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils", marker = "python_full_version >= '3.10'" },
     { name = "sphinx", marker = "python_full_version >= '3.10'" },
     { name = "tabulate", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/13/102d7134743120db25e636ffb57a30818e95a416583dca83aadac9c5dd87/sphinx_markdown_builder-0.6.11.tar.gz", hash = "sha256:ba3bf33e0e42ff30ae686ac73957a95e6d045790dcfbaca012dd8ae01794e577", size = 24020, upload-time = "2026-08-16T06:51:38.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/71/06b415631c2e494c80546073b46013d1715dceb3abe30bd63b34b4e7d9ca/sphinx_markdown_builder-0.6.11-py3-none-any.whl", hash = "sha256:acfb94d6ee66c7a47da0ca0420578fa16f115812af25b8fd21755d5909aacf51", size = 18088, upload-time = "2026-08-16T06:51:36.81Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add provider-free contract coverage for the QVeris Agents adapter through real `Runner.run` and `Runner.run_streamed` paths
- verify tool-call/output linkage, exactly-once discovery routing, stream completion, and complete scripted-response consumption
- resolve the development Agents SDK to `0.20.0` while preserving the published `qveris[openai-agents]` lower bound; no third-party test dependency is added
- refresh the lock entry required by the existing documentation-build dependency pin

## Validation

- `uv lock --check`
- `uv run --frozen --extra dev pytest -q` — 196 passed, 1 skipped
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check .`

Closes #307