### PR TITLE
fix(clients): normalize credit balance responses

### DIFF
--- a/agent/GUIDELINES.md
+++ b/agent/GUIDELINES.md
@@ -223,7 +223,7 @@ When a tool response exceeds `max_response_size`, the API returns:
 
 ## CLI Workflow
 
-When using the QVeris CLI (`@qverisai/cli` v0.11.0) instead of MCP, use the same Discover → Inspect → Probe → Call pattern via shell commands.
+When using the QVeris CLI (`@qverisai/cli` v0.11.1) instead of MCP, use the same Discover → Inspect → Probe → Call pattern via shell commands.
 
 ### Basic Agent Workflow
 
@@ -323,6 +323,6 @@ Run `qveris doctor` to check setup: Node.js version, API key validity, endpoint 
 | Probe | `{"parameters": {...}, "checks": ["schema", "quote"], "live_budget": "none"}` |
 | Call | `{"search_id": "...", "parameters": {...}, "model": "router-model-v1", "max_response_size": 20480}` |
 
-> **MCP backward compatibility:** Old tool names `search_tools`, `get_tools_by_ids`, `execute_tool` are still supported as deprecated aliases in MCP server v0.14.1. Use the canonical names (`discover`, `inspect`, `probe`, `call`, `usage_history`, `credits_ledger`) going forward.
+> **MCP backward compatibility:** Old tool names `search_tools`, `get_tools_by_ids`, `execute_tool` are still supported as deprecated aliases in MCP server v0.14.2. Use the canonical names (`discover`, `inspect`, `probe`, `call`, `usage_history`, `credits_ledger`) going forward.
 
 Full API documentation: https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/rest-api.md

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -97,7 +97,7 @@ Reconnect the client and confirm `discover`, `inspect`, `probe`, and `call` are 
 Detect which MCP-capable desktop client you are currently running in. QVeris supports Claude Code, ChatGPT (Codex), OpenCode, Cursor, Cherry Studio, TRAE, GitHub Copilot, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, and WorkBuddy.
 
 **Configuration involves two steps for all environments:**
-1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.1) to your environment.
+1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.2) to your environment.
 2. **Skill Configuration:** Teaches the agent how to use the tools using the MCP/client skill definition file.
    - **Skill URL:** `https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/skills/qveris/SKILL.md`
 

--- a/agent/llms-full.txt
+++ b/agent/llms-full.txt
@@ -127,7 +127,7 @@ QVeris supports six integration methods:
 
 ### QVeris CLI — Token-Efficient Agent Tool Use (Recommended)
 
-The CLI (`@qverisai/cli` v0.11.0) lets shell-capable agents access QVeris capabilities. CLI runs as a subprocess without preloading the catalog. Instructions, commands, and results still consume context tokens; QVeris MCP also uses a small set of routing tools. No mandatory runtime dependencies; optional OS credential storage uses `@napi-rs/keyring`.
+The CLI (`@qverisai/cli` v0.11.1) lets shell-capable agents access QVeris capabilities. CLI runs as a subprocess without preloading the catalog. Instructions, commands, and results still consume context tokens; QVeris MCP also uses a small set of routing tools. No mandatory runtime dependencies; optional OS credential storage uses `@napi-rs/keyring`.
 
 ```bash
 # Install
@@ -212,7 +212,7 @@ Full CLI docs: https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/packag
 
 ### MCP Server Quick Start
 
-The MCP server (`@qverisai/mcp` v0.14.1) exposes six canonical agent-facing tools via the Model Context Protocol:
+The MCP server (`@qverisai/mcp` v0.14.2) exposes six canonical agent-facing tools via the Model Context Protocol:
 
 | MCP Tool | Description | Cost |
 |----------|-------------|------|
@@ -559,9 +559,9 @@ Model improvement is a tailwind for QVeris, not a headwind.
 
 ### SDK & Tools
 
-- **CLI (npm):** https://www.npmjs.com/package/@qverisai/cli — `npm install -g @qverisai/cli` (v0.11.0)
-- **MCP Server (npm):** https://www.npmjs.com/package/@qverisai/mcp — `npx @qverisai/mcp` (v0.14.1)
-- **JavaScript SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/js-sdk (v0.8.0)
+- **CLI (npm):** https://www.npmjs.com/package/@qverisai/cli — `npm install -g @qverisai/cli` (v0.11.1)
+- **MCP Server (npm):** https://www.npmjs.com/package/@qverisai/mcp — `npx @qverisai/mcp` (v0.14.2)
+- **JavaScript SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/js-sdk (v0.8.1)
 - **Python SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk (v0.7.0)
 - **Online Docs:** https://qveris.ai/docs
 
@@ -653,9 +653,9 @@ Generate a new UUID for each user session, and reuse it throughout that session.
 ## Version Information
 
 - **llms-full.txt Version:** 1.2.0
-- **CLI Version:** 0.11.0
-- **MCP Server Version:** 0.14.1
-- **JavaScript SDK Version:** 0.8.0
+- **CLI Version:** 0.11.1
+- **MCP Server Version:** 0.14.2
+- **JavaScript SDK Version:** 0.8.1
 - **Python SDK Version:** 0.7.0
 - **Last Updated:** 2026-09-04
 

--- a/agent/llms.txt
+++ b/agent/llms.txt
@@ -29,9 +29,9 @@
 
 ## Access methods (recommended order)
 - Hosted MCP (recommended for remote-capable MCP clients): open /hosted-mcp on the QVeris site that issued the API key for the correct Streamable HTTP endpoint and Bearer authentication setup — no local process, Node.js, or package install
-- CLI v0.11.0 (recommended for shell-capable agents): npm install -g @qverisai/cli — no upfront catalog schemas, deterministic output, API discovery without preloading the catalog
-- MCP Server v0.14.1 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
-- JavaScript SDK v0.8.0: npm install @qverisai/sdk
+- CLI v0.11.1 (recommended for shell-capable agents): npm install -g @qverisai/cli — no upfront catalog schemas, deterministic output, API discovery without preloading the catalog
+- MCP Server v0.14.2 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
+- JavaScript SDK v0.8.1: npm install @qverisai/sdk
 - Python SDK v0.7.0: pip install qveris
 - REST API: https://qveris.ai/api/v1
 - Explicit endpoint override: QVERIS_BASE_URL

--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -2,7 +2,7 @@
 
 QVeris 能力路由网络的官方命令行工具。直接在终端或 Agent 框架中发现、检查和调用丰富的可用 API 能力。
 
-`@qverisai/cli` v0.11.0 是最新测试版本，包含 OAuth Device Flow 会话、零成本参数校验与报价、可选的发现和调用投影及 Call 模型归因，同时保持 API Key 兼容。
+`@qverisai/cli` v0.11.1 是最新测试版本，包含 OAuth Device Flow 会话、零成本参数校验与报价、可选的发现和调用投影及 Call 模型归因，同时保持 API Key 兼容。
 
 **为什么用 CLI？** CLI 通过子进程提供结构化输出和按需发现，无需预加载整个能力目录。使用说明、命令和结果仍会消耗上下文 token；QVeris MCP 同样使用少量路由工具。
 

--- a/docs/cn/zh-CN/js-sdk.md
+++ b/docs/cn/zh-CN/js-sdk.md
@@ -2,7 +2,7 @@
 
 类型化的 TypeScript/JavaScript SDK，让你在自己的 Agent 和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
 
-`@qverisai/sdk` v0.8.0 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
+`@qverisai/sdk` v0.8.1 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
 
 ## 安装
 

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` 是面向 Cursor、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
-`@qverisai/mcp` v0.14.1 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
+`@qverisai/mcp` v0.14.2 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
 
 - `discover` — 用自然语言发现能力
 - `inspect` — 获取工具详情（参数、成功率、示例）

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -2,7 +2,7 @@
 
 The official command-line tool for the QVeris capability routing network. Discover, inspect, and call a broad catalog of real-world API capabilities directly from your terminal or agent framework.
 
