### PR TITLE
fix(mcp): restore published tool contract

### DIFF
--- a/agent/GUIDELINES.md
+++ b/agent/GUIDELINES.md
@@ -323,6 +323,6 @@ Run `qveris doctor` to check setup: Node.js version, API key validity, endpoint 
 | Probe | `{"parameters": {...}, "checks": ["schema", "quote"], "live_budget": "none"}` |
 | Call | `{"search_id": "...", "parameters": {...}, "model": "router-model-v1", "max_response_size": 20480}` |
 
-> **MCP backward compatibility:** Old tool names `search_tools`, `get_tools_by_ids`, `execute_tool` are still supported as deprecated aliases in MCP server v0.14.0. Use the canonical names (`discover`, `inspect`, `probe`, `call`, `usage_history`, `credits_ledger`) going forward.
+> **MCP backward compatibility:** Old tool names `search_tools`, `get_tools_by_ids`, `execute_tool` are still supported as deprecated aliases in MCP server v0.14.1. Use the canonical names (`discover`, `inspect`, `probe`, `call`, `usage_history`, `credits_ledger`) going forward.
 
 Full API documentation: https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/rest-api.md

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -97,7 +97,7 @@ Reconnect the client and confirm `discover`, `inspect`, `probe`, and `call` are 
 Detect which MCP-capable desktop client you are currently running in. QVeris supports Claude Code, ChatGPT (Codex), OpenCode, Cursor, Cherry Studio, TRAE, GitHub Copilot, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, and WorkBuddy.
 
 **Configuration involves two steps for all environments:**
-1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.0) to your environment.
+1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.1) to your environment.
 2. **Skill Configuration:** Teaches the agent how to use the tools using the MCP/client skill definition file.
    - **Skill URL:** `https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/skills/qveris/SKILL.md`
 

--- a/agent/llms-full.txt
+++ b/agent/llms-full.txt
@@ -212,7 +212,7 @@ Full CLI docs: https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/packag
 
 ### MCP Server Quick Start
 
-The MCP server (`@qverisai/mcp` v0.14.0) exposes six canonical agent-facing tools via the Model Context Protocol:
+The MCP server (`@qverisai/mcp` v0.14.1) exposes six canonical agent-facing tools via the Model Context Protocol:
 
 | MCP Tool | Description | Cost |
 |----------|-------------|------|
@@ -560,7 +560,7 @@ Model improvement is a tailwind for QVeris, not a headwind.
 ### SDK & Tools
 
 - **CLI (npm):** https://www.npmjs.com/package/@qverisai/cli — `npm install -g @qverisai/cli` (v0.11.0)
-- **MCP Server (npm):** https://www.npmjs.com/package/@qverisai/mcp — `npx @qverisai/mcp` (v0.14.0)
+- **MCP Server (npm):** https://www.npmjs.com/package/@qverisai/mcp — `npx @qverisai/mcp` (v0.14.1)
 - **JavaScript SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/js-sdk (v0.8.0)
 - **Python SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk (v0.7.0)
 - **Online Docs:** https://qveris.ai/docs
@@ -654,10 +654,10 @@ Generate a new UUID for each user session, and reuse it throughout that session.
 
 - **llms-full.txt Version:** 1.2.0
 - **CLI Version:** 0.11.0
-- **MCP Server Version:** 0.14.0
+- **MCP Server Version:** 0.14.1
 - **JavaScript SDK Version:** 0.8.0
 - **Python SDK Version:** 0.7.0
-- **Last Updated:** 2026-08-10
+- **Last Updated:** 2026-09-04
 
 For the latest updates, always refer to:
 

--- a/agent/llms.txt
+++ b/agent/llms.txt
@@ -30,7 +30,7 @@
 ## Access methods (recommended order)
 - Hosted MCP (recommended for remote-capable MCP clients): open /hosted-mcp on the QVeris site that issued the API key for the correct Streamable HTTP endpoint and Bearer authentication setup — no local process, Node.js, or package install
 - CLI v0.11.0 (recommended for shell-capable agents): npm install -g @qverisai/cli — zero prompt tokens, deterministic output, 10,000+ tools without prompt bloat
