### PR TITLE
Fix capability contract validation and website sync metadata

### DIFF
--- a/.github/workflows/sync-docs-to-website.yml
+++ b/.github/workflows/sync-docs-to-website.yml
@@ -149,6 +149,7 @@ jobs:
           node qveris-agent-toolkit/scripts/sync-website-client-versions.mjs
           --toolkit-dir qveris-agent-toolkit
           --website-dir website
+          --source-commit ${{ steps.toolkit.outputs.sha }}
 
       - name: Validate public claims before opening the sync PR
         if: steps.guard.outputs.skip != 'true'

--- a/agent/llms-full.txt
+++ b/agent/llms-full.txt
@@ -583,8 +583,8 @@ Model improvement is a tailwind for QVeris, not a headwind.
 
 - **CLI (npm):** https://www.npmjs.com/package/@qverisai/cli — `npm install -g @qverisai/cli` (v0.11.2)
 - **MCP Server (npm):** https://www.npmjs.com/package/@qverisai/mcp — `npx @qverisai/mcp` (v0.14.3)
-- **JavaScript SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/js-sdk (v0.8.2)
-- **Python SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk (v0.7.1)
+- **JavaScript SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/js-sdk (v0.8.3)
+- **Python SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk (v0.7.2)
 - **Online Docs:** https://qveris.ai/docs
 
 ### Open Ecosystem
@@ -679,8 +679,8 @@ Generate a new UUID for each user session, and reuse it throughout that session.
 - **llms-full.txt Version:** 1.2.0
 - **CLI Version:** 0.11.2
 - **MCP Server Version:** 0.14.3
-- **JavaScript SDK Version:** 0.8.2
-- **Python SDK Version:** 0.7.1
+- **JavaScript SDK Version:** 0.8.3
+- **Python SDK Version:** 0.7.2
 - **Last Updated:** 2026-09-07
 
 For the latest updates, always refer to:

--- a/agent/llms.txt
+++ b/agent/llms.txt
@@ -39,8 +39,8 @@
 - Hosted MCP (recommended for remote-capable MCP clients): open /hosted-mcp on the QVeris site that issued the API key for the correct Streamable HTTP endpoint and Bearer authentication setup — no local process, Node.js, or package install
 - CLI v0.11.2 (recommended for shell-capable agents): npm install -g @qverisai/cli — no upfront catalog schemas, deterministic output, API discovery without preloading the catalog
 - MCP Server v0.14.3 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
-- JavaScript SDK v0.8.2: npm install @qverisai/sdk
-- Python SDK v0.7.1: pip install qveris
+- JavaScript SDK v0.8.3: npm install @qverisai/sdk
+- Python SDK v0.7.2: pip install qveris
 - REST API: https://qveris.ai/api/v1
 - Explicit endpoint override: QVERIS_BASE_URL
 

--- a/docs/cn/zh-CN/getting-started.md
+++ b/docs/cn/zh-CN/getting-started.md
@@ -120,7 +120,31 @@ Typed client 工作流：
 
 ```python
 import asyncio
+import math
 from qveris import QverisClient
+
+def matches_type(kind, value):
+    return {
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda: isinstance(value, bool),
+        "array": lambda: isinstance(value, list),
+        "object": lambda: isinstance(value, dict),
+    }.get(kind, lambda: False)()
+
+def supports_request(candidate, params):
+    if candidate.params is None:
+        return False
+    definitions = {p.name: p for p in candidate.params}
+    if len(definitions) != len(candidate.params):
+        return False
+    return all(not p.required or p.name in params for p in candidate.params) and all(
+        (p := definitions.get(name)) is not None and matches_type(p.type, value)
+        and (p.enum is None or any(allowed == value and
+             isinstance(allowed, bool) == isinstance(value, bool) for allowed in p.enum))
+        for name, value in params.items()
+    )
 
 async def main():
     client = QverisClient()
@@ -131,9 +155,7 @@ async def main():
             (
                 candidate
                 for candidate in discovered.results
-                if candidate.params is not None
-                and {parameter.name for parameter in candidate.params if parameter.required}.issubset(params)
-                and set(params).issubset({parameter.name for parameter in candidate.params})
+                if supports_request(candidate, params)
             ),
             None,
         )
@@ -146,9 +168,7 @@ async def main():
                 (
                     candidate
                     for candidate in inspected.results
-                    if candidate.params is not None
-                    and {parameter.name for parameter in candidate.params if parameter.required}.issubset(params)
-                    and set(params).issubset({parameter.name for parameter in candidate.params})
+                    if supports_request(candidate, params)
                 ),
                 None,
             )
@@ -207,10 +227,24 @@ const qveris = Qveris.fromEnv(); // 读取 QVERIS_API_KEY、QVERIS_BASE_URL
 
 const discovered = await qveris.discover('weather forecast API', { limit: 5 });
 const parameters: Record<string, unknown> = { city: 'London' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const supportsRequest = (candidate: (typeof discovered.results)[number]) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return Object.keys(parameters).every((name) => names.has(name)) &&
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(parameters).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) &&
     candidate.params.every((parameter) =>
       !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name),
     );

--- a/docs/cn/zh-CN/js-sdk.md
+++ b/docs/cn/zh-CN/js-sdk.md
@@ -2,7 +2,7 @@
 
 类型化的 TypeScript/JavaScript SDK，让你在自己的 Agent 和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
 
-`@qverisai/sdk` v0.8.2 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
+`@qverisai/sdk` v0.8.3 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
 
 ## 安装
 
@@ -48,10 +48,24 @@ const qveris = Qveris.fromEnv();
 // 1. 用自然语言发现能力（免费）
 const discovered = await qveris.discover('weather forecast API', { limit: 5 });
 const params: Record<string, unknown> = { city: 'London' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const supportsRequest = (candidate: (typeof discovered.results)[number]) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return Object.keys(params).every((name) => names.has(name)) &&
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(params).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) &&
     candidate.params.every((parameter) =>
       !parameter.required || Object.prototype.hasOwnProperty.call(params, parameter.name),
     );

--- a/docs/cn/zh-CN/python-sdk.md
+++ b/docs/cn/zh-CN/python-sdk.md
@@ -1,6 +1,6 @@
 # QVeris Python SDK
 
-QVeris Python SDK v0.7.1 是最新测试版本。使用异步客户端，在你自己的 Agent 和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
+QVeris Python SDK v0.7.2 是最新测试版本。使用异步客户端，在你自己的 Agent 和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
 
 SDK 提供两种控制粒度：
 
@@ -45,7 +45,32 @@ client = QverisClient(QverisConfig(
 
 ```python
 import asyncio
