### PR TITLE
ci: publish the OpenClaw plugin through trusted ClawHub

### DIFF
--- a/.github/workflows/qveris-plugin-clawhub-publish.yml
+++ b/.github/workflows/qveris-plugin-clawhub-publish.yml
@@ -1,0 +1,110 @@
+name: Publish QVeris OpenClaw plugin to ClawHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing qveris-plugin-v* tag to publish
+        required: true
+        type: string
+        default: qveris-plugin-v2026.9.7
+      dry_run:
+        description: Validate and preview without publishing
+        required: true
+        type: boolean
+        default: true
+
+permissions: {}
+
+jobs:
+  prepare:
+    name: Build immutable tagged artifact
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Validate requested tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^qveris-plugin-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::tag must match qveris-plugin-v<version>"
+            exit 1
+          fi
+
+      - name: Checkout tagged source
+        uses: actions/checkout@v7
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.3
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify tag and package identity
+        id: release
+        working-directory: packages/openclaw-qveris-plugin
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#qveris-plugin-v}"
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_NAME" != "@qverisai/qveris" ]; then
+            echo "::error::Unexpected package name: $PKG_NAME"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        working-directory: packages/openclaw-qveris-plugin
+        run: npm ci
+
+      - name: Build ClawPack artifact
+        working-directory: packages/openclaw-qveris-plugin
+        run: |
+          mkdir -p "$RUNNER_TEMP/qveris-openclaw-clawpack"
+          npm pack --pack-destination "$RUNNER_TEMP/qveris-openclaw-clawpack"
+
+      - name: Upload ClawPack artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: qveris-openclaw-plugin-clawpack
+          path: ${{ runner.temp }}/qveris-openclaw-clawpack/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Validate and publish through ClawHub
+    needs: prepare
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@d3bde70e3c9373720d4d3e335f9935399ea2c008
+    with:
+      package_artifact_name: qveris-openclaw-plugin-clawpack
+      owner: qverisai
+      family: code-plugin
+      version: ${{ needs.prepare.outputs.version }}
+      tags: latest
+      categories: models,context,web
+      source_repo: QVerisAI/qveris-agent-toolkit
+      source_commit: ${{ needs.prepare.outputs.commit }}
+      source_ref: refs/tags/${{ inputs.tag }}
+      source_path: packages/openclaw-qveris-plugin
+      dry_run: ${{ inputs.dry_run }}
+      wait_for_publication: true
+      publication_timeout_minutes: 40
+      inspector_artifact_name: qveris-openclaw-plugin-inspector-report
+      publish_json_artifact_name: qveris-openclaw-plugin-clawhub-publish-json


### PR DESCRIPTION
## Outcome

Adds a no-long-lived-secret path for publishing the existing `@qverisai/qveris` code plugin to its trusted ClawHub listing. This closes the current gap where npm is at `2026.9.7` but ClawHub remains at `2026.3.23`.

## Design

- Maintainers select an existing `qveris-plugin-v*` tag through `workflow_dispatch`.
- The job checks out that immutable tag, verifies package identity and version, and builds a ClawPack artifact.
- Publishing delegates to the official ClawHub reusable workflow pinned to commit `d3bde70e3c9373720d4d3e335f9935399ea2c008`.
- ClawHub validates the package, records exact source provenance, runs its security checks, and waits for definitive publication.
- The workflow defaults to dry-run and uses GitHub OIDC Trusted Publishing for real releases; no repository token is introduced.

After this PR merges, a current manager of the existing `qverisai` ClawHub package needs to bind the trusted publisher once:

```bash
clawhub package trusted-publisher set @qverisai/qveris --repository QVerisAI/qveris-agent-toolkit --workflow-filename qveris-plugin-clawhub-publish.yml
```

Then run this workflow for `qveris-plugin-v2026.9.7`, first with dry-run enabled and then disabled. Once ClawHub reports the version as published and clean, the public install path can switch to `openclaw plugins install clawhub:@qverisai/qveris` without bypassing source trust controls.

## Verification

- Package contents check: 19 files, passed
- Registry release contract tests: 30 passed
- TypeScript typecheck: passed
- ESLint and Prettier checks: passed
- Workflow YAML parse: passed

Tracks WonderfulValley/qveris-website#2645.