-`@qverisai/cli` v0.11.0 is the latest tested release. It includes OAuth Device Flow sessions, zero-cost parameter/quote probes, opt-in discovery and call projections, and Call model attribution while preserving API key compatibility.
+`@qverisai/cli` v0.11.1 is the latest tested release. It includes OAuth Device Flow sessions, zero-cost parameter/quote probes, opt-in discovery and call projections, and Call model attribution while preserving API key compatibility.
 
 **Why CLI?** CLI runs as a subprocess with structured output and on-demand discovery. It does not preload the full capability catalog. Instructions, commands, and results still consume context tokens; QVeris MCP also uses a small set of routing tools.
 

--- a/docs/en-US/js-sdk-api.md
+++ b/docs/en-US/js-sdk-api.md
@@ -1551,7 +1551,7 @@ Legacy/full pre-settlement bill snapshot when returned directly
 
 ##### remaining\_credits?
 
-> `optional` **remaining\_credits?**: `number`
+> `optional` **remaining\_credits?**: `number` \| `null`
 
 User's remaining credits after this execution
 
@@ -1985,7 +1985,7 @@ The original search query
 
 ##### remaining\_credits?
 
-> `optional` **remaining\_credits?**: `number`
+> `optional` **remaining\_credits?**: `number` \| `null`
 
 User's remaining credits after this operation
 

--- a/docs/en-US/js-sdk.md
+++ b/docs/en-US/js-sdk.md
@@ -2,7 +2,7 @@
 
 Typed TypeScript/JavaScript SDK to discover, inspect, probe, call, and audit real-world API capabilities from your own agents and applications.
 