+import math
 from qveris import QverisClient, QverisConfig
+
+def matches_type(kind, value):
+    return {
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda: isinstance(value, bool),
+        "array": lambda: isinstance(value, list),
+        "object": lambda: isinstance(value, dict),
+    }.get(kind, lambda: False)()
+
+def supports_request(candidate, params):
+    if candidate.params is None:
+        return False
+    definitions = {p.name: p for p in candidate.params}
+    if len(definitions) != len(candidate.params):
+        return False
+    return all(not p.required or p.name in params for p in candidate.params) and all(
+        (p := definitions.get(name)) is not None
+        and matches_type(p.type, value)
+        and (p.enum is None or any(allowed == value and
+             isinstance(allowed, bool) == isinstance(value, bool) for allowed in p.enum))
+        for name, value in params.items()
+    )
 
 async def main():
     client = QverisClient(QverisConfig(base_url="https://qveris.cn/api/v1"))
@@ -55,9 +80,7 @@ async def main():
         params = {"city": "北京"}
         tool = next(
             (candidate for candidate in discovered.results
-             if candidate.params is not None
-             and {p.name for p in candidate.params if p.required}.issubset(params)
-             and set(params).issubset({p.name for p in candidate.params})),
+             if supports_request(candidate, params)),
             None,
         )
 
@@ -69,9 +92,7 @@ async def main():
             )
             tool = next(
                 (candidate for candidate in details.results
-                 if candidate.params is not None
-                 and {p.name for p in candidate.params if p.required}.issubset(params)
-                 and set(params).issubset({p.name for p in candidate.params})),
+                 if supports_request(candidate, params)),
                 None,
             )
         if tool is None:

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -117,7 +117,31 @@ Typed client workflow:
 
 ```python
 import asyncio
+import math
 from qveris import QverisClient
+
+def matches_type(kind, value):
+    return {
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda: isinstance(value, bool),
+        "array": lambda: isinstance(value, list),
+        "object": lambda: isinstance(value, dict),
+    }.get(kind, lambda: False)()
+
+def supports_request(candidate, params):
+    if candidate.params is None:
+        return False
+    definitions = {p.name: p for p in candidate.params}
+    if len(definitions) != len(candidate.params):
+        return False
+    return all(not p.required or p.name in params for p in candidate.params) and all(
+        (p := definitions.get(name)) is not None and matches_type(p.type, value)
+        and (p.enum is None or any(allowed == value and
+             isinstance(allowed, bool) == isinstance(value, bool) for allowed in p.enum))
+        for name, value in params.items()
+    )
 
 async def main():
     client = QverisClient()
@@ -128,9 +152,7 @@ async def main():
             (
                 candidate
                 for candidate in discovered.results
-                if candidate.params is not None
-                and {parameter.name for parameter in candidate.params if parameter.required}.issubset(params)
-                and set(params).issubset({parameter.name for parameter in candidate.params})
+                if supports_request(candidate, params)
             ),
             None,
         )
@@ -143,9 +165,7 @@ async def main():
                 (
                     candidate
                     for candidate in inspected.results
-                    if candidate.params is not None
-                    and {parameter.name for parameter in candidate.params if parameter.required}.issubset(params)
-                    and set(params).issubset({parameter.name for parameter in candidate.params})
+                    if supports_request(candidate, params)
                 ),
                 None,
             )
@@ -199,10 +219,24 @@ const qveris = Qveris.fromEnv(); // reads QVERIS_API_KEY
 
 const discovered = await qveris.discover('weather forecast API', { limit: 5 });
 const parameters: Record<string, unknown> = { city: 'London' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const supportsRequest = (candidate: (typeof discovered.results)[number]) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return Object.keys(parameters).every((name) => names.has(name)) &&
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(parameters).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) &&
     candidate.params.every((parameter) =>
       !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name),
     );

--- a/docs/en-US/js-sdk-api.md
+++ b/docs/en-US/js-sdk-api.md
@@ -321,12 +321,25 @@ const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
 
 const found = await qveris.discover('stock price market data API', { limit: 5 });
 const parameters = { symbol: 'AAPL' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const tool = found.results.find((candidate) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return names.has('symbol') && candidate.params.every((parameter) =>
-    !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name),
-  );
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(parameters).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) && candidate.params.every((parameter) =>
+      !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name));
 });
 if (!tool) throw new Error('Inspect promising candidates to obtain a compatible contract.');
 

--- a/docs/en-US/js-sdk.md
+++ b/docs/en-US/js-sdk.md
@@ -2,7 +2,7 @@
 
 Typed TypeScript/JavaScript SDK to discover, inspect, probe, call, and audit real-world API capabilities from your own agents and applications.
 
-`@qverisai/sdk` v0.8.2 is the latest tested release. It is a thin, typed wrapper over the QVeris REST API (`discover`, `inspect`, `probe`, `call`, `credits`, `usage`, `ledger`). It has **zero runtime dependencies** — it uses the platform `fetch` (Node.js 18+) — and mirrors the wire semantics of the [Python SDK](python-sdk.md) and the [MCP server](mcp-server.md).
+`@qverisai/sdk` v0.8.3 is the latest tested release. It is a thin, typed wrapper over the QVeris REST API (`discover`, `inspect`, `probe`, `call`, `credits`, `usage`, `ledger`). It has **zero runtime dependencies** — it uses the platform `fetch` (Node.js 18+) — and mirrors the wire semantics of the [Python SDK](python-sdk.md) and the [MCP server](mcp-server.md).
 
 ## Installation
 
@@ -48,10 +48,24 @@ const qveris = Qveris.fromEnv();
 // 1. Discover capabilities with natural language (free)
 const discovered = await qveris.discover('weather forecast API', { limit: 5 });
 const params: Record<string, unknown> = { city: 'London' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const supportsRequest = (candidate: (typeof discovered.results)[number]) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return Object.keys(params).every((name) => names.has(name)) &&
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(params).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) &&
     candidate.params.every((parameter) =>
       !parameter.required || Object.prototype.hasOwnProperty.call(params, parameter.name),
     );

--- a/docs/en-US/python-sdk.md
+++ b/docs/en-US/python-sdk.md
@@ -1,6 +1,6 @@
 # QVeris Python SDK
 
-QVeris Python SDK v0.7.1 is the latest tested release. Use its async client to discover, inspect, probe, call, and audit real-world API capabilities from your own agents and applications.
+QVeris Python SDK v0.7.2 is the latest tested release. Use its async client to discover, inspect, probe, call, and audit real-world API capabilities from your own agents and applications.
 
 The SDK gives you two levels of control:
 
@@ -41,7 +41,32 @@ The default workflow is **discover → call**, then optionally **audit** what ha
 
 ```python
 import asyncio
