### PR TITLE
fix(openclaw): bind ClawHub source ref to release commit

### DIFF
--- a/.github/workflows/qveris-plugin-clawhub-publish.yml
+++ b/.github/workflows/qveris-plugin-clawhub-publish.yml
@@ -102,7 +102,9 @@ jobs:
       categories: models,context,web
       source_repo: QVerisAI/qveris-agent-toolkit
       source_commit: ${{ needs.prepare.outputs.commit }}
-      source_ref: refs/tags/${{ inputs.tag }}
+      # ClawHub's OIDC token authorizes the resolved candidate commit, so both
+      # source fields must use that SHA rather than the human-readable tag ref.
+      source_ref: ${{ needs.prepare.outputs.commit }}
       source_path: packages/openclaw-qveris-plugin
       dry_run: ${{ inputs.dry_run }}
       wait_for_publication: true

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+### Fixed
+
+- Aligned ClawHub Trusted Publishing source attribution with the authorized candidate commit SHA while retaining the immutable release tag for artifact checkout.
+
 ## [2026.9.8] - 2026-09-08
 
 ### Added

--- a/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
+++ b/packages/openclaw-qveris-plugin/scripts/check-openclaw-registry-release.node-test.mjs
@@ -425,3 +425,14 @@ test("keeps Registry verification between npm publish and GitHub Release creatio
     /check:runtime:registry -- --expected-git-head "\$GITHUB_SHA"/,
   );
 });
+
+test("attributes ClawHub trusted publishing to the authorized candidate commit", () => {
+  const workflow = readFileSync(
+    path.join(repositoryRoot, ".github/workflows/qveris-plugin-clawhub-publish.yml"),
+    "utf8",
+  );
+
+  assert.match(workflow, /source_commit: \$\{\{ needs\.prepare\.outputs\.commit \}\}/);
+  assert.match(workflow, /source_ref: \$\{\{ needs\.prepare\.outputs\.commit \}\}/);
+  assert.doesNotMatch(workflow, /source_ref: refs\/tags\/\$\{\{ inputs\.tag \}\}/);
+});


### PR DESCRIPTION
## Summary

- pass the verified release commit SHA as both `source_commit` and `source_ref` to ClawHub Trusted Publishing
- retain the human-readable immutable tag exclusively for checkout and package identity validation
- add a regression test that rejects tag refs in trusted source attribution
- document the fix under the plugin's Unreleased changelog

## Root cause

The `2026.9.8` dry-run succeeded because it does not mint or consume a trusted publish authorization. The real publish was rejected with:

> Trusted publish source ref must match the authorized candidate SHA

ClawHub authorizes the resolved candidate commit. The caller correctly passed that SHA as `source_commit`, but passed `refs/tags/qveris-plugin-v2026.9.8` as `source_ref`. Trusted publishing requires both fields to equal the authorized candidate SHA.

Failed run: https://github.com/QVerisAI/qveris-agent-toolkit/actions/runs/34179906923

## Validation

- `npm test` (103 plugin tests and 31 release tests)
- `npm run lint`
- parsed the workflow as YAML
- `git diff --check`

After merge, the existing immutable `qveris-plugin-v2026.9.8` artifact can be submitted again through the corrected workflow. No npm republish or tag replacement is required.
