### PR TITLE
chore(openclaw): prepare 2026.9.8 release

### DIFF
--- a/.github/workflows/qveris-plugin-clawhub-publish.yml
+++ b/.github/workflows/qveris-plugin-clawhub-publish.yml
@@ -7,7 +7,7 @@ on:
         description: Existing qveris-plugin-v* tag to publish
         required: true
         type: string
-        default: qveris-plugin-v2026.9.7
+        default: qveris-plugin-v2026.9.8
       dry_run:
         description: Validate and preview without publishing
         required: true

--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -115,10 +115,10 @@ jobs:
 
             ## Highlights
 
-            - Uses the shortest safe Discover → Call path while keeping Inspect conditional.
-            - Adds session-scoped exact-query discovery caching and TTL-bound successful-Capability memory with explicit refresh and clear controls.
-            - Preserves current parameter contracts and provenance, including safe refresh after Discover or Inspect, without reusing prior business values.
-            - Verifies the exact published Registry artifact against supported OpenClaw runtimes before creating this release.
+            - Confirms the trusted Registry package source during post-publish OpenClaw installation checks.
+            - Adds an immutable tagged-artifact path for publishing the plugin to ClawHub through Trusted Publishing.
+            - Lets ClawHub resolve the package owner from its trusted publisher binding without an unsupported override.
+            - Preserves exact Registry metadata, source-commit, integrity, runtime-manifest, and concrete-tool verification before creating this release.
 
             See [README](packages/openclaw-qveris-plugin/README.md) for usage.
           generate_release_notes: true

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,9 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+## [2026.9.8] - 2026-09-08
+
+### Added
+
+- Added a manually dispatched ClawHub release workflow that builds an immutable tagged artifact and publishes it through Trusted Publishing with source provenance and Inspector reports. ([#352], [#354])
+
 ### Fixed
 
-- Updated post-publish Registry verification to explicitly confirm the trusted package source required by current OpenClaw hosts.
+- Updated post-publish Registry verification to explicitly confirm the trusted package source required by current OpenClaw hosts. ([#351])
+- Let ClawHub resolve the package owner from its trusted publisher binding instead of passing an unsupported owner override. ([#354])
 
 ## [2026.9.7] - 2026-09-07
 
@@ -63,7 +70,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 - First published build with compiled `dist/` output. ([#90])
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.7...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.8...HEAD
+[2026.9.8]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.7...qveris-plugin-v2026.9.8
 [2026.9.7]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.30...qveris-plugin-v2026.9.7
 [2026.7.30]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.15...qveris-plugin-v2026.7.30
 [2026.7.15]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.6.4...qveris-plugin-v2026.7.15
@@ -78,3 +86,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 [#283]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/283
 [#347]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/347
 [#348]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/348
+[#351]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/351
+[#352]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/352
+[#354]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/354

--- a/packages/openclaw-qveris-plugin/openclaw.plugin.json
+++ b/packages/openclaw-qveris-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "qveris",
   "name": "QVeris Plugin",
   "description": "QVeris capability discovery, tool inspection, and tool calling",
-  "version": "2026.9.7",
+  "version": "2026.9.8",
   "setup": {
     "providers": [
       {

--- a/packages/openclaw-qveris-plugin/package-lock.json
+++ b/packages/openclaw-qveris-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.9.7",
+  "version": "2026.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/qveris",
-      "version": "2026.9.7",
+      "version": "2026.9.8",
       "dependencies": {
         "@sinclair/typebox": "0.34.52"
       },

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.9.7",
+  "version": "2026.9.8",
   "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- prepare `@qverisai/qveris@2026.9.8` across package, lockfile, plugin manifest, and release workflow defaults
- publish the merged Registry verification and ClawHub Trusted Publishing fixes in the package changelog
- replace stale `2026.9.7` GitHub Release highlights with the actual `2026.9.8` release changes

## Release preflight

- confirmed npm does not contain `@qverisai/qveris@2026.9.8`
- confirmed the remote does not contain `qveris-plugin-v2026.9.8`

## Validation

- `npm run typecheck`
- `npm test` (103 plugin tests and 30 Registry release tests)
- `npm run lint`
- `npm run check:pack` (19 expected files)
- `npm run check:runtime`
- `npm run check:runtime:packed`
- `npm audit --omit=dev` (0 vulnerabilities)
- parsed both modified release workflows as YAML
- `git diff --check`