+import math
 from qveris import QverisClient
+
+def matches_type(kind, value):
+    return {
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda: isinstance(value, bool),
+        "array": lambda: isinstance(value, list),
+        "object": lambda: isinstance(value, dict),
+    }.get(kind, lambda: False)()
+
+def supports_request(candidate, params):
+    if candidate.params is None:
+        return False
+    definitions = {p.name: p for p in candidate.params}
+    if len(definitions) != len(candidate.params):
+        return False
+    return all(not p.required or p.name in params for p in candidate.params) and all(
+        (p := definitions.get(name)) is not None
+        and matches_type(p.type, value)
+        and (p.enum is None or any(allowed == value and
+             isinstance(allowed, bool) == isinstance(value, bool) for allowed in p.enum))
+        for name, value in params.items()
+    )
 
 async def main():
     client = QverisClient()
@@ -51,9 +76,7 @@ async def main():
         params = {"city": "London"}
         tool = next(
             (candidate for candidate in discovered.results
-             if candidate.params is not None
-             and {p.name for p in candidate.params if p.required}.issubset(params)
-             and set(params).issubset({p.name for p in candidate.params})),
+             if supports_request(candidate, params)),
             None,
         )
 
@@ -65,9 +88,7 @@ async def main():
             )
             tool = next(
                 (candidate for candidate in details.results
-                 if candidate.params is not None
-                 and {p.name for p in candidate.params if p.required}.issubset(params)
-                 and set(params).issubset({p.name for p in candidate.params})),
+                 if supports_request(candidate, params)),
                 None,
             )
         if tool is None:

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -117,7 +117,31 @@ Typed client 工作流：
 
 ```python
 import asyncio
+import math
 from qveris import QverisClient
+
+def matches_type(kind, value):
+    return {
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda: isinstance(value, bool),
+        "array": lambda: isinstance(value, list),
+        "object": lambda: isinstance(value, dict),
+    }.get(kind, lambda: False)()
+
+def supports_request(candidate, params):
+    if candidate.params is None:
+        return False
+    definitions = {p.name: p for p in candidate.params}
+    if len(definitions) != len(candidate.params):
+        return False
+    return all(not p.required or p.name in params for p in candidate.params) and all(
+        (p := definitions.get(name)) is not None and matches_type(p.type, value)
+        and (p.enum is None or any(allowed == value and
+             isinstance(allowed, bool) == isinstance(value, bool) for allowed in p.enum))
+        for name, value in params.items()
+    )
 
 async def main():
     client = QverisClient()
@@ -128,9 +152,7 @@ async def main():
             (
                 candidate
                 for candidate in discovered.results
-                if candidate.params is not None
-                and {parameter.name for parameter in candidate.params if parameter.required}.issubset(params)
-                and set(params).issubset({parameter.name for parameter in candidate.params})
+                if supports_request(candidate, params)
             ),
             None,
         )
@@ -143,9 +165,7 @@ async def main():
                 (
                     candidate
                     for candidate in inspected.results
-                    if candidate.params is not None
-                    and {parameter.name for parameter in candidate.params if parameter.required}.issubset(params)
-                    and set(params).issubset({parameter.name for parameter in candidate.params})
+                    if supports_request(candidate, params)
                 ),
                 None,
             )
@@ -199,10 +219,24 @@ const qveris = Qveris.fromEnv(); // 读取 QVERIS_API_KEY
 
 const discovered = await qveris.discover('weather forecast API', { limit: 5 });
 const parameters: Record<string, unknown> = { city: 'London' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const supportsRequest = (candidate: (typeof discovered.results)[number]) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return Object.keys(parameters).every((name) => names.has(name)) &&
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(parameters).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) &&
     candidate.params.every((parameter) =>
       !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name),
     );

--- a/docs/zh-CN/js-sdk-api.md
+++ b/docs/zh-CN/js-sdk-api.md
@@ -319,12 +319,25 @@ const qveris = new Qveris({ apiKey: process.env.QVERIS_API_KEY! });
 
 const found = await qveris.discover('stock price market data API', { limit: 5 });
 const parameters = { symbol: 'AAPL' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const tool = found.results.find((candidate) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return names.has('symbol') && candidate.params.every((parameter) =>
-    !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name),
-  );
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(parameters).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) && candidate.params.every((parameter) =>
+      !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name));
 });
 if (!tool) throw new Error('Inspect promising candidates to obtain a compatible contract.');
 

--- a/docs/zh-CN/js-sdk.md
+++ b/docs/zh-CN/js-sdk.md
@@ -2,7 +2,7 @@
 
 类型化的 TypeScript/JavaScript SDK，让你在自己的智能体和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
 
-`@qverisai/sdk` v0.8.2 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
+`@qverisai/sdk` v0.8.3 是最新测试版本。它是对 QVeris REST API（`discover`、`inspect`、`probe`、`call`、`credits`、`usage`、`ledger`）的轻量类型化封装，**零运行时依赖**——使用平台原生 `fetch`（Node.js 18+）——并与 [Python SDK](python-sdk.md) 和 [MCP 服务器](mcp-server.md) 保持一致的通信语义。
 
 ## 安装
 
@@ -48,10 +48,24 @@ const qveris = Qveris.fromEnv();
 // 1. 用自然语言发现能力（免费）
 const discovered = await qveris.discover('weather forecast API', { limit: 5 });
 const params: Record<string, unknown> = { city: 'London' };
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
 const supportsRequest = (candidate: (typeof discovered.results)[number]) => {
   if (!candidate.params) return false;
-  const names = new Set(candidate.params.map((parameter) => parameter.name));
-  return Object.keys(params).every((name) => names.has(name)) &&
+  const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+  if (definitions.size !== candidate.params.length) return false;
+  return Object.entries(params).every(([name, value]) => {
+    const parameter = definitions.get(name);
+    return Boolean(parameter && matchesType(parameter.type, value) &&
+      (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+  }) &&
     candidate.params.every((parameter) =>
       !parameter.required || Object.prototype.hasOwnProperty.call(params, parameter.name),
     );

--- a/docs/zh-CN/python-sdk.md
+++ b/docs/zh-CN/python-sdk.md
@@ -1,6 +1,6 @@
 # QVeris Python SDK
 
-QVeris Python SDK v0.7.1 是最新测试版本。使用异步客户端，在你自己的智能体和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
+QVeris Python SDK v0.7.2 是最新测试版本。使用异步客户端，在你自己的智能体和应用中发现、检查、探测、调用并审计 丰富的 API 能力。
 
 SDK 提供两种控制粒度：
 
@@ -41,7 +41,32 @@ API 地址优先级为：`QverisConfig(base_url=...)` > `QVERIS_BASE_URL` > `htt
 
 ```python
 import asyncio
+import math
 from qveris import QverisClient
+
+def matches_type(kind, value):
+    return {
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda: isinstance(value, bool),
+        "array": lambda: isinstance(value, list),
+        "object": lambda: isinstance(value, dict),
+    }.get(kind, lambda: False)()
+
+def supports_request(candidate, params):
+    if candidate.params is None:
+        return False
+    definitions = {p.name: p for p in candidate.params}
+    if len(definitions) != len(candidate.params):
+        return False
+    return all(not p.required or p.name in params for p in candidate.params) and all(
+        (p := definitions.get(name)) is not None
+        and matches_type(p.type, value)
+        and (p.enum is None or any(allowed == value and
+             isinstance(allowed, bool) == isinstance(value, bool) for allowed in p.enum))
+        for name, value in params.items()
+    )
 
 async def main():
     client = QverisClient()
@@ -51,9 +76,7 @@ async def main():
         params = {"city": "北京"}
         tool = next(
             (candidate for candidate in discovered.results
-             if candidate.params is not None
-             and {p.name for p in candidate.params if p.required}.issubset(params)
-             and set(params).issubset({p.name for p in candidate.params})),
+             if supports_request(candidate, params)),
             None,
         )
 
@@ -65,9 +88,7 @@ async def main():
             )
             tool = next(
                 (candidate for candidate in details.results
-                 if candidate.params is not None
-                 and {p.name for p in candidate.params if p.required}.issubset(params)
-                 and set(params).issubset({p.name for p in candidate.params})),
+                 if supports_request(candidate, params)),
                 None,
             )
         if tool is None:

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-09-07
+
+### Fixed
+
+- Reject incompatible Discover candidates in runnable and documented examples when supplied values violate the current parameter type or enum contract.
+
 ## [0.8.2] - 2026-09-07
 
 ### Changed
@@ -75,7 +81,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 - `0.1.x` under this npm name was an early MCP-focused SDK, superseded by `@qverisai/mcp`.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.2...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.3...HEAD
+[0.8.3]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.2...js-sdk-v0.8.3
 [0.8.2]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.1...js-sdk-v0.8.2
 [0.8.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.8.0...js-sdk-v0.8.1
 [0.8.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/js-sdk-v0.7.0...js-sdk-v0.8.0

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -27,11 +27,25 @@ for (const tool of found.results) {
 }
 
 const parameters: Record<string, unknown> = { symbol: 'AAPL' };
-// 2. Select only a contract with no required inputs missing from this request
+const matchesType = (type: string, value: unknown) => {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return false;
+};
+// 2. Select only a contract compatible with every supplied value
 const selected = found.results.find((tool) => {
   if (!tool.params) return false;
-  const names = new Set(tool.params.map((param) => param.name));
-  return Object.keys(parameters).every((name) => names.has(name)) &&
+  const definitions = new Map(tool.params.map((param) => [param.name, param]));
+  if (definitions.size !== tool.params.length) return false;
+  return Object.entries(parameters).every(([name, value]) => {
+    const param = definitions.get(name);
+    return Boolean(param && matchesType(param.type, value) &&
+      (!param.enum || param.enum.some((allowed) => Object.is(allowed, value))));
+  }) &&
     tool.params.every((param) => !param.required || Object.prototype.hasOwnProperty.call(parameters, param.name));
 });
 if (!selected) throw new Error('Inspect candidates before calling: no compatible contract was returned');

--- a/packages/js-sdk/examples/_shared.ts
+++ b/packages/js-sdk/examples/_shared.ts
@@ -7,7 +7,9 @@
  * `RUN_QVERIS_CALLS=1` so running an example never spends credits by accident.
  */
 
-import { Qveris, type ToolInfo } from '@qverisai/sdk';
+import { Qveris } from '@qverisai/sdk';
+
+export { supportsParameters } from './contract.js';
 
 /**
  * Build a client from `QVERIS_API_KEY`, or explain how to set one and return
@@ -27,14 +29,4 @@ export function getClientOrExplain(): Qveris | null {
 /** A `call` spends credits, so only execute one when explicitly opted in. */
 export function shouldCall(): boolean {
   return process.env.RUN_QVERIS_CALLS === '1';
-}
-
-/** Select only a current contract that accepts every supplied field and has no unmet required inputs. */
-export function supportsParameters(tool: ToolInfo, requested: Record<string, unknown>): boolean {
-  if (!Array.isArray(tool.params)) return false;
-  const names = new Set(tool.params.map((param) => param.name));
-  return (
-    Object.keys(requested).every((name) => names.has(name)) &&
-    tool.params.every((param) => !param.required || Object.prototype.hasOwnProperty.call(requested, param.name))
-  );
 }

--- a/packages/js-sdk/examples/contract.ts
+++ b/packages/js-sdk/examples/contract.ts
@@ -1,0 +1,37 @@
+import type { ToolInfo } from '@qverisai/sdk';
+
+function matchesParameterType(type: string, value: unknown): boolean {
+  switch (type) {
+    case 'string':
+      return typeof value === 'string';
+    case 'integer':
+      return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return value !== null && typeof value === 'object' && !Array.isArray(value);
+    default:
+      return false;
+  }
+}
+
+/** Select only a current contract that accepts every supplied field, type, and enum value. */
+export function supportsParameters(tool: ToolInfo, requested: Record<string, unknown>): boolean {
+  if (!Array.isArray(tool.params)) return false;
+  const definitions = new Map(tool.params.map((param) => [param.name, param]));
+  if (definitions.size !== tool.params.length) return false;
+  return (
+    Object.entries(requested).every(([name, value]) => {
+      const parameter = definitions.get(name);
+      return Boolean(
+        parameter &&
+        matchesParameterType(parameter.type, value) &&
+        (!Array.isArray(parameter.enum) || parameter.enum.some((allowed) => Object.is(allowed, value))),
+      );
+    }) && tool.params.every((param) => !param.required || Object.prototype.hasOwnProperty.call(requested, param.name))
+  );
+}

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/sdk",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "QVeris TypeScript SDK for agent capability discovery, inspection, calling, and audit",
   "keywords": [
     "qveris",

--- a/packages/js-sdk/src/client.ts
+++ b/packages/js-sdk/src/client.ts
@@ -192,12 +192,25 @@ export interface ProbeOptions {
  *
  * const found = await qveris.discover('stock price market data API', { limit: 5 });
  * const parameters = { symbol: 'AAPL' };
+ * const matchesType = (type: string, value: unknown) => {
+ *   if (type === 'string') return typeof value === 'string';
+ *   if (type === 'integer') return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+ *   if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+ *   if (type === 'boolean') return typeof value === 'boolean';
+ *   if (type === 'array') return Array.isArray(value);
+ *   if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+ *   return false;
+ * };
  * const tool = found.results.find((candidate) => {
  *   if (!candidate.params) return false;
- *   const names = new Set(candidate.params.map((parameter) => parameter.name));
- *   return names.has('symbol') && candidate.params.every((parameter) =>
- *     !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name),
- *   );
+ *   const definitions = new Map(candidate.params.map((parameter) => [parameter.name, parameter]));
+ *   if (definitions.size !== candidate.params.length) return false;
+ *   return Object.entries(parameters).every(([name, value]) => {
+ *     const parameter = definitions.get(name);
+ *     return Boolean(parameter && matchesType(parameter.type, value) &&
+ *       (!parameter.enum || parameter.enum.some((allowed) => Object.is(allowed, value))));
+ *   }) && candidate.params.every((parameter) =>
+ *       !parameter.required || Object.prototype.hasOwnProperty.call(parameters, parameter.name));
  * });
  * if (!tool) throw new Error('Inspect promising candidates to obtain a compatible contract.');
  *

--- a/packages/js-sdk/src/example-contract.test.ts
+++ b/packages/js-sdk/src/example-contract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { supportsParameters } from '../examples/contract.js';
+import type { ToolInfo, ToolParameter } from './types.js';
+
+function tool(params?: ToolParameter[]): ToolInfo {
+  return { tool_id: 'provider.tool', params };
+}
+
+function parameter(name: string, type: string, required = false, values?: string[]): ToolParameter {
+  return { name, type: type as ToolParameter['type'], required, description: '', enum: values };
+}
+
+describe('example parameter contract selection', () => {
+  it('accepts compatible JSON values and enum members', () => {
+    expect(
+      supportsParameters(
+        tool([
+          parameter('city', 'string', true, ['London', 'Paris']),
+          parameter('days', 'number'),
+          parameter('alerts', 'boolean'),
+          parameter('tags', 'array'),
+          parameter('options', 'object'),
+        ]),
+        { city: 'London', days: 3, alerts: false, tags: [], options: {} },
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['wrong type', tool([parameter('city', 'string', true)]), { city: 42 }],
+    ['enum mismatch', tool([parameter('city', 'string', true, ['Paris'])]), { city: 'London' }],
+    ['missing required input', tool([parameter('city', 'string', true)]), {}],
+    ['unsupported input', tool([parameter('city', 'string')]), { symbol: 'AAPL' }],
+    ['unknown contract type', tool([parameter('city', 'date')]), { city: '2026-09-07' }],
+    ['non-finite number', tool([parameter('days', 'number')]), { days: Number.NaN }],
+    ['array passed as object', tool([parameter('options', 'object')]), { options: [] }],
+    ['duplicate definitions', tool([parameter('city', 'string'), parameter('city', 'string')]), { city: 'London' }],
+  ])('rejects %s', (_label, candidate, requested) => {
+    expect(supportsParameters(candidate, requested)).toBe(false);
+  });
+});

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- Reject incompatible Discover candidates in the runnable Agent loop when supplied values violate the current parameter type or enum contract.
+
 ## [0.14.3] - 2026-09-07
 
 ### Changed

--- a/packages/mcp/examples/_shared.ts
+++ b/packages/mcp/examples/_shared.ts
@@ -1,0 +1,41 @@
+export type ContractTool = {
+  tool_id: string;
+  name?: string;
+  params?: Array<{ name: string; type: string; required?: boolean; enum?: unknown[] }>;
+};
+
+function matchesParameterType(type: string, value: unknown): boolean {
+  switch (type) {
+    case 'string':
+      return typeof value === 'string';
+    case 'integer':
+      return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return value !== null && typeof value === 'object' && !Array.isArray(value);
+    default:
+      return false;
+  }
+}
+
+/** Accept only requests that satisfy the complete contract returned by QVeris. */
+export function supportsParameters(tool: ContractTool, requested: Record<string, unknown>): boolean {
+  if (!Array.isArray(tool.params)) return false;
+  const definitions = new Map(tool.params.map((param) => [param.name, param]));
+  if (definitions.size !== tool.params.length) return false;
+  return (
+    Object.entries(requested).every(([name, value]) => {
+      const parameter = definitions.get(name);
+      return Boolean(
+        parameter &&
+        matchesParameterType(parameter.type, value) &&
+        (!Array.isArray(parameter.enum) || parameter.enum.some((allowed) => Object.is(allowed, value))),
+      );
+    }) && tool.params.every((param) => !param.required || Object.prototype.hasOwnProperty.call(requested, param.name))
+  );
+}

--- a/packages/mcp/examples/agent-loop.ts
+++ b/packages/mcp/examples/agent-loop.ts
@@ -18,12 +18,9 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { supportsParameters, type ContractTool } from './_shared.js';
 
-type ToolResult = {
-  tool_id: string;
-  name?: string;
-  params?: Array<{ name: string; required?: boolean }>;
-};
+type ToolResult = ContractTool;
 type DiscoverResult = { search_id?: string; results?: ToolResult[] };
 type InspectResult = { results?: ToolResult[] };
 type ToolCallResult = Awaited<ReturnType<Client['callTool']>>;
@@ -49,15 +46,6 @@ function readResult<T>(result: ToolCallResult): T | undefined {
     return JSON.parse(first.text) as T;
   }
   return undefined;
-}
-
-function supportsParameters(tool: ToolResult, requested: Record<string, unknown>): boolean {
-  if (!Array.isArray(tool.params)) return false;
-  const names = new Set(tool.params.map((param) => param.name));
-  return (
-    Object.keys(requested).every((name) => names.has(name)) &&
-    tool.params.every((param) => !param.required || Object.prototype.hasOwnProperty.call(requested, param.name))
-  );
 }
 
 async function main(): Promise<void> {

--- a/packages/mcp/src/example-contract.test.ts
+++ b/packages/mcp/src/example-contract.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { supportsParameters } from '../examples/_shared.js';
+
+describe('MCP example parameter contract selection', () => {
+  const candidate = {
+    tool_id: 'provider.tool',
+    params: [
+      { name: 'symbol', type: 'string', required: true, enum: ['AAPL'] },
+      { name: 'limit', type: 'integer' },
+    ],
+  };
+
+  it('accepts values that match type and enum constraints', () => {
+    expect(supportsParameters(candidate, { symbol: 'AAPL', limit: 10 })).toBe(true);
+  });
+
+  it.each([{ symbol: 'MSFT' }, { symbol: 'AAPL', limit: 1.5 }, { symbol: 'AAPL', extra: true }])(
+    'rejects incompatible parameters %#',
+    (requested) => {
+      expect(supportsParameters(candidate, requested)).toBe(false);
+    },
+  );
+});

--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-09-07
+
+### Fixed
+
+- Reject incompatible Discover candidates in runnable and documented examples when supplied values violate the current parameter type or enum contract.
+
 ## [0.7.1] - 2026-09-07
 
 ### Changed
@@ -103,7 +109,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Generated OpenAPI contract models with drift CI. ([#48])
 - `Agent` runtime: LLM tool loop over the QVeris workflow with streaming events.
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.7.1...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.7.2...HEAD
+[0.7.2]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.7.1...python-sdk-v0.7.2
 [0.7.1]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.7.0...python-sdk-v0.7.1
 [0.7.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.6.0...python-sdk-v0.7.0
 [0.6.0]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/python-sdk-v0.5.0...python-sdk-v0.6.0

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -101,7 +101,32 @@ never pass through the SDK.
 
 ```python
 import asyncio
