### PR TITLE
feat(mcp): advertise the hosted server in the registry

### DIFF
--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.QVerisAI/mcp",
-  "description": "Discover, inspect and call ranked external data & tool APIs with unified billing and usage audit",
+  "title": "QVeris",
+  "description": "Discover, inspect, quote, and call external tools, with usage and final credit settlement audits",
   "repository": {
     "url": "https://github.com/QVerisAI/qveris-agent-toolkit",
     "source": "github",
@@ -9,6 +10,20 @@
   },
   "websiteUrl": "https://qveris.ai",
   "version": "0.14.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.qveris.ai/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer QVeris API key (format: Bearer YOUR_QVERIS_API_KEY)",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ],
   "packages": [
     {
       "registryType": "npm",

--- a/packages/mcp/src/server-json.test.ts
+++ b/packages/mcp/src/server-json.test.ts
@@ -31,9 +31,20 @@ interface RegistryManifest {
   packages?: RegistryPackage[];
 }
 
+interface PackageManifest {
+  name?: string;
+  mcpName?: string;
+  version?: string;
+}
+
 function loadRegistryManifest(): RegistryManifest {
   const path = join(process.cwd(), 'server.json');
   return JSON.parse(readFileSync(path, 'utf8')) as RegistryManifest;
+}
+
+function loadPackageManifest(): PackageManifest {
+  const path = join(process.cwd(), 'package.json');
+  return JSON.parse(readFileSync(path, 'utf8')) as PackageManifest;
 }
 
 describe('MCP Registry manifest', () => {
@@ -63,9 +74,12 @@ describe('MCP Registry manifest', () => {
 
   it('keeps the registry identity and schema aligned with the published package', () => {
     const manifest = loadRegistryManifest();
+    const packageManifest = loadPackageManifest();
+    const local = manifest.packages?.find((entry) => entry.identifier === packageManifest.name);
 
     expect(manifest.$schema).toBe('https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json');
-    expect(manifest.name).toBe('io.github.QVerisAI/mcp');
-    expect(manifest.version).toBe('0.14.0');
+    expect(manifest.name).toBe(packageManifest.mcpName);
+    expect(manifest.version).toBe(packageManifest.version);
+    expect(local?.version).toBe(packageManifest.version);
   });
 });

--- a/packages/mcp/src/server-json.test.ts
+++ b/packages/mcp/src/server-json.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+interface RegistryInput {
+  name?: string;
+  description?: string;
+  isRequired?: boolean;
+  isSecret?: boolean;
+}
+
+interface RegistryRemote {
+  type?: string;
+  url?: string;
+  headers?: RegistryInput[];
+}
+
+interface RegistryPackage {
+  identifier?: string;
+  version?: string;
+  transport?: { type?: string };
+}
+
+interface RegistryManifest {
+  $schema?: string;
+  name?: string;
+  title?: string;
+  description?: string;
+  version?: string;
+  remotes?: RegistryRemote[];
+  packages?: RegistryPackage[];
+}
+
+function loadRegistryManifest(): RegistryManifest {
+  const path = join(process.cwd(), 'server.json');
+  return JSON.parse(readFileSync(path, 'utf8')) as RegistryManifest;
+}
+
+describe('MCP Registry manifest', () => {
+  it('advertises both Hosted Streamable HTTP and local stdio transports', () => {
+    const manifest = loadRegistryManifest();
+    const hosted = manifest.remotes?.find((remote) => remote.type === 'streamable-http');
+    const local = manifest.packages?.find((entry) => entry.identifier === '@qverisai/mcp');
+
+    expect(manifest.title).toBe('QVeris');
+    expect(manifest.description).toContain('Discover, inspect, quote, and call');
+    expect(hosted?.url).toBe('https://mcp.qveris.ai/mcp');
+    expect(local?.transport?.type).toBe('stdio');
+    expect(local?.version).toBe(manifest.version);
+  });
+
+  it('declares the Hosted API key as a required secret Authorization header', () => {
+    const manifest = loadRegistryManifest();
+    const authorization = manifest.remotes?.[0]?.headers?.find((header) => header.name === 'Authorization');
+
+    expect(authorization).toEqual({
+      name: 'Authorization',
+      description: 'Bearer QVeris API key (format: Bearer YOUR_QVERIS_API_KEY)',
+      isRequired: true,
+      isSecret: true,
+    });
+  });
+
+  it('keeps the registry identity and schema aligned with the published package', () => {
+    const manifest = loadRegistryManifest();
+
+    expect(manifest.$schema).toBe('https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json');
+    expect(manifest.name).toBe('io.github.QVerisAI/mcp');
+    expect(manifest.version).toBe('0.14.0');
+  });
+});


### PR DESCRIPTION
## 解决的问题

关联 WonderfulValley/qveris-website#2505 的拆解项 C。官方 MCP Registry 目前只声明 npm/stdio 包，使用者无法从 Registry 直接得知 QVeris 已提供 Hosted Streamable HTTP 服务、认证头和六个核心能力的产品定位。

## 原因

`packages/mcp/server.json` 缺少顶层 `title` 和 `remotes`；描述只强调本地包，没有把 Discover / Inspect / Probe / Call / Usage / Credits Ledger 的用途表达完整。

## 做到哪里了

- 增加 Registry 展示名 `QVeris`。
- 描述更新为可独立理解的 Discover、Inspect、Quote/Probe、Call、usage 与 final credit settlement audit 定位，并满足官方 100 字符上限。
- 保留 npm `@qverisai/mcp@0.14.0` stdio 安装方式。
- 同时声明 Hosted remote：`https://mcp.qveris.ai/mcp`，transport 为 `streamable-http`。
- 声明必填且保密的 `Authorization` header，明确格式为 `Bearer YOUR_QVERIS_API_KEY`，不写入真实密钥。
- 新增 manifest 回归测试，校验 title/description、remote URL、认证字段、stdio 共存、Registry identity、schema 与 package version。

## 验证

- 官方 `2025-12-11` MCP Registry JSON Schema（实时下载）校验通过。
- `server-json.test.ts`：3/3 passed。
- MCP package `tsc --noEmit`：通过。
- ESLint 与 Prettier：通过。
- 线上无密钥探测：Hosted MCP 返回 401，说明认证边界生效；公开 Server Card 返回 200。

## 不包含

- 不修改 MCP 工具运行逻辑或版本号。
- 不新增或修改任何工作流、connector 配置或密钥。
- Registry 只声明公开 Hosted 服务，不混入另一部署地址。