### PR TITLE
fix(types): align credits response nullability

### DIFF
--- a/docs/en-US/js-sdk-api.md
+++ b/docs/en-US/js-sdk-api.md
@@ -1387,7 +1387,7 @@ Supplies a bearer credential for an API request.
 
 ##### remaining\_credits
 
-> **remaining\_credits**: `number`
+> **remaining\_credits**: `number` \| `null`
 
 ##### welcome\_bonus?
 

--- a/docs/zh-CN/js-sdk-api.md
+++ b/docs/zh-CN/js-sdk-api.md
@@ -1385,7 +1385,7 @@ Supplies a bearer credential for an API request.
 
 ##### remaining\_credits
 
-> **remaining\_credits**: `number`
+> **remaining\_credits**: `number` \| `null`
 
 ##### welcome\_bonus?
 

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- Normalize finite numeric-string credit balances at the response boundary, preserve `null` as unavailable, and align the public search and execution response types with the OpenAPI `number | null` contract without replaying paid calls. ([#341])
+- Normalize finite numeric-string credit balances at the response boundary, preserve `null` as unavailable, and align all credit-bearing response types with the OpenAPI `number | null` contract without replaying paid calls. ([#341])
 
 ## [0.8.0] - 2026-08-10
 

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -510,7 +510,7 @@ export interface ApiEnvelope<T> {
 }
 
 export interface CreditsResponse {
-  remaining_credits: number;
+  remaining_credits: number | null;
   daily_free?: Record<string, unknown>;
   invite_reward?: Record<string, unknown>;
   welcome_bonus?: Record<string, unknown>;

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
-- Normalize finite numeric-string credit balances before MCP output validation, preserve documented `null` balances, and degrade invalid balances to unavailable without discarding completed capability results. The canonical `call` tool and deprecated `execute_tool` alias now publish the same `number | null` contract while paid calls remain single-submit. ([#341])
+- Normalize finite numeric-string credit balances before MCP output validation, preserve documented `null` balances across credit-bearing response types, and degrade invalid balances to unavailable without discarding completed capability results. The canonical `call` tool and deprecated `execute_tool` alias now publish the same `number | null` contract while paid calls remain single-submit. ([#341])
 
 ## [0.14.1] - 2026-09-04
 

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -510,7 +510,7 @@ export interface ApiEnvelope<T> {
 }
 
 export interface CreditsResponse {
-  remaining_credits: number;
+  remaining_credits: number | null;
   daily_free?: Record<string, unknown>;
   invite_reward?: Record<string, unknown>;
   welcome_bonus?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

- widen `CreditsResponse.remaining_credits` to `number | null` in both maintained TypeScript type copies
- keep `Qveris.credits()` and MCP `getCredits()` sound when the response normalizer preserves a null balance or degrades an invalid balance to unavailable
- regenerate the English and Chinese JavaScript SDK API references
- clarify the pending MCP and JavaScript SDK patch-release notes

## Context

Follow-up to #342. That change normalizes credit balances across successful API responses, including `/auth/credits`; the account credits type must therefore expose the same runtime nullability as the search and execution response types.

## Validation

- JavaScript SDK: 107 tests, typecheck, lint
- MCP: 209 tests, typecheck, lint
- release tooling: 43 tests
- public-copy check: 95 files, 0 findings
- generated API reference is clean on a second generation pass
- `git diff --check`

