### PR TITLE
feat: publish QVeris as a Gemini CLI extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ The Cursor plugin in this repository bundles the hosted QVeris MCP connection an
 
 The API key is stored by Cursor as a plugin variable and is never committed to this repository.
 
+#### Gemini CLI extension
+
+Install QVeris directly from this repository:
+
+```bash
+gemini extensions install https://github.com/QVerisAI/qveris-agent-toolkit
+```
+
+During installation, enter your `QVERIS_API_KEY` when prompted. Gemini CLI stores it as a sensitive extension setting and connects to the hosted QVeris MCP server at `https://mcp.qveris.ai/mcp`.
+
+Restart Gemini CLI after installation, then run `/mcp` to confirm that the `qveris` server is connected and its tools are available.
+
 ### After setup
 
 Try a task: "Check the current weather in Tokyo"

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -127,6 +127,18 @@ Agent 会自动下载 [OpenClaw 官方技能](skills/openclaw/qveris-official/SK
 
 请按照 [安装指南 (agent/SETUP.md)](agent/SETUP.md) 操作 — Agent 会为你的环境配置 MCP server + [技能](skills/qveris/SKILL.md)。
 
+#### Gemini CLI 扩展
+
+可以直接从本仓库安装 QVeris：
+
+```bash
+gemini extensions install https://github.com/QVerisAI/qveris-agent-toolkit
+```
+
+安装时按提示输入 `QVERIS_API_KEY`。Gemini CLI 会将它作为敏感扩展设置安全保存，并连接到托管的 QVeris MCP 服务 `https://mcp.qveris.ai/mcp`。
+
+安装完成后重启 Gemini CLI，然后运行 `/mcp` 确认 `qveris` 服务器已连接且工具可用。
+
 ### 安装完成后
 
 试一个任务："帮我查一下东京现在的天气"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,21 @@
+{
+  "name": "qveris",
+  "version": "0.14.0",
+  "description": "Discover, inspect, and call 10,000+ real-world tools from Gemini CLI with QVeris.",
+  "mcpServers": {
+    "qveris": {
+      "httpUrl": "https://mcp.qveris.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer $QVERIS_API_KEY"
+      }
+    }
+  },
+  "settings": [
+    {
+      "name": "QVeris API Key",
+      "description": "Your QVeris API key. Get one at https://qveris.ai/account?page=api-keys.",
+      "envVar": "QVERIS_API_KEY",
+      "sensitive": true
+    }
+  ]
+}


### PR DESCRIPTION
## What

- add a root-level `gemini-extension.json` for the hosted QVeris MCP server
- collect `QVERIS_API_KEY` through Gemini CLI's sensitive extension settings
- document installation and verification in English and Chinese

After merge, a repository admin must add the `gemini-cli-extension` GitHub topic. Gemini CLI's gallery crawler will then discover this public repository automatically on its daily crawl; no separate gallery submission is required.

## Validation

- `npx -y @google/gemini-cli@latest extensions validate .` — passed
- authenticated MCP initialize handshake — passed (protocol `2025-06-18`)
- unauthenticated endpoint check — correctly returns HTTP 401 with `Bearer credential required`
- `git diff --check` — passed

## Checklist

- [x] Tests added/updated for behavior changes (manifest validated with the official CLI)
- [x] No package behavior changed; no package changelog update required
- [x] Generated files untouched
