### PR TITLE
fix: let ClawHub resolve the trusted package owner

### DIFF
--- a/.github/workflows/qveris-plugin-clawhub-publish.yml
+++ b/.github/workflows/qveris-plugin-clawhub-publish.yml
@@ -94,7 +94,8 @@ jobs:
     uses: openclaw/clawhub/.github/workflows/package-publish.yml@d3bde70e3c9373720d4d3e335f9935399ea2c008
     with:
       package_artifact_name: qveris-openclaw-plugin-clawpack
-      owner: qverisai
+      # Trusted Publishing derives the owner from the bound package record;
+      # passing an owner override is intentionally rejected by ClawHub.
       family: code-plugin
       version: ${{ needs.prepare.outputs.version }}
       tags: latest


### PR DESCRIPTION
## Root cause

The first real OIDC publish reached ClawHub after the tagged artifact and Plugin Inspector passed, but ClawHub rejected the publish with:

> Trusted publishes must not override the package owner

The workflow passed `owner: qverisai`. For Trusted Publishing, ClawHub intentionally derives the owner from the package record bound to the workflow and rejects any caller override.

## Fix

Remove the owner input and document why it must stay implicit. Package ownership remains constrained by the existing Trusted Publisher binding for `@qverisai/qveris`.

## Verification

- Workflow YAML parses successfully.
- `git diff --check` passes.
- The prior real run reached the ClawHub publish API with the expected repository, workflow, tag, source commit, package version, and a clean Plugin Inspector report; owner override was the sole reported failure.

Failed run: https://github.com/QVerisAI/qveris-agent-toolkit/actions/runs/34178290073