-`@qverisai/sdk` v0.8.0 is the latest tested release. It is a thin, typed wrapper over the QVeris REST API (`discover`, `inspect`, `probe`, `call`, `credits`, `usage`, `ledger`). It has **zero runtime dependencies** — it uses the platform `fetch` (Node.js 18+) — and mirrors the wire semantics of the [Python SDK](python-sdk.md) and the [MCP server](mcp-server.md).
+`@qverisai/sdk` v0.8.1 is the latest tested release. It is a thin, typed wrapper over the QVeris REST API (`discover`, `inspect`, `probe`, `call`, `credits`, `usage`, `ledger`). It has **zero runtime dependencies** — it uses the platform `fetch` (Node.js 18+) — and mirrors the wire semantics of the [Python SDK](python-sdk.md) and the [MCP server](mcp-server.md).
 
 ## Installation
 

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` is the official QVeris MCP server for MCP-compatible clients such as ChatGPT (Codex), Cursor, Claude Desktop, Cherry Studio, GitHub Copilot, Cline, Roo Code, Kiro, Qoder, CodeBuddy, WorkBuddy, and other coding agents.
 
-`@qverisai/mcp` v0.14.1 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
+`@qverisai/mcp` v0.14.2 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
 
 - `discover` — Find capabilities by natural language
 - `inspect` — Get detailed tool info (params, success rate, examples)

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -2,7 +2,7 @@
 
 QVeris 能力路由网络的官方命令行工具。直接在终端或智能体框架中发现、检查和调用丰富的可用 API 能力。
 
-`@qverisai/cli` v0.11.0 是最新测试版本，包含 OAuth Device Flow 会话、零成本参数校验与报价、可选的发现和调用投影及 Call 模型归因，同时保持 API Key 兼容。
+`@qverisai/cli` v0.11.1 是最新测试版本，包含 OAuth Device Flow 会话、零成本参数校验与报价、可选的发现和调用投影及 Call 模型归因，同时保持 API Key 兼容。
 
 **为什么用 CLI？** CLI 通过子进程提供结构化输出和按需发现，无需预加载整个能力目录。使用说明、命令和结果仍会消耗上下文 token；QVeris MCP 同样使用少量路由工具。
 

--- a/docs/zh-CN/js-sdk-api.md
+++ b/docs/zh-CN/js-sdk-api.md
@@ -1549,7 +1549,7 @@ Legacy/full pre-settlement bill snapshot when returned directly
 
 ##### remaining\_credits?
 
-> `optional` **remaining\_credits?**: `number`
+> `optional` **remaining\_credits?**: `number` \| `null`
 
 User's remaining credits after this execution
 
@@ -1983,7 +1983,7 @@ The original search query
 
 ##### remaining\_credits?
 
-> `optional` **remaining\_credits?**: `number`
+> `optional` **remaining\_credits?**: `number` \| `null`
 
 User's remaining credits after this operation
 

--- a/docs/zh-CN/js-sdk.md
+++ b/docs/zh-CN/js-sdk.md
@@ -2,7 +2,7 @@
 
 类型化的 TypeScript/JavaScript SDK，让你在自己的智能体和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
 
-`@qverisai/sdk` v0.8.0 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
+`@qverisai/sdk` v0.8.1 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
 
 ## 安装
 

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` 是面向 ChatGPT（Codex）、Cursor、Claude Desktop、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程智能体等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
-`@qverisai/mcp` v0.14.1 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
+`@qverisai/mcp` v0.14.2 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
 
 - `discover` — 用自然语言发现能力
 - `inspect` — 获取工具详情（参数、成功率、示例）

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "qveris",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Discover, inspect, and call real-world API capabilities from Gemini CLI with QVeris.",
   "mcpServers": {
     "qveris": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-09-07
+
+### Fixed
+
+- Normalize finite numeric-string credit balances at the API boundary so preflight and human-readable output consistently display them; invalid balances become unavailable with a diagnostic and paid calls remain single-submit. ([#341])
+
 ## [0.11.0] - 2026-08-10
 
 ### Added
@@ -102,7 +108,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Initial release: `discover` / `inspect` / `call` from the terminal against the QVeris API.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.11.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.11.1...HEAD
+[0.11.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.11.0...cli-v0.11.1
 [0.11.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.10.0...cli-v0.11.0
 [0.10.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.9.0...cli-v0.10.0
 [0.9.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/cli-v0.8.2...cli-v0.9.0
@@ -139,3 +146,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#10]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/10
 [#9]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/9
 [#273]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/273
+[#341]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/341

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/cli",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "bin": {
         "qveris": "bin/qveris.mjs"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "QVeris CLI for agent capability discovery, inspection, calling, and audit",
   "type": "module",
   "bin": {

--- a/packages/cli/src/client/api.mjs
+++ b/packages/cli/src/client/api.mjs
@@ -12,6 +12,7 @@ import {
 } from "./retry.mjs";
 
 import { getOAuthSessionMetadata } from "../auth/storage.mjs";
+import { normalizeCreditBalanceResponse } from "./credit-balance.mjs";
 
 export function resolveApiBaseUrl({ baseUrlFlag, preferOAuth = false } = {}) {
   if (preferOAuth && baseUrlFlag === undefined && typeof process.env.QVERIS_BASE_URL !== "string") {
@@ -131,7 +132,7 @@ async function requestJson(
         throw err;
       } else {
         try {
-          return await response.json();
+          return normalizeCreditBalanceResponse(await response.json());
         } catch {
           throw new CliError("API_ERROR", "Invalid JSON response from API");
         }

--- a/packages/cli/src/client/credit-balance.mjs
+++ b/packages/cli/src/client/credit-balance.mjs
@@ -1,0 +1,46 @@
+/** Normalize the public number/null credit-balance contract at the HTTP boundary. */
+const JSON_NUMBER_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+export function normalizeCreditBalance(value) {
+  if (value === undefined) return { value: undefined, invalid: false };
+  if (value === null) return { value: null, invalid: false };
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? { value, invalid: false } : { value: null, invalid: true };
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!JSON_NUMBER_PATTERN.test(trimmed)) return { value: null, invalid: true };
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? { value: parsed, invalid: false } : { value: null, invalid: true };
+  }
+  return { value: null, invalid: true };
+}
+
+/**
+ * Normalize a top-level public response, or the data object in a response
+ * envelope. Capability result payloads are deliberately not traversed.
+ */
+export function normalizeCreditBalanceResponse(response, warn = (message) => console.error(message)) {
+  if (!isRecord(response)) return response;
+
+  const normalizedRoot = normalizeRecord(response, warn);
+  if (!isRecord(normalizedRoot.data)) return normalizedRoot;
+
+  const normalizedData = normalizeRecord(normalizedRoot.data, warn);
+  if (normalizedData === normalizedRoot.data) return normalizedRoot;
+  return { ...normalizedRoot, data: normalizedData };
+}
+
+function normalizeRecord(record, warn) {
+  if (!Object.prototype.hasOwnProperty.call(record, "remaining_credits")) return record;
+  const normalized = normalizeCreditBalance(record.remaining_credits);
+  if (normalized.invalid) {
+    warn("[qveris] Invalid remaining_credits in API response; treating the balance as unavailable.");
+  }
+  if (normalized.value === record.remaining_credits) return record;
+  return { ...record, remaining_credits: normalized.value };
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/cli/src/client/preflight.mjs
+++ b/packages/cli/src/client/preflight.mjs
@@ -1,6 +1,7 @@
 import { resolve } from "../config/resolve.mjs";
 import { getSiteUrl } from "../config/endpoint.mjs";
 import { getOAuthSessionMetadata } from "../auth/storage.mjs";
+import { normalizeCreditBalance } from "./credit-balance.mjs";
 import { discoverTools, resolveApiBaseUrl } from "./api.mjs";
 import { ERROR_CODES } from "../errors/codes.mjs";
 
@@ -129,13 +130,14 @@ export async function runPreflight({
 
   checks.push(check("connectivity", "ok", "API reachable — free discover probe, no credits used"));
 
-  if (typeof response?.remaining_credits === "number") {
-    const positive = response.remaining_credits > 0;
+  const remainingCredits = normalizeCreditBalance(response?.remaining_credits).value;
+  if (typeof remainingCredits === "number") {
+    const positive = remainingCredits > 0;
     checks.push(
       check(
         "credits",
         positive ? "ok" : "warn",
-        `${response.remaining_credits} credits remaining`,
+        `${remainingCredits} credits remaining`,
         positive ? null : `Purchase credits at ${getSiteUrl(local.baseUrl)}/pricing`,
       ),
     );

--- a/packages/cli/src/commands/credits.mjs
+++ b/packages/cli/src/commands/credits.mjs
@@ -4,6 +4,7 @@ import { getSiteUrl } from "../config/endpoint.mjs";
 import { bold, dim, cyan, yellow, green } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
 import { createSpinner } from "../output/spinner.mjs";
+import { normalizeCreditBalance } from "../client/credit-balance.mjs";
 
 export async function runCredits(flags) {
   const apiKey = resolveApiKey(flags.apiKey);
@@ -16,7 +17,7 @@ export async function runCredits(flags) {
     const result = unwrapApiResponse(await getCredits({ apiKey, baseUrl, timeoutMs: 10000 }));
     spinner.stop();
 
-    const credits = result.remaining_credits;
+    const credits = normalizeCreditBalance(result.remaining_credits).value;
 
     if (flags.json) {
       outputJson(result);

--- a/packages/cli/src/output/formatter.mjs
+++ b/packages/cli/src/output/formatter.mjs
@@ -1,4 +1,5 @@
 import { bold, cyan, dim, green, yellow, red } from "./colors.mjs";
+import { normalizeCreditBalance } from "../client/credit-balance.mjs";
 
 // ── discover ──────────────────────────────────────────────────────────
 
@@ -6,7 +7,7 @@ export function formatDiscoverResult(result) {
   const tools = result.results ?? [];
   const total = result.total ?? tools.length;
   const searchTime = result.elapsed_time_ms;
-  const remaining = result.remaining_credits;
+  const remaining = normalizeCreditBalance(result.remaining_credits).value;
   const lines = [];
 
   if (tools.length === 0) {
@@ -89,7 +90,7 @@ export function formatDiscoverResult(result) {
 
 export function formatInspectResult(tools) {
   const list = Array.isArray(tools) ? tools : (tools?.results ?? tools?.tools ?? [tools]);
-  const remaining = tools?.remaining_credits;
+  const remaining = normalizeCreditBalance(tools?.remaining_credits).value;
   const lines = [];
 
   for (const t of list) {
@@ -185,7 +186,7 @@ export function formatCallResult(result) {
   const success = result.success ?? false;
   const billing = getCompactBilling(result);
   const cost = getPreSettlementAmount(result);
-  const remaining = result.remaining_credits;
+  const remaining = normalizeCreditBalance(result.remaining_credits).value;
   const executionId = result.execution_id;
   const toolId = result.tool_id;
   const lines = [];

--- a/packages/cli/test/api.test.mjs
+++ b/packages/cli/test/api.test.mjs
@@ -223,6 +223,32 @@ test("API client preserves read projection fallback but never resubmits a paid c
   assert.deepEqual(callRedirectModes, ["error"]);
 });
 
+test("API client normalizes numeric-string balances without resubmitting a paid call", async () => {
+  let requests = 0;
+  const result = await withMockFetch(
+    () => {
+      requests += 1;
+      return jsonResponse({
+        execution_id: "exec-balance",
+        success: true,
+        result: { data: { ok: true } },
+        remaining_credits: "992.5",
+      });
+    },
+    () =>
+      callTool({
+        apiKey: "sk-test",
+        baseUrl: "https://unit.test/api/v1",
+        toolId: "weather-tool",
+        discoveryId: "search-1",
+        parameters: {},
+      }),
+  );
+
+  assert.equal(result.remaining_credits, 992.5);
+  assert.equal(requests, 1);
+});
+
 test("API client does not downgrade invalid projections", async () => {
   let requests = 0;
   await assert.rejects(

--- a/packages/cli/test/credit-balance.test.mjs
+++ b/packages/cli/test/credit-balance.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { normalizeCreditBalance, normalizeCreditBalanceResponse } from "../src/client/credit-balance.mjs";
+
+const contract = JSON.parse(
+  readFileSync(new URL("../../../test-fixtures/credit-balance-contract.json", import.meta.url), "utf8"),
+);
+
+for (const fixture of contract.cases) {
+  test(`credit balance contract: ${fixture.name}`, () => {
+    assert.deepEqual(normalizeCreditBalance(fixture.input), {
+      value: fixture.expected,
+      invalid: fixture.invalid,
+    });
+  });
+}
+
+for (const input of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+  test(`credit balance contract rejects non-finite ${String(input)}`, () => {
+    assert.deepEqual(normalizeCreditBalance(input), { value: null, invalid: true });
+  });
+}
+
+test("normalizes raw and enveloped balances without traversing capability results", () => {
+  const warnings = [];
+  const warn = (message) => warnings.push(message);
+  assert.deepEqual(normalizeCreditBalanceResponse({ remaining_credits: "12.5" }, warn), {
+    remaining_credits: 12.5,
+  });
+  assert.deepEqual(normalizeCreditBalanceResponse({ status: "success", data: { remaining_credits: "0" } }, warn), {
+    status: "success",
+    data: { remaining_credits: 0 },
+  });
+  const capabilityResult = { result: { data: { remaining_credits: "provider-defined" } } };
+  assert.equal(normalizeCreditBalanceResponse(capabilityResult, warn), capabilityResult);
+  assert.deepEqual(warnings, []);
+});
+
+test("invalid balances become unavailable and emit one diagnostic", () => {
+  const warnings = [];
+  assert.deepEqual(
+    normalizeCreditBalanceResponse({ remaining_credits: "unavailable" }, (message) => warnings.push(message)),
+    { remaining_credits: null },
+  );
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /treating the balance as unavailable/);
+});

--- a/packages/cli/test/formatter.test.mjs
+++ b/packages/cli/test/formatter.test.mjs
@@ -1,7 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatDiscoverResult, formatInspectResult } from "../src/output/formatter.mjs";
+import { formatCallResult, formatDiscoverResult, formatInspectResult } from "../src/output/formatter.mjs";
+
+test("formatters display normalized numeric-string balances", () => {
+  const discover = formatDiscoverResult({
+    search_id: "s-1",
+    total: 1,
+    results: [{ tool_id: "t-1", name: "Tool" }],
+    remaining_credits: "42.5",
+  });
+  assert.match(discover, /42\.5 credits remaining/);
+
+  const inspect = formatInspectResult({
+    results: [{ tool_id: "t-1", name: "Tool" }],
+    remaining_credits: "42.5",
+  });
+  assert.match(inspect, /42\.5 credits remaining/);
+
+  const call = formatCallResult({ execution_id: "e-1", success: true, remaining_credits: "42.5" });
+  assert.match(call, /42\.5 remaining/);
+});
 
 test("execution history is not presented as verification", () => {
   const output = formatInspectResult([{ tool_id: "sample", has_last_execution: true }]);

--- a/packages/cli/test/preflight.test.mjs
+++ b/packages/cli/test/preflight.test.mjs
@@ -35,6 +35,16 @@ test("runPreflight: healthy probe reports connectivity, credits, and contract co
   assert.equal(c.contract.status, "ok");
 });
 
+test("runPreflight: numeric-string credits are reported consistently", async () => {
+  const probe = async () => ({ search_id: "s1", results: [], remaining_credits: "42.5" });
+  const { checks, ok } = await runPreflight({ apiKeyFlag: "sk-test", probe });
+
+  assert.equal(ok, true);
+  const credits = byName(checks).credits;
+  assert.equal(credits.status, "ok");
+  assert.match(credits.detail, /42\.5 credits/);
+});
+
 test("runPreflight: stored OAuth session restores its endpoint without environment configuration", async () => {
   const previous = {
     key: process.env.QVERIS_API_KEY,

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-09-07
+
+### Fixed
+
+- Normalize finite numeric-string credit balances at the response boundary, preserve `null` as unavailable, and align the public search and execution response types with the OpenAPI `number | null` contract without replaying paid calls. ([#341])
+
 ## [0.8.0] - 2026-08-10
 
 ### Added
@@ -63,7 +69,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - `0.1.x` under this npm name was an early MCP-focused SDK, superseded by `@qverisai/mcp`.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.0...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.1...HEAD
+[0.8.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.0...js-sdk-v0.8.1
 [0.8.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.7.0...js-sdk-v0.8.0
 [0.7.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.6.0...js-sdk-v0.7.0
 [0.6.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.5.0...js-sdk-v0.6.0
@@ -82,3 +89,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
 [#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256
 [#273]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/273
+[#341]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/341

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/sdk",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "QVeris TypeScript SDK for agent capability discovery, inspection, calling, and audit",
   "keywords": [
     "qveris",

--- a/packages/js-sdk/src/client.test.ts
+++ b/packages/js-sdk/src/client.test.ts
@@ -396,6 +396,24 @@ describe('Qveris client', () => {
     expect(response.billing?.charge_lines?.[0].component_key).toBe('request');
   });
 
+  it('normalizes a numeric-string balance without resubmitting the paid call', async () => {
+    const fetchMock = mockFetch({
+      execution_id: 'exec-balance',
+      success: true,
+      result: { data: { ok: true } },
+      remaining_credits: '992.5',
+    });
+    globalThis.fetch = fetchMock;
+
+    const response = await new Qveris({ apiKey: API_KEY }).call('weather.forecast.v1', {
+      parameters: {},
+      searchId: 'search-123',
+    });
+
+    expect(response.remaining_credits).toBe(992.5);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('call passes summary projection and accepts its compact response shape', async () => {
     const fetchMock = mockFetch({
       execution_id: 'exec-summary',

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -22,6 +22,7 @@ import {
   resolveMaxRetries,
   RETRYABLE_STATUS,
 } from './retry.js';
+import { normalizeCreditBalanceResponse } from './credit-balance.js';
 import type {
   ApiEnvelope,
   ApiError,
@@ -509,7 +510,7 @@ export class Qveris {
             });
           }
 
-          return this.unwrapEnvelope<T>(payload, requestContext);
+          return normalizeCreditBalanceResponse(this.unwrapEnvelope<T>(payload, requestContext));
         }
       } catch (err: unknown) {
         if (err instanceof QverisApiError) {

--- a/packages/js-sdk/src/credit-balance.test.ts
+++ b/packages/js-sdk/src/credit-balance.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { normalizeCreditBalance, normalizeCreditBalanceResponse } from './credit-balance.js';
+
+const contract = JSON.parse(
+  readFileSync(new URL('../../../test-fixtures/credit-balance-contract.json', import.meta.url), 'utf8'),
+) as { cases: Array<{ name: string; input: unknown; expected: number | null; invalid: boolean }> };
+
+describe('credit balance response contract', () => {
+  it.each(contract.cases)('normalizes $name', ({ input, expected, invalid }) => {
+    expect(normalizeCreditBalance(input)).toEqual({ value: expected, invalid });
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])('rejects non-finite number %s', (input) => {
+    expect(normalizeCreditBalance(input)).toEqual({ value: null, invalid: true });
+  });
+
+  it('normalizes raw and enveloped responses without traversing capability results', () => {
+    const warn = vi.fn();
+    expect(normalizeCreditBalanceResponse({ remaining_credits: '12.5' }, warn)).toEqual({ remaining_credits: 12.5 });
+    expect(normalizeCreditBalanceResponse({ status: 'success', data: { remaining_credits: '0' } }, warn)).toEqual({
+      status: 'success',
+      data: { remaining_credits: 0 },
+    });
+    const capabilityResult = { result: { data: { remaining_credits: 'provider-defined' } } };
+    expect(normalizeCreditBalanceResponse(capabilityResult, warn)).toBe(capabilityResult);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('converts an invalid balance to null and emits one diagnostic', () => {
+    const warn = vi.fn();
+    expect(normalizeCreditBalanceResponse({ remaining_credits: 'unavailable' }, warn)).toEqual({
+      remaining_credits: null,
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/js-sdk/src/credit-balance.ts
+++ b/packages/js-sdk/src/credit-balance.ts
@@ -1,0 +1,54 @@
+export interface CreditBalanceNormalization {
+  value: number | null | undefined;
+  invalid: boolean;
+}
+
+const JSON_NUMBER_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+/** Normalize the public number/null credit-balance contract at the HTTP boundary. */
+export function normalizeCreditBalance(value: unknown): CreditBalanceNormalization {
+  if (value === undefined) return { value: undefined, invalid: false };
+  if (value === null) return { value: null, invalid: false };
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? { value, invalid: false } : { value: null, invalid: true };
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!JSON_NUMBER_PATTERN.test(trimmed)) return { value: null, invalid: true };
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? { value: parsed, invalid: false } : { value: null, invalid: true };
+  }
+  return { value: null, invalid: true };
+}
+
+/**
+ * Normalize a top-level public response, or the data object in a response
+ * envelope. Capability result payloads are deliberately not traversed.
+ */
+export function normalizeCreditBalanceResponse<T>(
+  response: T,
+  warn: (message: string) => void = (message) => globalThis.console?.warn(message),
+): T {
+  if (!isRecord(response)) return response;
+
+  const normalizedRoot = normalizeRecord(response, warn);
+  if (!isRecord(normalizedRoot.data)) return normalizedRoot as T;
+
+  const normalizedData = normalizeRecord(normalizedRoot.data, warn);
+  if (normalizedData === normalizedRoot.data) return normalizedRoot as T;
+  return { ...normalizedRoot, data: normalizedData } as T;
+}
+
+function normalizeRecord(record: Record<string, unknown>, warn: (message: string) => void): Record<string, unknown> {
+  if (!Object.prototype.hasOwnProperty.call(record, 'remaining_credits')) return record;
+  const normalized = normalizeCreditBalance(record.remaining_credits);
+  if (normalized.invalid) {
+    warn('[qveris] Invalid remaining_credits in API response; treating the balance as unavailable.');
+  }
+  if (normalized.value === record.remaining_credits) return record;
+  return { ...record, remaining_credits: normalized.value };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -275,7 +275,7 @@ export interface SearchResponse {
   stats?: SearchStats;
 
   /** User's remaining credits after this operation */
-  remaining_credits?: number;
+  remaining_credits?: number | null;
 
   /** Total elapsed time in milliseconds */
   elapsed_time_ms?: number;
@@ -451,7 +451,7 @@ export interface ExecuteResponse {
   pre_settlement_bill?: Record<string, unknown>;
 
   /** User's remaining credits after this execution */
-  remaining_credits?: number;
+  remaining_credits?: number | null;
 
   /** Timestamp of execution (ISO 8601 format) */
   created_at?: string;

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-09-07
+
+### Fixed
+
+- Normalize finite numeric-string credit balances before MCP output validation, preserve documented `null` balances, and degrade invalid balances to unavailable without discarding completed capability results. The canonical `call` tool and deprecated `execute_tool` alias now publish the same `number | null` contract while paid calls remain single-submit. ([#341])
+
 ## [0.14.1] - 2026-09-04
 
 ### Added
@@ -155,7 +161,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - Handle empty/non-JSON success responses gracefully; `params_to_tool` documented as an object.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.14.1...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.14.2...HEAD
+[0.14.2]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.14.1...mcp-v0.14.2
 [0.14.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.14.0...mcp-v0.14.1
 [0.14.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.13.0...mcp-v0.14.0
 [0.13.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/mcp-v0.12.0...mcp-v0.13.0
@@ -203,3 +210,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 [#8]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/8
 [#259]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/259
 [#256]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/256
+[#341]: https://github.com/QVerisAI/qveris-agent-toolkit/issues/341

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.30.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.QVerisAI/mcp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -9,7 +9,7 @@
     "subfolder": "packages/mcp"
   },
   "websiteUrl": "https://qveris.ai",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -29,7 +29,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp/src/api/client.test.ts
+++ b/packages/mcp/src/api/client.test.ts
@@ -513,6 +513,26 @@ describe('QverisClient', () => {
       );
     });
 
+    it('normalizes a numeric-string balance without resubmitting the paid call', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          execution_id: 'exec-balance',
+          success: true,
+          result: { data: { ok: true } },
+          remaining_credits: '992.5',
+        }),
+      });
+
+      const result = await client.executeTool('weather-tool', {
+        search_id: 'search-123',
+        parameters: {},
+      });
+
+      expect(result.remaining_credits).toBe(992.5);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('should not resubmit a paid call for a legacy extra-field rejection', async () => {
       const previous = PAID_CALL_POLICY.contract_fixtures.n_minus_1;
       fetchMock.mockResolvedValueOnce({
@@ -578,6 +598,21 @@ describe('QverisClient', () => {
         expect(fetchMock).toHaveBeenCalledTimes(PAID_CALL_POLICY.paid_call.expected_http_attempts);
       },
     );
+
+    it('should single-submit a paid call when the request times out', async () => {
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      fetchMock.mockRejectedValue(abortError);
+
+      await expect(
+        client.executeTool('weather-tool', {
+          search_id: 'search-123',
+          parameters: {},
+        }),
+      ).rejects.toMatchObject({ status: 408 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(PAID_CALL_POLICY.paid_call.expected_http_attempts);
+    });
 
     it('should URL-encode tool_id', async () => {
       fetchMock.mockResolvedValueOnce({

--- a/packages/mcp/src/api/client.ts
+++ b/packages/mcp/src/api/client.ts
@@ -34,6 +34,7 @@ import {
   resolveMaxRetries,
   RETRYABLE_STATUS,
 } from '../retry.js';
+import { normalizeCreditBalanceResponse } from './credit-balance.js';
 
 const DEFAULT_BASE_URL = 'https://qveris.ai/api/v1';
 
@@ -231,7 +232,7 @@ export class QverisClient {
           throw error;
         } else {
           try {
-            return (await response.json()) as T;
+            return normalizeCreditBalanceResponse(await response.json()) as T;
           } catch {
             const error: ApiError = {
               status: response.status,

--- a/packages/mcp/src/api/credit-balance.test.ts
+++ b/packages/mcp/src/api/credit-balance.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { normalizeCreditBalance, normalizeCreditBalanceResponse } from './credit-balance.js';
+
+const contract = JSON.parse(
+  readFileSync(new URL('../../../../test-fixtures/credit-balance-contract.json', import.meta.url), 'utf8'),
+) as { cases: Array<{ name: string; input: unknown; expected: number | null; invalid: boolean }> };
+
+describe('credit balance response contract', () => {
+  it.each(contract.cases)('normalizes $name', ({ input, expected, invalid }) => {
+    expect(normalizeCreditBalance(input)).toEqual({ value: expected, invalid });
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])('rejects non-finite number %s', (input) => {
+    expect(normalizeCreditBalance(input)).toEqual({ value: null, invalid: true });
+  });
+
+  it('normalizes raw and enveloped responses without traversing capability results', () => {
+    const warn = vi.fn();
+    expect(normalizeCreditBalanceResponse({ remaining_credits: '12.5' }, warn)).toEqual({ remaining_credits: 12.5 });
+    expect(normalizeCreditBalanceResponse({ status: 'success', data: { remaining_credits: '0' } }, warn)).toEqual({
+      status: 'success',
+      data: { remaining_credits: 0 },
+    });
+    const capabilityResult = { result: { data: { remaining_credits: 'provider-defined' } } };
+    expect(normalizeCreditBalanceResponse(capabilityResult, warn)).toBe(capabilityResult);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('converts an invalid balance to null and emits one diagnostic', () => {
+    const warn = vi.fn();
+    expect(normalizeCreditBalanceResponse({ remaining_credits: 'unavailable' }, warn)).toEqual({
+      remaining_credits: null,
+    });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('treating the balance as unavailable'));
+  });
+});

--- a/packages/mcp/src/api/credit-balance.ts
+++ b/packages/mcp/src/api/credit-balance.ts
@@ -1,0 +1,54 @@
+export interface CreditBalanceNormalization {
+  value: number | null | undefined;
+  invalid: boolean;
+}
+
+const JSON_NUMBER_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+/** Normalize the public number/null credit-balance contract at the HTTP boundary. */
+export function normalizeCreditBalance(value: unknown): CreditBalanceNormalization {
+  if (value === undefined) return { value: undefined, invalid: false };
+  if (value === null) return { value: null, invalid: false };
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? { value, invalid: false } : { value: null, invalid: true };
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!JSON_NUMBER_PATTERN.test(trimmed)) return { value: null, invalid: true };
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? { value: parsed, invalid: false } : { value: null, invalid: true };
+  }
+  return { value: null, invalid: true };
+}
+
+/**
+ * Normalize a top-level public response, or the data object in a response
+ * envelope. Capability result payloads are deliberately not traversed.
+ */
+export function normalizeCreditBalanceResponse<T>(
+  response: T,
+  warn: (message: string) => void = (message) => process.stderr.write(`${message}\n`),
+): T {
+  if (!isRecord(response)) return response;
+
+  const normalizedRoot = normalizeRecord(response, warn);
+  if (!isRecord(normalizedRoot.data)) return normalizedRoot as T;
+
+  const normalizedData = normalizeRecord(normalizedRoot.data, warn);
+  if (normalizedData === normalizedRoot.data) return normalizedRoot as T;
+  return { ...normalizedRoot, data: normalizedData } as T;
+}
+
+function normalizeRecord(record: Record<string, unknown>, warn: (message: string) => void): Record<string, unknown> {
+  if (!Object.prototype.hasOwnProperty.call(record, 'remaining_credits')) return record;
+  const normalized = normalizeCreditBalance(record.remaining_credits);
+  if (normalized.invalid) {
+    warn('[qveris] Invalid remaining_credits in API response; treating the balance as unavailable.');
+  }
+  if (normalized.value === record.remaining_credits) return record;
+  return { ...record, remaining_credits: normalized.value };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/mcp/src/full-spec.test.ts
+++ b/packages/mcp/src/full-spec.test.ts
@@ -1,11 +1,11 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createQverisServer, QVERIS_MCP_TOOL_ANNOTATIONS } from './index.js';
 import type { QverisClient } from './api/client.js';
-import type { ExecuteRequest, SearchRequest } from './types.js';
+import type { ExecuteRequest, ExecuteResponse, SearchRequest } from './types.js';
 
 type FakeQverisClient = QverisClient & {
   calls: string[];
@@ -90,6 +90,9 @@ describe('output schemas + structured content', () => {
     expect((discover?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('view');
     expect((discover?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('lang');
     expect((call?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('respond_with');
+    expect((call?.outputSchema as { properties?: Record<string, unknown> }).properties?.remaining_credits).toEqual({
+      anyOf: [{ type: 'number' }, { type: 'null' }],
+    });
 
     await c.callTool({ name: 'discover', arguments: { query: 'weather', view: 'routing', lang: 'en' } });
     expect(qveris.searchRequests).toEqual([
@@ -138,6 +141,51 @@ describe('output schemas + structured content', () => {
     const c = await connect({ client: fakeQverisClient() });
     const result = await c.callTool({ name: 'search_tools', arguments: { query: 'weather' } });
     expect(result.structuredContent).toMatchObject({ search_id: 's1' });
+    await c.close();
+  });
+
+  it('normalizes number, numeric-string, null, and invalid balances before MCP output validation', async () => {
+    const qveris = fakeQverisClient();
+    const balances: unknown[] = [42, '992.5', null, 'unavailable'];
+    let submissions = 0;
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    qveris.executeTool = async () => {
+      submissions += 1;
+      return {
+        execution_id: 'e1',
+        success: true,
+        result: { rows: [1] },
+        remaining_credits: balances.shift(),
+      } as unknown as ExecuteResponse;
+    };
+    const c = await connect({ client: qveris });
+
+    const canonical = await c.callTool({
+      name: 'call',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} },
+    });
+    expect(canonical.structuredContent).toMatchObject({ remaining_credits: 42, result: { rows: [1] } });
+
+    const numericString = await c.callTool({
+      name: 'call',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} },
+    });
+    expect(numericString.structuredContent).toMatchObject({ remaining_credits: 992.5, result: { rows: [1] } });
+
+    const alias = await c.callTool({
+      name: 'execute_tool',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} },
+    });
+    expect(alias.structuredContent).toMatchObject({ remaining_credits: null, result: { rows: [1] } });
+
+    const invalid = await c.callTool({
+      name: 'call',
+      arguments: { tool_id: 't1', search_id: 's1', params_to_tool: {} },
+    });
+    expect(invalid.structuredContent).toMatchObject({ remaining_credits: null, result: { rows: [1] } });
+    expect(submissions).toBe(4);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('treating the balance as unavailable'));
+    stderr.mockRestore();
     await c.close();
   });
 });

--- a/packages/mcp/src/http.test.ts
+++ b/packages/mcp/src/http.test.ts
@@ -183,7 +183,12 @@ describe('startHttpServer (end-to-end over Streamable HTTP)', () => {
       },
       async executeTool(toolId: string, request: ExecuteRequest) {
         executeRequests.push({ toolId, request });
-        return { execution_id: 'e1', success: true, result: { ok: true } };
+        return {
+          execution_id: 'e1',
+          success: true,
+          result: { ok: true },
+          remaining_credits: '992.5',
+        } as unknown as Awaited<ReturnType<QverisClient['executeTool']>>;
       },
     } as unknown as QverisClient;
     await startServer({}, undefined, (sessionId) => createQverisServer(qveris, sessionId));
@@ -197,7 +202,7 @@ describe('startHttpServer (end-to-end over Streamable HTTP)', () => {
     expect((call?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty('respond_with');
 
     await client.callTool({ name: 'discover', arguments: { query: 'weather', view: 'routing', lang: 'en' } });
-    await client.callTool({
+    const projected = await client.callTool({
       name: 'call',
       arguments: { tool_id: 'weather.v1', search_id: 's1', params_to_tool: {}, respond_with: 'summary' },
     });
@@ -211,6 +216,7 @@ describe('startHttpServer (end-to-end over Streamable HTTP)', () => {
       request: { search_id: 's1', parameters: {}, respond_with: 'summary' },
     });
     expect(executeRequests[1]?.request).not.toHaveProperty('respond_with');
+    expect(projected.structuredContent).toMatchObject({ remaining_credits: 992.5, result: { ok: true } });
     await client.close();
   });
 

--- a/packages/mcp/src/output-schemas.ts
+++ b/packages/mcp/src/output-schemas.ts
@@ -38,7 +38,7 @@ const executeResponseSchema = {
     success: { type: 'boolean' },
     result: {},
     billing: { type: 'object', additionalProperties: true },
-    remaining_credits: { type: 'number' },
+    remaining_credits: { anyOf: [{ type: 'number' }, { type: 'null' }] },
   },
   additionalProperties: true,
 } as const;

--- a/packages/mcp/src/tools/execute.ts
+++ b/packages/mcp/src/tools/execute.ts
@@ -8,6 +8,7 @@
  */
 
 import type { QverisClient } from '../api/client.js';
+import { normalizeCreditBalanceResponse } from '../api/credit-balance.js';
 import type { ExecuteResponse } from '../types.js';
 
 /**
@@ -137,7 +138,7 @@ export async function executeExecuteTool(
     ...(input.respond_with !== undefined && { respond_with: input.respond_with }),
   });
 
-  return response;
+  return normalizeCreditBalanceResponse(response);
 }
 
 function isParamsObject(value: unknown): value is Record<string, unknown> {

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -275,7 +275,7 @@ export interface SearchResponse {
   stats?: SearchStats;
 
   /** User's remaining credits after this operation */
-  remaining_credits?: number;
+  remaining_credits?: number | null;
 
   /** Total elapsed time in milliseconds */
   elapsed_time_ms?: number;
@@ -451,7 +451,7 @@ export interface ExecuteResponse {
   pre_settlement_bill?: Record<string, unknown>;
 
   /** User's remaining credits after this execution */
-  remaining_credits?: number;
+  remaining_credits?: number | null;
 
   /** Timestamp of execution (ISO 8601 format) */
   created_at?: string;

--- a/test-fixtures/credit-balance-contract.json
+++ b/test-fixtures/credit-balance-contract.json
@@ -1,0 +1,76 @@
+{
+  "cases": [
+    {
+      "name": "number",
+      "input": 992.5,
+      "expected": 992.5,
+      "invalid": false
+    },
+    {
+      "name": "numeric string",
+      "input": "992.5",
+      "expected": 992.5,
+      "invalid": false
+    },
+    {
+      "name": "zero string",
+      "input": "0",
+      "expected": 0,
+      "invalid": false
+    },
+    {
+      "name": "trimmed numeric string",
+      "input": " 42.25 ",
+      "expected": 42.25,
+      "invalid": false
+    },
+    {
+      "name": "exponent numeric string",
+      "input": "1e3",
+      "expected": 1000,
+      "invalid": false
+    },
+    {
+      "name": "null",
+      "input": null,
+      "expected": null,
+      "invalid": false
+    },
+    {
+      "name": "empty string",
+      "input": "",
+      "expected": null,
+      "invalid": true
+    },
+    {
+      "name": "whitespace string",
+      "input": "   ",
+      "expected": null,
+      "invalid": true
+    },
+    {
+      "name": "non-numeric string",
+      "input": "unavailable",
+      "expected": null,
+      "invalid": true
+    },
+    {
+      "name": "hex string",
+      "input": "0x10",
+      "expected": null,
+      "invalid": true
+    },
+    {
+      "name": "numeric separator string",
+      "input": "1_000",
+      "expected": null,
+      "invalid": true
+    },
+    {
+      "name": "object",
+      "input": { "value": 12 },
+      "expected": null,
+      "invalid": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- normalize `remaining_credits` at the MCP, JavaScript SDK, and CLI response boundaries
- convert finite JSON-number strings to numbers, preserve `null`, and degrade invalid values to unavailable with a diagnostic
- normalize MCP call results before output-schema validation so a completed capability result is never discarded by balance type drift
- publish the same `number | null` output contract for `call` and its deprecated alias, and align handwritten response types with OpenAPI
- prepare patch releases: MCP 0.14.2, JavaScript SDK 0.8.1, and CLI 0.11.1

## Safety and compatibility

- capability-owned nested result payloads are not traversed or rewritten
- paid calls remain strict single-submit for legacy `422`, `429`, `503`, redirects, timeouts, and response normalization
- canonical and deprecated MCP tools continue to share their schema and execution path
- shared fixtures keep normalization behavior aligned across all three JavaScript packages

## Validation

- `npm test` — CLI 156, MCP 209, JavaScript SDK 107, OpenClaw plugin 79 + 29 registry checks, Python SDK 196 passed / 1 skipped, release checks 43
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run check:public-copy` — 95 files, 0 findings
- `npm run test:public-copy` — 9 tests
- `npm run release:clients:check` — all three new package tags pending
- `npm pack --dry-run --json` for MCP, JavaScript SDK, and CLI
- documentation boundary scans and `git diff --check`

Closes #341
