### PR TITLE
fix(docs): keep MCP setup copy deployment-neutral

### DIFF
--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -182,9 +182,7 @@ GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServ
 
 ##### 托管 MCP 配置
 
-MCP Registry 清单登记的是全球服务端点。该清单发布并被 VS Code MCP Gallery 收录后，从 Gallery 安装会连接全球服务，不会自动切换到本页的中国服务端点。Gallery 收录由 GitHub 决定。
-
-中国服务用户请在 `.vscode/mcp.json` 中手动配置以下端点；这与 Gallery 的全球端点配置不同。VS Code 会自动发现 OAuth，按提示在浏览器中完成登录即可：
+请在 `.vscode/mcp.json` 中手动配置以下托管端点。VS Code 会自动发现 OAuth，按提示在浏览器中完成登录即可：
 
 ```json
 {

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -205,11 +205,11 @@ GitHub Copilot's `mcp.json` uses a top-level `servers` object, not `mcpServers`.
 
 ##### Hosted MCP configuration
 
-The MCP Registry manifest registers the global hosted endpoint. After this
-manifest is released and included in the VS Code MCP Gallery, installing QVeris
-from the Gallery will use that endpoint and discover OAuth automatically.
-Complete the browser sign-in when prompted. Gallery inclusion is controlled by
-GitHub; you can also configure the same endpoint directly in `.vscode/mcp.json`:
+After the QVeris MCP Registry manifest is released and included in the VS Code
+MCP Gallery, installing QVeris from the Gallery will use the hosted endpoint and
+discover OAuth automatically. Complete the browser sign-in when prompted.
+Gallery inclusion is controlled by GitHub; you can also configure the endpoint
+directly in `.vscode/mcp.json`:
 
 ```json
 {

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -205,7 +205,7 @@ GitHub Copilot 的 `mcp.json` 使用顶层 `servers` 对象，而不是 `mcpServ
 
 ##### 托管 MCP 配置
 
-MCP Registry 清单登记的是全球服务端点。该清单发布并被 VS Code MCP Gallery 收录后，从 Gallery 安装 QVeris 会使用该端点并自动发现 OAuth。按提示在浏览器中完成登录即可。Gallery 收录由 GitHub 决定；也可以直接在 `.vscode/mcp.json` 中配置同一端点：
+QVeris MCP Registry 清单发布并被 VS Code MCP Gallery 收录后，从 Gallery 安装即可使用托管端点并自动发现 OAuth。按提示在浏览器中完成登录即可。Gallery 收录由 GitHub 决定；也可以直接在 `.vscode/mcp.json` 中配置该端点：
 
 ```json
 {

--- a/packages/mcp/src/vscode-docs.test.ts
+++ b/packages/mcp/src/vscode-docs.test.ts
@@ -7,16 +7,19 @@ const guides = [
     path: 'docs/en-US/mcp-server.md',
     heading: '##### Hosted MCP configuration',
     endpoint: 'https://mcp.qveris.ai/mcp',
+    forbidden: ['qveris.cn', 'global hosted endpoint'],
   },
   {
     path: 'docs/zh-CN/mcp-server.md',
     heading: '##### 托管 MCP 配置',
     endpoint: 'https://mcp.qveris.ai/mcp',
+    forbidden: ['qveris.cn', '全球服务端点'],
   },
   {
     path: 'docs/cn/zh-CN/mcp-server.md',
     heading: '##### 托管 MCP 配置',
     endpoint: 'https://mcp.qveris.cn/mcp',
+    forbidden: ['qveris.ai', 'MCP Registry', 'Gallery', '全球', '中国服务端点'],
   },
 ] as const;
 
@@ -30,14 +33,18 @@ function readSection(path: string, heading: string): string {
 }
 
 describe('VS Code MCP guide', () => {
-  it.each(guides)('keeps OAuth and API-key fallback examples valid in $path', ({ path, heading, endpoint }) => {
-    const section = readSection(path, heading);
+  it.each(guides)(
+    'keeps OAuth and API-key fallback examples valid in $path',
+    ({ path, heading, endpoint, forbidden }) => {
+      const section = readSection(path, heading);
 
-    expect(section).toContain(endpoint);
-    expect(section).toContain('"servers"');
-    expect(section).not.toContain('"mcpServers"');
-    expect(section).toContain('"inputs"');
-    expect(section).toContain('"password": true');
-    expect(section).toContain('"Authorization": "Bearer ${input:qveris-api-key}"');
-  });
+      expect(section).toContain(endpoint);
+      expect(section).toContain('"servers"');
+      expect(section).not.toContain('"mcpServers"');
+      expect(section).toContain('"inputs"');
+      expect(section).toContain('"password": true');
+      expect(section).toContain('"Authorization": "Bearer ${input:qveris-api-key}"');
+      for (const term of forbidden) expect(section).not.toContain(term);
+    },
+  );
 });

--- a/scripts/check-public-copy.mjs
+++ b/scripts/check-public-copy.mjs
@@ -42,6 +42,7 @@ const RULES = [
   ["obsolete-scale-package", /(?:\|\s*Scale\s*\|\s*\$50(?:\+|\s|起)|26,250\+?\s*credits)/i],
   ["hardcoded-cn-minimum", /最低充值金额\s*[:：]?\s*(?:¥|￥|CNY|RMB)\s*\d/i],
   ["key-prefix-routing", /(?:auto-detects? region from key prefix|从\s*key\s*前缀自动检测)/i],
+  ["deployment-label", /(?:\b(?:China|Global) region\b|\bglobal (?:hosted |service )?(?:endpoint|deployment)\b|(?:中国|全球)区|(?:中国|全球)(?:服务)?(?:端点|部署)|中国服务用户)/i],
   ["zero-token-promise", /(?:zero (?:prompt )?tokens?|零\s*(?:prompt\s*|提示词\s*)?token|\|\s*Token (?:cost|消耗)\s*\|\s*(?:Zero|零)|每个工具增加 ~200-500|each tool adds ~200-500)/i],
 ]
 

--- a/scripts/check-public-copy.mjs
+++ b/scripts/check-public-copy.mjs
@@ -42,7 +42,7 @@ const RULES = [
   ["obsolete-scale-package", /(?:\|\s*Scale\s*\|\s*\$50(?:\+|\s|起)|26,250\+?\s*credits)/i],
   ["hardcoded-cn-minimum", /最低充值金额\s*[:：]?\s*(?:¥|￥|CNY|RMB)\s*\d/i],
   ["key-prefix-routing", /(?:auto-detects? region from key prefix|从\s*key\s*前缀自动检测)/i],
-  ["deployment-label", /(?:\b(?:China|Global) region\b|\bglobal (?:hosted |service )?(?:endpoint|deployment)\b|(?:中国|全球)区|(?:中国|全球)(?:服务)?(?:端点|部署)|中国服务用户)/i],
+  ["deployment-label", /(?:\b(?:China|Global) (?:(?:hosted|service) )?(?:endpoint|deployment|region)\b|(?:中国|全球)区|(?:中国|全球)(?:服务)?(?:端点|部署)|中国服务用户)/i],
   ["zero-token-promise", /(?:zero (?:prompt )?tokens?|零\s*(?:prompt\s*|提示词\s*)?token|\|\s*Token (?:cost|消耗)\s*\|\s*(?:Zero|零)|每个工具增加 ~200-500|each tool adds ~200-500)/i],
 ]
 

--- a/scripts/check-public-copy.test.mjs
+++ b/scripts/check-public-copy.test.mjs
@@ -45,6 +45,9 @@ test("rejects deployment labels in public copy", () => {
   for (const source of [
     "Use the global hosted endpoint.",
     "Choose the China region.",
+    "Use the China endpoint.",
+    "Connect to the China hosted endpoint.",
+    "Use the China deployment.",
     "MCP Registry 清单登记的是全球服务端点。",
     "中国服务用户请配置以下端点。",
   ]) {

--- a/scripts/check-public-copy.test.mjs
+++ b/scripts/check-public-copy.test.mjs
@@ -41,6 +41,19 @@ test("keeps public endpoints audience-specific and internal markers private", ()
   assert.ok(checkPublicCopy('{"x-qveris-regions": []}', "docs/openapi/example.json").length)
 })
 
+test("rejects deployment labels in public copy", () => {
+  for (const source of [
+    "Use the global hosted endpoint.",
+    "Choose the China region.",
+    "MCP Registry 清单登记的是全球服务端点。",
+    "中国服务用户请配置以下端点。",
+  ]) {
+    assert.ok(checkPublicCopy(source, "docs/en-US/mcp-server.md").some(f => f.rule === "deployment-label"), source)
+  }
+  assert.deepEqual(checkPublicCopy("Configure the hosted endpoint.", "docs/en-US/mcp-server.md"), [])
+  assert.deepEqual(checkPublicCopy("请配置以下托管端点。", "docs/cn/zh-CN/mcp-server.md"), [])
+})
+
 test("rejects obsolete CLI guarantees while permitting optional dependencies", () => {
   for (const source of ["Zero prompt tokens", "| **Token cost** | Zero — subprocess |", "零 prompt token", "Zero runtime dependencies", "Auto-detects region from key prefix"]) {
     assert.ok(checkPublicCopy(source, "docs/en-US/cli.md").length, source)


### PR DESCRIPTION
## Summary

- keep hosted MCP setup guidance scoped to each document audience
- remove deployment-topology labels from public VS Code configuration copy
- add public-copy and MCP guide regression checks for endpoint and audience boundaries

## Validation

- `npm run check:public-copy`
- `npm run test:public-copy`
- `npm --prefix packages/mcp test` (216 tests)
- `npm --prefix packages/mcp run typecheck`
- `npm --prefix packages/mcp run lint`
- `node --test scripts/prepare-website-docs.test.mjs scripts/website-release-tags.test.mjs`