+import math
 from qveris import QverisClient
+
+def matches_type(kind, value):
+    return {
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda: isinstance(value, bool),
+        "array": lambda: isinstance(value, list),
+        "object": lambda: isinstance(value, dict),
+    }.get(kind, lambda: False)()
+
+def supports_request(tool, params):
+    if tool.params is None:
+        return False
+    definitions = {p.name: p for p in tool.params}
+    if len(definitions) != len(tool.params):
+        return False
+    return all(not p.required or p.name in params for p in tool.params) and all(
+        (p := definitions.get(name)) is not None
+        and matches_type(p.type, value)
+        and (p.enum is None or any(allowed == value and
+             isinstance(allowed, bool) == isinstance(value, bool) for allowed in p.enum))
+        for name, value in params.items()
+    )
 
 async def main():
     client = QverisClient()
@@ -110,9 +135,7 @@ async def main():
         params = {"city": "London"}
         selected = next(
             (tool for tool in discovered.results
-             if tool.params is not None
-             and {p.name for p in tool.params if p.required}.issubset(params)
-             and set(params).issubset({p.name for p in tool.params})),
+             if supports_request(tool, params)),
             None,
         )
         if selected is None:
@@ -122,9 +145,7 @@ async def main():
             )
             selected = next(
                 (tool for tool in inspected.results
-                 if tool.params is not None
-                 and {p.name for p in tool.params if p.required}.issubset(params)
-                 and set(params).issubset({p.name for p in tool.params})),
+                 if supports_request(tool, params)),
                 None,
             )
         if selected is None:

--- a/packages/python-sdk/examples/_shared.py
+++ b/packages/python-sdk/examples/_shared.py
@@ -1,5 +1,6 @@
+import math
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from qveris import QverisClient, ToolInfo
 
@@ -15,13 +16,44 @@ def should_call() -> bool:
     return os.getenv("RUN_QVERIS_CALLS") == "1"
 
 
+def _matches_parameter_type(parameter_type: Any, value: Any) -> bool:
+    if parameter_type == "string":
+        return isinstance(value, str)
+    if parameter_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if parameter_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+    if parameter_type == "boolean":
+        return isinstance(value, bool)
+    if parameter_type == "array":
+        return isinstance(value, list)
+    if parameter_type == "object":
+        return isinstance(value, dict)
+    return False
+
+
+def _matches_enum(allowed_values: Optional[List[Any]], value: Any) -> bool:
+    if allowed_values is None:
+        return True
+    return any(
+        allowed == value and not (isinstance(allowed, bool) != isinstance(value, bool)) for allowed in allowed_values
+    )
+
+
 def supports_parameters(tool: ToolInfo, requested: Dict[str, Any]) -> bool:
-    """Require an explicit compatible contract; None means metadata was omitted."""
+    """Require an explicit contract compatible with every supplied value."""
     if tool.params is None:
         return False