-- MCP Server v0.14.0 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
+- MCP Server v0.14.1 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
 - JavaScript SDK v0.8.0: npm install @qverisai/sdk
 - Python SDK v0.7.0: pip install qveris
 - REST API: https://qveris.ai/api/v1

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` 是面向 Cursor、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
-`@qverisai/mcp` v0.14.0 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
+`@qverisai/mcp` v0.14.1 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
 
 - `discover` — 用自然语言发现能力
 - `inspect` — 获取工具详情（参数、成功率、示例）

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` is the official QVeris MCP server for MCP-compatible clients such as ChatGPT (Codex), Cursor, Claude Desktop, Cherry Studio, GitHub Copilot, Cline, Roo Code, Kiro, Qoder, CodeBuddy, WorkBuddy, and other coding agents.
 
-`@qverisai/mcp` v0.14.0 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
+`@qverisai/mcp` v0.14.1 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
 
 - `discover` — Find capabilities by natural language
 - `inspect` — Get detailed tool info (params, success rate, examples)

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` 是面向 ChatGPT（Codex）、Cursor、Claude Desktop、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程智能体等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
-`@qverisai/mcp` v0.14.0 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
+`@qverisai/mcp` v0.14.1 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
 
 - `discover` — 用自然语言发现能力
 - `inspect` — 获取工具详情（参数、成功率、示例）

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "qveris",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Discover, inspect, and call 10,000+ real-world tools from Gemini CLI with QVeris.",
   "mcpServers": {
     "qveris": {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,9 +6,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-09-04
+
 ### Added
 
 - Added complete MCP tool annotations (`title`, read-only, destructive, idempotent, and open-world hints) for every canonical tool and deprecated alias. The `call` family is conservatively marked as non-idempotent, destructive, and open-world. ([#316])
+
+### Fixed
+
+- Deprecated aliases now reuse their canonical tool's `outputSchema` as well as its input schema and safety annotations, preventing protocol metadata drift.
 
 ## [0.14.0] - 2026-08-10
 
@@ -149,7 +155,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Handle empty/non-JSON success responses gracefully; `params_to_tool` documented as an object.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.14.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.14.1...HEAD
+[0.14.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.14.0...mcp-v0.14.1
 [0.14.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.13.0...mcp-v0.14.0
 [0.13.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.12.0...mcp-v0.13.0
 [0.12.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.11.0...mcp-v0.12.0

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.30.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.QVerisAI/mcp",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -9,7 +9,7 @@
     "subfolder": "packages/mcp"
   },
   "websiteUrl": "https://qveris.ai",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -29,7 +29,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp/src/full-spec.test.ts
+++ b/packages/mcp/src/full-spec.test.ts
@@ -5,28 +5,42 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { createQverisServer, QVERIS_MCP_TOOL_ANNOTATIONS } from './index.js';
 import type { QverisClient } from './api/client.js';
+import type { ExecuteRequest, SearchRequest } from './types.js';
+
+type FakeQverisClient = QverisClient & {
+  calls: string[];
+  searchRequests: SearchRequest[];
+  executeRequests: Array<{ toolId: string; request: ExecuteRequest }>;
+};
 
 /** Client-shaped fake covering the methods the tool executors use. */
-function fakeQverisClient() {
+function fakeQverisClient(): FakeQverisClient {
+  const calls: string[] = [];
+  const searchRequests: SearchRequest[] = [];
+  const executeRequests: Array<{ toolId: string; request: ExecuteRequest }> = [];
   return {
-    calls: [] as string[],
-    async searchTools() {
-      this.calls.push('search');
+    calls,
+    searchRequests,
+    executeRequests,
+    async searchTools(request: SearchRequest) {
+      calls.push('search');
+      searchRequests.push(request);
       return { search_id: 's1', total: 1, results: [{ tool_id: 't1', name: 'T', description: 'd' }] };
     },
     async getToolsByIds() {
-      this.calls.push('inspect');
+      calls.push('inspect');
       return { search_id: 's1', results: [{ tool_id: 't1', name: 'T', description: 'd' }] };
     },
     async probeTool() {
-      this.calls.push('probe');
+      calls.push('probe');
       return { schema: { valid: true } };
     },
-    async executeTool() {
-      this.calls.push('execute');
+    async executeTool(toolId: string, request: ExecuteRequest) {
+      calls.push('execute');
+      executeRequests.push({ toolId, request });
       return { execution_id: 'e1', success: true, result: { ok: 1 } };
     },
-  } as unknown as QverisClient & { calls: string[] };
+  } as unknown as FakeQverisClient;
 }
 
 async function connect(opts: { client?: QverisClient; elicitHandler?: (msg: string) => Promise<boolean> } = {}) {
@@ -46,7 +60,7 @@ async function connect(opts: { client?: QverisClient; elicitHandler?: (msg: stri
 }
 
 describe('output schemas + structured content', () => {
-  it('declares outputSchema on all six canonical tools', async () => {
+  it('declares outputSchema on canonical tools and reuses it for deprecated aliases', async () => {
     const c = await connect();
     const { tools } = await c.listTools();
     for (const name of ['discover', 'inspect', 'probe', 'call', 'usage_history', 'credits_ledger']) {
@@ -54,6 +68,45 @@ describe('output schemas + structured content', () => {
       expect(tool?.outputSchema, `${name} outputSchema`).toBeDefined();
       expect((tool?.outputSchema as { additionalProperties?: boolean }).additionalProperties).toBe(true);
     }
+    for (const [alias, canonical] of Object.entries({
+      search_tools: 'discover',
+      get_tools_by_ids: 'inspect',
+      execute_tool: 'call',
+    })) {
+      const aliasSchema = tools.find((tool) => tool.name === alias)?.outputSchema;
+      const canonicalSchema = tools.find((tool) => tool.name === canonical)?.outputSchema;
+      expect(aliasSchema, `${alias} outputSchema`).toEqual(canonicalSchema);
+    }
+    await c.close();
+  });
+
+  it('initializes MCP and forwards projection inputs while omitted projections retain full behavior', async () => {
+    const qveris = fakeQverisClient();
+    const c = await connect({ client: qveris });
+    const { tools } = await c.listTools();
+    const discover = tools.find((tool) => tool.name === 'discover');
+    const call = tools.find((tool) => tool.name === 'call');
+
+    expect((discover?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('view');
+    expect((discover?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('lang');
+    expect((call?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('respond_with');
+
+    await c.callTool({ name: 'discover', arguments: { query: 'weather', view: 'routing', lang: 'en' } });
+    expect(qveris.searchRequests).toEqual([
+      { query: 'weather', limit: 20, session_id: 'session-1', view: 'routing', lang: 'en' },
+    ]);
+
+    await c.callTool({
+      name: 'call',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {}, respond_with: 'summary' },
+    });
+    expect(qveris.executeRequests[0]).toMatchObject({
+      toolId: 't1',
+      request: { search_id: 's1', session_id: 'session-1', parameters: {}, respond_with: 'summary' },
+    });
+
+    await c.callTool({ name: 'call', arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} } });
+    expect(qveris.executeRequests[1]?.request).not.toHaveProperty('respond_with');
     await c.close();
   });
 

--- a/packages/mcp/src/http.test.ts
+++ b/packages/mcp/src/http.test.ts
@@ -12,6 +12,8 @@ import {
   type RunningHttpServer,
 } from './http.js';
 import { bearerAuthHeaderInput } from './server-card.js';
+import type { QverisClient } from './api/client.js';
+import type { ExecuteRequest, SearchRequest } from './types.js';
 
 describe('resolveTransportConfig', () => {
   it('defaults to stdio with no flags or env', () => {
@@ -168,6 +170,47 @@ describe('startHttpServer (end-to-end over Streamable HTTP)', () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     expect(names).toEqual(expect.arrayContaining(['discover', 'inspect', 'call', 'usage_history', 'credits_ledger']));
+    await client.close();
+  });
+
+  it('initializes, lists projection inputs, and forwards projections through MCP over HTTP', async () => {
+    const searchRequests: SearchRequest[] = [];
+    const executeRequests: Array<{ toolId: string; request: ExecuteRequest }> = [];
+    const qveris = {
+      async searchTools(request: SearchRequest) {
+        searchRequests.push(request);
+        return { search_id: 's1', total: 1, results: [] };
+      },
+      async executeTool(toolId: string, request: ExecuteRequest) {
+        executeRequests.push({ toolId, request });
+        return { execution_id: 'e1', success: true, result: { ok: true } };
+      },
+    } as unknown as QverisClient;
+    await startServer({}, undefined, (sessionId) => createQverisServer(qveris, sessionId));
+
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const discover = tools.find((tool) => tool.name === 'discover');
+    const call = tools.find((tool) => tool.name === 'call');
+    expect((discover?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('view');
+    expect((discover?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('lang');
+    expect((call?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('respond_with');
+
+    await client.callTool({ name: 'discover', arguments: { query: 'weather', view: 'routing', lang: 'en' } });
+    await client.callTool({
+      name: 'call',
+      arguments: { tool_id: 'weather.v1', search_id: 's1', params_to_tool: {}, respond_with: 'summary' },
+    });
+    await client.callTool({ name: 'call', arguments: { tool_id: 'weather.v1', search_id: 's1', params_to_tool: {} } });
+
+    expect(searchRequests).toEqual([
+      { query: 'weather', limit: 20, session_id: expect.any(String), view: 'routing', lang: 'en' },
+    ]);
+    expect(executeRequests[0]).toMatchObject({
+      toolId: 'weather.v1',
+      request: { search_id: 's1', parameters: {}, respond_with: 'summary' },
+    });
+    expect(executeRequests[1]?.request).not.toHaveProperty('respond_with');
     await client.close();
   });
 

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -14,6 +14,7 @@ import {
 import type { QverisClient } from './api/client.js';
 import { creditsLedgerSchema } from './tools/credits-ledger.js';
 import { executeToolSchema } from './tools/execute.js';
+import { TOOL_OUTPUT_SCHEMAS } from './output-schemas.js';
 import { probeToolSchema } from './tools/probe.js';
 import { getToolsByIdsSchema } from './tools/get-by-ids.js';
 import { searchToolsSchema } from './tools/search.js';
@@ -111,6 +112,9 @@ describe('MCP public tool interface', () => {
     expect(byName.get('search_tools')?.inputSchema).toBe(searchToolsSchema);
     expect(byName.get('get_tools_by_ids')?.inputSchema).toBe(getToolsByIdsSchema);
     expect(byName.get('execute_tool')?.inputSchema).toBe(executeToolSchema);
+    expect(byName.get('search_tools')?.outputSchema).toBe(TOOL_OUTPUT_SCHEMAS.discover);
+    expect(byName.get('get_tools_by_ids')?.outputSchema).toBe(TOOL_OUTPUT_SCHEMAS.inspect);
+    expect(byName.get('execute_tool')?.outputSchema).toBe(TOOL_OUTPUT_SCHEMAS.call);
 
     expect(byName.get('search_tools')?.description).toContain('Deprecated');
     expect(byName.get('get_tools_by_ids')?.description).toContain('Deprecated');

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -202,18 +202,21 @@ export function listQverisMcpTools() {
       name: 'search_tools',
       description: '[Deprecated: use "discover" instead] Search for available tools based on natural language queries.',
       inputSchema: searchToolsSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.discover,
       annotations: QVERIS_MCP_TOOL_ANNOTATIONS.discover,
     },
     {
       name: 'get_tools_by_ids',
       description: '[Deprecated: use "inspect" instead] Get descriptions of tools based on their tool IDs.',
       inputSchema: getToolsByIdsSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.inspect,
       annotations: QVERIS_MCP_TOOL_ANNOTATIONS.inspect,
     },
     {
       name: 'execute_tool',
       description: '[Deprecated: use "call" instead] Execute a specific remote tool with provided parameters.',
       inputSchema: executeToolSchema,
+      outputSchema: TOOL_OUTPUT_SCHEMAS.call,
       annotations: QVERIS_MCP_TOOL_ANNOTATIONS.call,
     },
   ];


### PR DESCRIPTION
## Summary

- prepare `@qverisai/mcp` 0.14.1 with the already-reviewed complete tool safety annotations
- make every deprecated alias reuse its canonical `outputSchema`, input schema, and annotations
- preserve discover routing projection, response-language, call result projection, model attribution, and strict single-submit paid-call behavior
- synchronize package, Registry manifest, extension, and public version metadata

## Protocol coverage

- real Streamable HTTP MCP `initialize → tools/list → tools/call` coverage validates `view`, `lang`, and `respond_with`
- verifies omitted projection parameters preserve the full-response request shape
- verifies every canonical and alias tool advertises complete annotations and aliases match canonical schemas
- existing client tests retain one-attempt guarantees for paid-call `422`, `429`, `503`, and redirects

## Validation

- `npm --prefix packages/mcp test` — 189 tests
- `npm --prefix packages/mcp run typecheck`
- `npm --prefix packages/mcp run lint`
- `npm --prefix packages/mcp run build`
- `npm run test:release-clients` — 43 tests
- `npm --prefix packages/mcp pack --dry-run`
- documentation boundary scans and `git diff --check`

`0.14.1` was confirmed unoccupied in npm before preparing this release.