### PR TITLE
chore(openclaw): prepare 2026.9.9 release

### DIFF
--- a/.github/workflows/qveris-plugin-clawhub-publish.yml
+++ b/.github/workflows/qveris-plugin-clawhub-publish.yml
@@ -7,7 +7,7 @@ on:
         description: Existing qveris-plugin-v* tag to publish
         required: true
         type: string
-        default: qveris-plugin-v2026.9.8
+        default: qveris-plugin-v2026.9.9
       dry_run:
         description: Validate and preview without publishing
         required: true

--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -115,9 +115,9 @@ jobs:
 
             ## Highlights
 
-            - Confirms the trusted Registry package source during post-publish OpenClaw installation checks.
-            - Adds an immutable tagged-artifact path for publishing the plugin to ClawHub through Trusted Publishing.
-            - Lets ClawHub resolve the package owner from its trusted publisher binding without an unsupported override.
+            - Aligns ClawHub Trusted Publishing source attribution with the authorized candidate commit SHA.
+            - Keeps the immutable release tag for artifact checkout while binding both trusted source fields to the verified commit.
+            - Adds regression coverage that prevents tag refs from being submitted as the authorized source ref.
             - Preserves exact Registry metadata, source-commit, integrity, runtime-manifest, and concrete-tool verification before creating this release.
 
             See [README](packages/openclaw-qveris-plugin/README.md) for usage.

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,9 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+## [2026.9.9] - 2026-09-08
+
 ### Fixed
 
-- Aligned ClawHub Trusted Publishing source attribution with the authorized candidate commit SHA while retaining the immutable release tag for artifact checkout.
+- Aligned ClawHub Trusted Publishing source attribution with the authorized candidate commit SHA while retaining the immutable release tag for artifact checkout. ([#356])
 
 ## [2026.9.8] - 2026-09-08
 
@@ -74,7 +76,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 - First published build with compiled `dist/` output. ([#90])
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.8...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.9...HEAD
+[2026.9.9]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.8...qveris-plugin-v2026.9.9
 [2026.9.8]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.7...qveris-plugin-v2026.9.8
 [2026.9.7]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.30...qveris-plugin-v2026.9.7
 [2026.7.30]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.15...qveris-plugin-v2026.7.30
@@ -93,3 +96,4 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 [#351]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/351
 [#352]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/352
 [#354]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/354
+[#356]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/356

--- a/packages/openclaw-qveris-plugin/openclaw.plugin.json
+++ b/packages/openclaw-qveris-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "qveris",
   "name": "QVeris Plugin",
   "description": "QVeris capability discovery, tool inspection, and tool calling",
-  "version": "2026.9.8",
+  "version": "2026.9.9",
   "setup": {
     "providers": [
       {

--- a/packages/openclaw-qveris-plugin/package-lock.json
+++ b/packages/openclaw-qveris-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.9.8",
+  "version": "2026.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/qveris",
-      "version": "2026.9.8",
+      "version": "2026.9.9",
       "dependencies": {
         "@sinclair/typebox": "0.34.52"
       },

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.9.8",
+  "version": "2026.9.9",
   "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- prepare `@qverisai/qveris@2026.9.9` from the commit containing the ClawHub candidate-SHA fix
- align package, lockfile, plugin manifest, workflow default, changelog, and GitHub Release highlights
- preserve the `2026.9.8` npm artifact and tag as immutable after its successful publication

This release intentionally uses the next available calendar-version slot on `2026-09-08`. The prior `2026.9.8` npm release succeeded before ClawHub rejected its source-ref attribution, and neither that package nor its tag will be replaced.

## Release preflight

- confirmed npm does not contain `@qverisai/qveris@2026.9.9`
- confirmed the remote does not contain `qveris-plugin-v2026.9.9`

## Validation

- `npm run typecheck`
- `npm test` (103 plugin tests and 31 release tests)
- `npm run lint`
- `npm run check:pack` (19 expected files)
- `npm run check:runtime:packed`
- `git diff --check`

After merge, the new tag will make the workflow commit, packaged artifact, ClawHub OIDC candidate SHA, and public source attribution identical.