-    names = {param.name for param in tool.params}
+    definitions = {param.name: param for param in tool.params}
+    if len(definitions) != len(tool.params):
+        return False
     required = {param.name for param in tool.params if param.required}
-    return set(requested).issubset(names) and required.issubset(requested)
+    return required.issubset(requested) and all(
+        (parameter := definitions.get(name)) is not None
+        and _matches_parameter_type(parameter.type, value)
+        and _matches_enum(parameter.enum, value)
+        for name, value in requested.items()
+    )
 
 
 async def preview_capability(

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qveris"
-version = "0.7.1"
+version = "0.7.2"
 description = "QVeris Python SDK for agent capability discovery, calling, and audit"
 requires-python = ">=3.8"
 license = "MIT"

--- a/packages/python-sdk/tests/test_example_contract.py
+++ b/packages/python-sdk/tests/test_example_contract.py
@@ -1,0 +1,49 @@
+import math
+
+from examples._shared import supports_parameters
+from qveris import ToolInfo, ToolParameter
+
+
+def parameter(name: str, type_: str, *, required: bool = False, enum=None) -> ToolParameter:
+    return ToolParameter(name=name, type=type_, required=required, enum=enum)
+
+
+def tool(params=None) -> ToolInfo:
+    return ToolInfo(tool_id="provider.tool", params=params)
+
+
+def test_supports_parameters_accepts_compatible_json_values_and_enum_members() -> None:
+    candidate = tool(
+        [
+            parameter("city", "string", required=True, enum=["London", "Paris"]),
+            parameter("days", "number"),
+            parameter("alerts", "boolean"),
+            parameter("tags", "array"),
+            parameter("options", "object"),
+        ]
+    )
+
+    assert supports_parameters(
+        candidate,
+        {"city": "London", "days": 3, "alerts": False, "tags": [], "options": {}},
+    )
+
+
+def test_supports_parameters_rejects_incompatible_contracts() -> None:
+    assert not supports_parameters(tool(None), {"city": "London"})
+    assert not supports_parameters(tool([parameter("city", "string", required=True)]), {})
+    assert not supports_parameters(tool([parameter("city", "string")]), {"city": 42})
+    assert not supports_parameters(tool([parameter("city", "string", enum=["Paris"])]), {"city": "London"})
+    assert not supports_parameters(tool([parameter("days", "number")]), {"days": math.inf})
+    assert not supports_parameters(tool([parameter("days", "number")]), {"days": True})
+    assert not supports_parameters(tool([parameter("options", "object")]), {"options": []})
+    assert not supports_parameters(tool([parameter("city", "date")]), {"city": "2026-09-07"})
+    assert not supports_parameters(tool([parameter("city", "string")]), {"symbol": "AAPL"})
+    assert not supports_parameters(
+        tool([parameter("city", "string"), parameter("city", "string")]),
+        {"city": "London"},
+    )
+
+
+def test_enum_comparison_does_not_treat_booleans_as_numbers() -> None:
+    assert not supports_parameters(tool([parameter("value", "integer", enum=[True])]), {"value": 1})

--- a/packages/python-sdk/uv.lock
+++ b/packages/python-sdk/uv.lock
@@ -6025,7 +6025,7 @@ wheels = [
 
 [[package]]
 name = "qveris"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/scripts/sdk-guide-contracts.test.mjs
+++ b/scripts/sdk-guide-contracts.test.mjs
@@ -22,6 +22,12 @@ const JS_GUIDES = [
   "docs/cn/zh-CN/js-sdk.md",
 ];
 
+const GETTING_STARTED_GUIDES = [
+  "docs/en-US/getting-started.md",
+  "docs/zh-CN/getting-started.md",
+  "docs/cn/zh-CN/getting-started.md",
+];
+
 const PYTHON_API_REFERENCES = [
   "docs/en-US/python-sdk-api.md",
   "docs/zh-CN/python-sdk-api.md",
@@ -53,6 +59,21 @@ test("all TypeScript SDK guides document Probe and strict paid calls", () => {
       "compatibilityMode: 'legacyOptionalFields'",
       "single-submit",
     ]) {
+      assert.ok(guide.includes(marker), `${path} is missing ${marker}`);
+    }
+  }
+});
+
+test("SDK quickstarts validate parameter types and enums before selecting a candidate", () => {
+  for (const path of [...JS_GUIDES, ...GETTING_STARTED_GUIDES]) {
+    const guide = read(path);
+    for (const marker of ["matchesType", "Number.isFinite", "parameter.enum", "Object.is"]) {
+      assert.ok(guide.includes(marker), `${path} is missing ${marker}`);
+    }
+  }
+  for (const path of [...PYTHON_GUIDES, ...GETTING_STARTED_GUIDES]) {
+    const guide = read(path);
+    for (const marker of ["matches_type", "math.isfinite", "p.enum", "isinstance(allowed, bool)"]) {
       assert.ok(guide.includes(marker), `${path} is missing ${marker}`);
     }
   }

--- a/scripts/sync-website-client-versions.mjs
+++ b/scripts/sync-website-client-versions.mjs
@@ -7,6 +7,7 @@ import process from "node:process"
 import { websiteReleaseTag } from "./website-release-tags.mjs"
 
 const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+const COMMIT_RE = /^[0-9a-f]{40}$/
 const VERSION_REFERENCE_RE = /\bv?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/g
 
 const CLIENTS = [
@@ -50,14 +51,15 @@ const VERSION_SURFACES = [
 ]
 
 function parseArgs(argv) {
-  const args = { toolkitDir: "", websiteDir: "" }
+  const args = { toolkitDir: "", websiteDir: "", sourceCommit: "" }
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
     if (arg === "--toolkit-dir") args.toolkitDir = argv[++index] ?? ""
     else if (arg === "--website-dir") args.websiteDir = argv[++index] ?? ""
+    else if (arg === "--source-commit") args.sourceCommit = argv[++index] ?? ""
     else if (arg === "--help" || arg === "-h") {
       console.log(
-        "Usage: node scripts/sync-website-client-versions.mjs --toolkit-dir <dir> --website-dir <dir>",
+        "Usage: node scripts/sync-website-client-versions.mjs --toolkit-dir <dir> --website-dir <dir> --source-commit <sha>",
       )
       process.exit(0)
     } else {
@@ -66,6 +68,10 @@ function parseArgs(argv) {
   }
   if (!args.toolkitDir) throw new Error("Missing required --toolkit-dir")
   if (!args.websiteDir) throw new Error("Missing required --website-dir")
+  if (!args.sourceCommit) throw new Error("Missing required --source-commit")
+  if (!COMMIT_RE.test(args.sourceCommit)) {
+    throw new Error("--source-commit must be a full lowercase 40-character Git SHA")
+  }
   return args
 }
 
@@ -138,6 +144,18 @@ async function main() {
     entry.testedVersion = versions[client.key]
   }
   updates.set(registryPath, `${JSON.stringify(registry, null, 2)}\n`)
+
+  const manifestPath = path.join(websiteDir, "docs/.source-manifest.json")
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"))
+  const toolkitSource = manifest?.sources?.toolkit_owned
+  if (!toolkitSource || !Array.isArray(toolkitSource.paths)) {
+    throw new Error("docs/.source-manifest.json must define sources.toolkit_owned.paths")
+  }
+  toolkitSource.source_commit = args.sourceCommit
+  toolkitSource.published_versions = Object.fromEntries(
+    CLIENTS.map(({ key }) => [key, versions[key]]),
+  )
+  updates.set(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
 
   for (const surface of VERSION_SURFACES) {
     const target = path.join(websiteDir, surface.path)

--- a/scripts/sync-website-client-versions.test.mjs
+++ b/scripts/sync-website-client-versions.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test"
 import { fileURLToPath } from "node:url"
 
 const SCRIPT = fileURLToPath(new URL("./sync-website-client-versions.mjs", import.meta.url))
+const SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567"
 
 async function write(root, relPath, content) {
   const target = path.join(root, relPath)
@@ -27,6 +28,30 @@ async function approveMcp(website, version) {
     }],
   }))
 }
+
+async function writeSourceManifest(website) {
+  await write(website, "docs/.source-manifest.json", `${JSON.stringify({
+    sources: {
+      toolkit_owned: {
+        source_commit: "fedcba9876543210fedcba9876543210fedcba98",
+        published_versions: {
+          cli: "1.0.0", mcp: "2.0.0", typescriptSdk: "3.0.0", pythonSdk: "4.0.0",
+        },
+        paths: ["docs/en-US/cli.md"],
+      },
+    },
+  })}\n`)
+}
+
+test("website version sync requires an exact source commit", () => {
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, "--toolkit-dir", ".", "--website-dir", ".", "--source-commit", "HEAD"],
+    { encoding: "utf8" },
+  )
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /full lowercase 40-character Git SHA/)
+})
 
 test("website client versions respect MCP approval instead of advancing on a tag alone", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "qveris-website-versions-"))
