### PR TITLE
fix(openclaw): confirm Registry source during verification

### DIFF
--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated post-publish Registry verification to explicitly confirm the trusted package source required by current OpenClaw hosts.
+
 ## [2026.9.7] - 2026-09-07
 
 ### Added

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.mjs
@@ -25,7 +25,7 @@ export class ReleaseTransientError extends Error {
 }
 
 export function buildRegistryInstallArgs(spec) {
-  return ["plugins", "install", spec, "--pin", "--accept-capabilities"];
+  return ["plugins", "install", spec, "--pin", "--force", "--accept-capabilities"];
 }
 
 export function validateRegistryMetadata(metadata, expected) {

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
@@ -118,12 +118,13 @@ function fixtureOperations({ metadataSequence = [metadata()], installSequence = 
   };
 }
 
-test("pins the Registry package and accepts declared plugin capabilities", () => {
+test("pins the trusted Registry package and explicitly accepts its source and capabilities", () => {
   assert.deepEqual(buildRegistryInstallArgs("@qverisai/qveris@2026.7.30"), [
     "plugins",
     "install",
     "@qverisai/qveris@2026.7.30",
     "--pin",
+    "--force",
     "--accept-capabilities",
   ]);
 });


### PR DESCRIPTION
## Summary

- pass OpenClaw's explicit `--force` source-confirmation flag during post-publish Registry installation
- keep `--pin` and capability consent intact
- update the exact install-argument regression test
- record the release-verification fix in the Unreleased changelog

## Release recovery

The `2026.9.7` npm publish job succeeded, but its post-publish Registry verification stopped because current OpenClaw hosts reject Registry installation without explicit source confirmation. The immutable npm artifact and tag were not changed or republished.

After applying this fix locally, the verifier passed against `@qverisai/qveris@2026.9.7` and confirmed:

- npm metadata version and integrity
- `gitHead` `853bf404e47d5ff2cbe6e745f5df8afb5727c2ac`
- isolated Registry installation
- plugin version and runtime status
- concrete registration of `qveris_discover`, `qveris_call`, and `qveris_inspect`

The missing GitHub Release was then created from the existing tag.

## Validation

- OpenClaw plugin tests: 103 passed
- Registry release tests: 30 passed
- typecheck and lint
- public-copy checks
- live exact-artifact Registry verification against OpenClaw `2026.9.2`