@@ -52,6 +77,7 @@ test("website client versions respect MCP approval instead of advancing on a tag
       git(toolkit, "tag", tag)
     }
     await approveMcp(website, "2.3.4")
+    await writeSourceManifest(website)
     const approval = await fs.readFile(path.join(website, "content/public-claims-registry.json"), "utf8")
 
     await write(
@@ -95,7 +121,7 @@ test("website client versions respect MCP approval instead of advancing on a tag
 
     const result = spawnSync(
       process.execPath,
-      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website],
+      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website, "--source-commit", SOURCE_COMMIT],
       { encoding: "utf8" },
     )
     assert.equal(result.status, 0, result.stderr)
@@ -110,6 +136,14 @@ test("website client versions respect MCP approval instead of advancing on a tag
         pythonSdk: "4.5.6-rc.1",
       },
     )
+    const manifest = JSON.parse(await fs.readFile(path.join(website, "docs/.source-manifest.json"), "utf8"))
+    assert.equal(manifest.sources.toolkit_owned.source_commit, SOURCE_COMMIT)
+    assert.deepEqual(manifest.sources.toolkit_owned.published_versions, {
+      cli: "1.2.3",
+      mcp: "2.3.4",
+      typescriptSdk: "3.4.5",
+      pythonSdk: "4.5.6-rc.1",
+    })
     assert.match(await fs.readFile(path.join(website, "content/llms.txt"), "utf8"), /CLI v1\.2\.3/)
     assert.match(
       await fs.readFile(path.join(website, "content/llms.txt"), "utf8"),
@@ -125,7 +159,7 @@ test("website client versions respect MCP approval instead of advancing on a tag
     await approveMcp(website, "2.3.5")
     const advanced = spawnSync(
       process.execPath,
-      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website],
+      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website, "--source-commit", SOURCE_COMMIT],
       { encoding: "utf8" },
     )
     assert.equal(advanced.status, 0, advanced.stderr)
@@ -134,18 +168,21 @@ test("website client versions respect MCP approval instead of advancing on a tag
     for (const surface of ["llms.txt", "llms-full.txt", "setup.md", "guidelines.md"]) {
       assert.match(await fs.readFile(path.join(website, "content", surface), "utf8"), /v2\.3\.5/)
     }
-    const publicPaths = ["tool-versions.json", "llms.txt", "llms-full.txt", "setup.md", "guidelines.md"]
-    const before = await Promise.all(publicPaths.map((file) => fs.readFile(path.join(website, "content", file), "utf8")))
+    const publicPaths = [
+      "content/tool-versions.json", "content/llms.txt", "content/llms-full.txt",
+      "content/setup.md", "content/guidelines.md", "docs/.source-manifest.json",
+    ]
+    const before = await Promise.all(publicPaths.map((file) => fs.readFile(path.join(website, file), "utf8")))
     await approveMcp(website, "2.3.6") // An approved version still needs a real tag.
     const unavailable = spawnSync(
       process.execPath,
-      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website],
+      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website, "--source-commit", SOURCE_COMMIT],
       { encoding: "utf8" },
     )
     assert.equal(unavailable.status, 1)
     assert.match(unavailable.stderr, /mcp-v2.3.6.*unavailable/)
     assert.deepEqual(
-      await Promise.all(publicPaths.map((file) => fs.readFile(path.join(website, "content", file), "utf8"))),
+      await Promise.all(publicPaths.map((file) => fs.readFile(path.join(website, file), "utf8"))),
       before,
     )
   } finally {
@@ -170,6 +207,7 @@ test("website version sync fails closed when a required public reference is miss
       git(toolkit, "tag", tag)
     }
     await approveMcp(website, "2.3.4")
+    await writeSourceManifest(website)
 
     await write(
       website,
@@ -185,7 +223,7 @@ test("website version sync fails closed when a required public reference is miss
 
     const result = spawnSync(
       process.execPath,
-      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website],
+      [SCRIPT, "--toolkit-dir", toolkit, "--website-dir", website, "--source-commit", SOURCE_COMMIT],
       { encoding: "utf8" },
     )
     assert.equal(result.status, 1)


### PR DESCRIPTION
Summary:
- validate supplied parameter names, required fields, JSON types, finite numbers, and enum values before selecting a Discover candidate
- apply the fail-closed selection rule across JavaScript, Python, MCP, Getting Started, generated API docs, and localized examples
- update the website source manifest atomically with the exact toolkit commit and the versions actually selected by the sync policy
- prepare JavaScript SDK 0.8.3 and Python SDK 0.7.2 so corrected SDK pages can be synced from immutable release tags

Validation:
- JavaScript SDK: 116 tests, typecheck, example typecheck, lint, and build
- Python SDK: 199 tests, ruff checks, formatting, and wheel/sdist build
- MCP: 213 tests, typecheck, example typecheck, and lint
- release, SDK guide, website version sync, public-copy, and region-boundary checks
- website release checks against a temporary release/test checkout

Addresses the unresolved P1 and P2 findings on WonderfulValley/qveris-website#2654. Publishing the prepared patch versions remains a separate explicit action after merge.