### PR TITLE
Isolate persisted CLI discovery sessions

### DIFF
--- a/docs/cn/zh-CN/cli.md
+++ b/docs/cn/zh-CN/cli.md
@@ -501,6 +501,7 @@ API 地址单独遵循 `--base-url` > `QVERIS_BASE_URL` > 已存储的 OAuth 会
 - 发现 ID
 - 查询内容
 - API 地址
+- 不包含秘密的授权上下文绑定
 - 结果列表（tool_id、名称、提供商）
 
 后续 `inspect` 和 `call` 自动读取会话，支持数字索引快捷方式：
@@ -511,7 +512,7 @@ qveris inspect 1                  # 使用会话中的索引 1
 qveris call 2 --params '{...}'   # 使用索引 2 + 发现 ID
 ```
 
-会话 30 分钟后过期。用 `qveris history` 查看，`qveris history --clear` 清除。
+会话 30 分钟后过期。只有当前 API 地址和授权上下文与创建会话时精确匹配，数字索引、隐式 Discovery ID 和 `init --resume` 才可使用。切换地址或账号后必须重新 Discover。用 `qveris history` 查看，`qveris history --clear` 清除。
 
 这里保存的是最近一次 Discover 的索引和来源信息，不是语义意图路由或完整 schema 缓存。新的 Discover 会覆盖旧索引。每次 Call 都要根据当前请求重新构造业务值；如果会话摘要不含安全构造请求所需契约，应先 Inspect。
 

--- a/docs/en-US/cli.md
+++ b/docs/en-US/cli.md
@@ -554,6 +554,7 @@ After each `discover`, the CLI saves session state to `~/.config/qveris/.session
 - Discovery ID
 - Query
 - Base URL
+- Non-secret authorization-context binding
 - Result list (tool_id, name, provider)
 
 Subsequent `inspect` and `call` commands auto-read this session, enabling numeric index shortcuts:
@@ -564,7 +565,7 @@ qveris inspect 1                  # uses index 1 from session
 qveris call 2 --params '{...}'   # uses index 2 + discovery ID
 ```
 
-Sessions expire after 30 minutes. Use `qveris history` to view and `qveris history --clear` to reset.
+Sessions expire after 30 minutes. Numeric indexes, implicit discovery IDs, and `init --resume` are accepted only when the current API endpoint and authorization context exactly match the session that created them. After switching endpoint or account, run Discover again. Use `qveris history` to view and `qveris history --clear` to reset.
 
 This is last-discovery index/provenance state, not semantic intent routing or a complete schema cache. A new Discover replaces the indexes. Build each Call's business values from the current request, and Inspect if the saved summary does not contain the contract needed to do so safely.
 

--- a/docs/zh-CN/cli.md
+++ b/docs/zh-CN/cli.md
@@ -504,6 +504,7 @@ API 地址单独遵循 `--base-url` > `QVERIS_BASE_URL` > 已存储的 OAuth 会
 - 发现 ID
 - 查询内容
 - API 地址
+- 不包含秘密的授权上下文绑定
 - 结果列表（tool_id、名称、提供商）
 
 后续 `inspect` 和 `call` 自动读取会话，支持数字索引快捷方式：
@@ -514,7 +515,7 @@ qveris inspect 1                  # 使用会话中的索引 1
 qveris call 2 --params '{...}'   # 使用索引 2 + 发现 ID
 ```
 
-会话 30 分钟后过期。用 `qveris history` 查看，`qveris history --clear` 清除。
+会话 30 分钟后过期。只有当前 API 地址和授权上下文与创建会话时精确匹配，数字索引、隐式 Discovery ID 和 `init --resume` 才可使用。切换地址或账号后必须重新 Discover。用 `qveris history` 查看，`qveris history --clear` 清除。
 
 这里保存的是最近一次 Discover 的索引和来源信息，不是语义意图路由或完整 schema 缓存。新的 Discover 会覆盖旧索引。每次 Call 都要根据当前请求重新构造业务值；如果会话摘要不含安全构造请求所需契约，应先 Inspect。
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- Bind persisted Discover indexes and implicit discovery IDs to the exact API endpoint and authorization context that created them, preventing CLI session provenance from crossing accounts or deployments. ([#364])
+
 ## [0.11.2] - 2026-09-07
 
 ### Changed

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -178,7 +178,7 @@ qveris init --resume --params '{"city": "London"}'
 qveris init --json
 ```
 
-`init` is a client-side first-call wizard: it handles discovery, selection, inspection, parameter preparation, calling, and exact `usage` / `ledger` reconciliation guidance inside one command. It is not a server-side aggregate API. Manual Agent workflows should use Discover → Call when discovery contains the current contract, and add Inspect or Probe only when needed. Use `--resume` after recoverable parameter or provider failures to reuse the last discovery session.
+`init` is a client-side first-call wizard: it handles discovery, selection, inspection, parameter preparation, calling, and exact `usage` / `ledger` reconciliation guidance inside one command. It is not a server-side aggregate API. Manual Agent workflows should use Discover → Call when discovery contains the current contract, and add Inspect or Probe only when needed. Use `--resume` after recoverable parameter or provider failures to reuse the last discovery session. Persisted indexes, implicit discovery IDs, and `--resume` are accepted only with the same API endpoint and authorization context that created them; after switching either one, run Discover again.
 
 ### Discover
 

--- a/packages/cli/src/auth/context.mjs
+++ b/packages/cli/src/auth/context.mjs
@@ -1,0 +1,42 @@
+import { createHash, randomUUID } from "node:crypto";
+
+const CONTEXT_PREFIX = "v1";
+
+function digest(parts) {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(String(part));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function validStoredId(value) {
+  return typeof value === "string" && /^[A-Za-z0-9._:-]{1,128}$/.test(value);
+}
+
+export function createOAuthAuthorizationContextId() {
+  return randomUUID();
+}
+
+export function deriveLegacyOAuthAuthorizationContextId(metadata, secret) {
+  if (typeof metadata?.issuer !== "string" || typeof secret?.refresh_token !== "string") return null;
+  if (!metadata.issuer || !secret.refresh_token) return null;
+  return digest([metadata.issuer, secret.refresh_token]);
+}
+
+export function authorizationContextForApiKey(apiKey) {
+  if (typeof apiKey !== "string" || !apiKey) return null;
+  return `${CONTEXT_PREFIX}:api-key:${digest([apiKey])}`;
+}
+
+export function authorizationContextIdForOAuth(metadata, secret) {
+  return validStoredId(metadata?.authorization_context_id)
+    ? metadata.authorization_context_id
+    : deriveLegacyOAuthAuthorizationContextId(metadata, secret);
+}
+
+export function authorizationContextForOAuth(metadata, secret) {
+  const storedId = authorizationContextIdForOAuth(metadata, secret);
+  return storedId ? `${CONTEXT_PREFIX}:oauth:${storedId}` : null;
+}

--- a/packages/cli/src/auth/oauth.mjs
+++ b/packages/cli/src/auth/oauth.mjs
@@ -1,4 +1,5 @@
 import { setTimeout as delay } from "node:timers/promises";
+import { authorizationContextIdForOAuth } from "./context.mjs";
 import { CliError } from "../errors/handler.mjs";
 import { getOAuthSessionMetadata, loadOAuthSessionSecret, saveOAuthSession, withOAuthRefreshLock } from "./storage.mjs";
 
@@ -17,8 +18,17 @@ function isSameOAuthSession(left, right) {
     left?.issuer === right?.issuer &&
     left?.api_base_url === right?.api_base_url &&
     left?.token_endpoint === right?.token_endpoint &&
-    left?.revocation_endpoint === right?.revocation_endpoint
+    left?.revocation_endpoint === right?.revocation_endpoint &&
+    left?.authorization_context_id === right?.authorization_context_id
   );
+}
+
+function bindLegacyAuthorizationContext(metadata, secret) {
+  if (!metadata) return metadata;
+  const authorizationContextId = authorizationContextIdForOAuth(metadata, secret);
+  return authorizationContextId && authorizationContextId !== metadata.authorization_context_id
+    ? { ...metadata, authorization_context_id: authorizationContextId }
+    : metadata;
 }
 
 function oauthError(code) {
@@ -373,6 +383,7 @@ export async function refreshOAuthSession(metadata, secret, fetchImpl = fetch) {
   }
   const updated = {
     ...metadata,
+    authorization_context_id: authorizationContextIdForOAuth(metadata, secret),
     ...binding,
     expires_at: Date.now() + Math.max(1, Number(tokens.expires_in) || 3600) * 1000,
   };
@@ -428,20 +439,22 @@ export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) 
   async function refresh() {
     if (!sharedRefreshPromise) {
       sharedRefreshPromise = (async () => {
-        const initialMetadata = getOAuthSessionMetadata();
+        let initialMetadata = getOAuthSessionMetadata();
         const initialSecret = await loadOAuthSessionSecret(initialMetadata);
         if (!initialMetadata || !initialSecret) {
           throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
         }
+        initialMetadata = bindLegacyAuthorizationContext(initialMetadata, initialSecret);
         if (initialMetadata.storage === "session") {
           return refreshOAuthSession(initialMetadata, initialSecret, fetchImpl);
         }
         return withOAuthRefreshLock(async () => {
-          const metadata = getOAuthSessionMetadata({ fresh: true });
+          let metadata = getOAuthSessionMetadata({ fresh: true });
           const secret = await loadOAuthSessionSecret(metadata, { fresh: true });
           if (!metadata || !secret) {
             throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
           }
+          metadata = bindLegacyAuthorizationContext(metadata, secret);
           if (!isSameOAuthSession(metadata, initialMetadata)) {
             throw new CliError(
               "API_ERROR",
@@ -465,11 +478,12 @@ export function createStoredOAuthCredentialProvider({ fetchImpl = fetch } = {}) 
   return {
     authType: "oauth",
     async getCredential(context) {
-      const metadata = getOAuthSessionMetadata();
+      let metadata = getOAuthSessionMetadata();
       let secret = await loadOAuthSessionSecret(metadata);
       if (!metadata || !secret) {
         throw oauthError("invalid_grant", "OAuth session is unavailable; run qveris auth login again");
       }
+      metadata = bindLegacyAuthorizationContext(metadata, secret);
       if (new URL(context.resource).origin !== metadata.issuer) {
         throw new CliError("API_ERROR", "OAuth session does not match the selected API endpoint");
       }

--- a/packages/cli/src/client/auth.mjs
+++ b/packages/cli/src/client/auth.mjs
@@ -1,7 +1,8 @@
 import { resolve } from "../config/resolve.mjs";
 import { CliError } from "../errors/handler.mjs";
 import { createStoredOAuthCredentialProvider } from "../auth/oauth.mjs";
-import { hasOAuthSession } from "../auth/storage.mjs";
+import { authorizationContextForApiKey, authorizationContextForOAuth } from "../auth/context.mjs";
+import { getOAuthSessionMetadata, hasOAuthSession, loadOAuthSessionSecret } from "../auth/storage.mjs";
 
 const PLACEHOLDER_PATTERNS = [/^your[_-]?(qveris)?[_-]?api[_-]?key/i, /^sk-1_xxx/, /^sk-1_$/, /^YOUR_/];
 
@@ -22,6 +23,51 @@ export function resolveApiKey(flagValue) {
   }
 
   return trimmed;
+}
+
+export async function resolveAuthorizationContextId({ apiKey } = {}) {
+  if (apiKey !== undefined) {
+    const context = authorizationContextForApiKey(apiKey);
+    if (context) return context;
+    throw new CliError("AUTH_MISSING_KEY");
+  }
+
+  const metadata = getOAuthSessionMetadata();
+  const secret = await loadOAuthSessionSecret(metadata);
+  const context = authorizationContextForOAuth(metadata, secret);
+  if (!context) {
+    throw new CliError("AUTH_OAUTH_FAILED", "OAuth session cannot be bound to CLI discovery state; log in again.");
+  }
+  return context;
+}
+
+export function createAuthorizationContextCredentialProvider({ apiKey, authorizationContext }) {
+  if (apiKey !== undefined) return undefined;
+  const provider = createStoredOAuthCredentialProvider();
+
+  async function assertCurrentContext() {
+    const current = await resolveAuthorizationContextId({ apiKey: undefined });
+    if (current !== authorizationContext) {
+      throw new CliError(
+        "AUTH_OAUTH_FAILED",
+        "OAuth authorization context changed before the request was sent; retry discovery with the current login.",
+      );
+    }
+  }
+
+  return {
+    authType: provider.authType,
+    async getCredential(context) {
+      const credential = await provider.getCredential(context);
+      await assertCurrentContext();
+      return credential;
+    },
+    async refreshCredential() {
+      const credential = await provider.refreshCredential();
+      await assertCurrentContext();
+      return credential;
+    },
+  };
 }
 
 export function isPlaceholderApiKey(value) {

--- a/packages/cli/src/commands/auth.mjs
+++ b/packages/cli/src/commands/auth.mjs
@@ -1,3 +1,4 @@
+import { createOAuthAuthorizationContextId } from "../auth/context.mjs";
 import { resolveBaseUrl } from "../config/endpoint.mjs";
 import { discoverTools } from "../client/api.mjs";
 import { CliError } from "../errors/handler.mjs";
@@ -70,6 +71,7 @@ async function authLogin(flags) {
     session = {
       issuer,
       api_base_url: baseUrl,
+      authorization_context_id: createOAuthAuthorizationContextId(),
       ...binding,
       token_endpoint: metadata.token_endpoint,
       revocation_endpoint: metadata.revocation_endpoint,

--- a/packages/cli/src/commands/call.mjs
+++ b/packages/cli/src/commands/call.mjs
@@ -1,6 +1,10 @@
-import { resolveApiKey } from "../client/auth.mjs";
+import {
+  createAuthorizationContextCredentialProvider,
+  resolveApiKey,
+  resolveAuthorizationContextId,
+} from "../client/auth.mjs";
 import { callTool, resolveApiBaseUrl } from "../client/api.mjs";
-import { resolveToolId, getSessionDiscoveryId } from "../session/session.mjs";
+import { resolveToolId, getSessionDiscoveryId, readSessionForContext } from "../session/session.mjs";
 import { resolveParams } from "../utils/params.mjs";
 import { formatCallResult } from "../output/formatter.mjs";
 import { outputJson } from "../output/json.mjs";
@@ -34,14 +38,34 @@ export async function runCall(idOrIndex, flags) {
   const maxSize = resolveMaxSize(flags);
   const { baseUrl } = resolveApiBaseUrl({ baseUrlFlag: flags.baseUrl, preferOAuth: apiKey === undefined });
 
-  const resolved = resolveToolId(idOrIndex);
+  const numericIndex = /^\d+$/.test(idOrIndex);
+  const usesSessionShortcut = numericIndex || !flags.discoveryId;
+  let session = null;
+  let credentialProvider;
+  if (usesSessionShortcut) {
+    const authorizationContext = await resolveAuthorizationContextId({ apiKey });
+    credentialProvider = createAuthorizationContextCredentialProvider({ apiKey, authorizationContext });
+    const resolvedSession = readSessionForContext({ baseUrl, authorizationContext });
+    if (resolvedSession.status === "context_mismatch") {
+      throw new CliError(
+        "SESSION_EXPIRED",
+        "Stored discovery belongs to another API endpoint or authorization context. Run 'qveris discover' again.",
+      );
+    }
+    session = resolvedSession.session;
+  }
+
+  const resolved = resolveToolId(idOrIndex, { session });
+  if (numericIndex && !resolved.fromSession) {
+    throw new CliError("SESSION_EXPIRED", "No matching discovery index. Run 'qveris discover' first.");
+  }
   const toolId = resolved.toolId;
   let discoveryId = flags.discoveryId || null;
 
   if (!discoveryId && resolved.fromSession && resolved.discoveryId) {
     discoveryId = resolved.discoveryId;
   }
-  if (!discoveryId) discoveryId = getSessionDiscoveryId();
+  if (!discoveryId) discoveryId = getSessionDiscoveryId({ session });
   if (!discoveryId && /^\d+$/.test(idOrIndex)) {
     throw new CliError("SESSION_EXPIRED", "No discovery ID. Run 'qveris discover' first or pass --discovery-id.");
   }
@@ -82,6 +106,7 @@ export async function runCall(idOrIndex, flags) {
   try {
     const result = await callTool({
       apiKey,
+      credentialProvider,
       baseUrl,
       toolId,
       discoveryId,

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -1,4 +1,8 @@
-import { resolveApiKey } from "../client/auth.mjs";
+import {
+  createAuthorizationContextCredentialProvider,
+  resolveApiKey,
+  resolveAuthorizationContextId,
+} from "../client/auth.mjs";
 import { discoverTools, resolveApiBaseUrl } from "../client/api.mjs";
 import { writeSession } from "../session/session.mjs";
 import { formatDiscoverResult } from "../output/formatter.mjs";
@@ -11,6 +15,8 @@ export async function runDiscover(query, flags) {
     baseUrlFlag: flags.baseUrl,
     preferOAuth: apiKey === undefined,
   });
+  const authorizationContext = await resolveAuthorizationContextId({ apiKey });
+  const credentialProvider = createAuthorizationContextCredentialProvider({ apiKey, authorizationContext });
   const limit = parseInt(flags.limit, 10) || 5;
   const timeoutMs = (parseInt(flags.timeout, 10) || 30) * 1000;
 
@@ -19,6 +25,7 @@ export async function runDiscover(query, flags) {
   try {
     const result = await discoverTools({
       apiKey,
+      credentialProvider,
       baseUrl: resolvedBaseUrl,
       query,
       limit,
@@ -35,6 +42,7 @@ export async function runDiscover(query, flags) {
       discoveryId: result.search_id,
       query,
       baseUrl: resolvedBaseUrl,
+      authorizationContext,
       results: tools.map((t, i) => ({
         index: i + 1,
         tool_id: t.tool_id,

--- a/packages/cli/src/commands/history.mjs
+++ b/packages/cli/src/commands/history.mjs
@@ -21,7 +21,8 @@ export async function runHistory(flags) {
   }
 
   if (flags.json) {
-    outputJson(session);
+    const { authorizationContext: _authorizationContext, ...publicSession } = session;
+    outputJson(publicSession);
     return;
   }
 

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -1,11 +1,15 @@
-import { resolveApiKey } from "../client/auth.mjs";
+import {
+  createAuthorizationContextCredentialProvider,
+  resolveApiKey,
+  resolveAuthorizationContextId,
+} from "../client/auth.mjs";
 import { callTool, discoverTools, inspectToolsByIds, resolveApiBaseUrl } from "../client/api.mjs";
 import { nodeCheck } from "../client/preflight.mjs";
 import { resolve } from "../config/resolve.mjs";
 import { CliError } from "../errors/handler.mjs";
 import { bold, cyan, dim, green, red, yellow } from "../output/colors.mjs";
 import { outputJson } from "../output/json.mjs";
-import { readSession, writeSession } from "../session/session.mjs";
+import { readSessionForContext, writeSession } from "../session/session.mjs";
 import { resolveParams } from "../utils/params.mjs";
 
 const DEFAULT_QUERY = "weather forecast API";
@@ -34,6 +38,8 @@ export async function runInit(queryArg, flags) {
     baseUrlFlag: flags.baseUrl,
     preferOAuth: apiKey === undefined,
   });
+  const authorizationContext = await resolveAuthorizationContextId({ apiKey });
+  const credentialProvider = createAuthorizationContextCredentialProvider({ apiKey, authorizationContext });
   record(steps, "auth", "ok", apiKey === undefined ? "OAuth session resolved" : "API key resolved", {
     source: apiKey === undefined ? "oauth session" : resolve("api_key", flags.apiKey || flags.token).source,
     ...(apiKey === undefined ? { type: "oauth" } : { type: "api_key", key: maskKey(apiKey) }),
@@ -51,7 +57,14 @@ export async function runInit(queryArg, flags) {
   const flagParameters = flags.params ? resolveParams(flags.params) : null;
 
   if (flags.resume) {
-    const session = readSession();
+    const resolvedSession = readSessionForContext({ baseUrl, authorizationContext });
+    if (resolvedSession.status === "context_mismatch") {
+      throw new CliError(
+        "SESSION_EXPIRED",
+        "Stored init discovery belongs to another API endpoint or authorization context. Run 'qveris init' without --resume.",
+      );
+    }
+    const session = resolvedSession.session;
     if (!session?.discoveryId || !Array.isArray(session.results) || session.results.length === 0) {
       throw new CliError(
         "SESSION_EXPIRED",
@@ -72,7 +85,7 @@ export async function runInit(queryArg, flags) {
     });
   } else {
     record(steps, "discover", "running", `Discovering capabilities for "${query}"`, { query, limit });
-    discovery = await discoverTools({ apiKey, baseUrl, query, limit, timeoutMs });
+    discovery = await discoverTools({ apiKey, credentialProvider, baseUrl, query, limit, timeoutMs });
     const results = discovery.results ?? [];
     if (results.length === 0) {
       throw new CliError(
@@ -86,6 +99,7 @@ export async function runInit(queryArg, flags) {
       discoveryId,
       query,
       baseUrl,
+      authorizationContext,
       results: results.map((t, i) => ({
         index: i + 1,
         tool_id: t.tool_id,
@@ -114,6 +128,7 @@ export async function runInit(queryArg, flags) {
   );
   const inspected = await inspectToolsByIds({
     apiKey,
+    credentialProvider,
     baseUrl,
     toolIds: candidateToolIds,
     discoveryId,
@@ -163,6 +178,7 @@ export async function runInit(queryArg, flags) {
 
   const callResult = await callTool({
     apiKey,
+    credentialProvider,
     baseUrl,
     toolId: selected.tool_id,
     discoveryId,

--- a/packages/cli/src/commands/inspect.mjs
+++ b/packages/cli/src/commands/inspect.mjs
@@ -1,33 +1,59 @@
-import { resolveApiKey } from "../client/auth.mjs";
-import { inspectToolsByIds } from "../client/api.mjs";
-import { resolveToolId, getSessionDiscoveryId } from "../session/session.mjs";
+import {
+  createAuthorizationContextCredentialProvider,
+  resolveApiKey,
+  resolveAuthorizationContextId,
+} from "../client/auth.mjs";
+import { inspectToolsByIds, resolveApiBaseUrl } from "../client/api.mjs";
+import { resolveToolId, getSessionDiscoveryId, readSessionForContext } from "../session/session.mjs";
 import { formatInspectResult } from "../output/formatter.mjs";
 import { outputJson } from "../output/json.mjs";
 import { createSpinner } from "../output/spinner.mjs";
+import { CliError } from "../errors/handler.mjs";
 
 export async function runInspect(idsOrIndexes, flags) {
   const apiKey = resolveApiKey(flags.apiKey);
   const timeoutMs = (parseInt(flags.timeout, 10) || 30) * 1000;
+  const { baseUrl } = resolveApiBaseUrl({ baseUrlFlag: flags.baseUrl, preferOAuth: apiKey === undefined });
+  const numericIndex = idsOrIndexes.some((value) => /^\d+$/.test(value));
+  const usesSessionShortcut = numericIndex || !flags.discoveryId;
+  let session = null;
+  let credentialProvider;
+  if (usesSessionShortcut) {
+    const authorizationContext = await resolveAuthorizationContextId({ apiKey });
+    credentialProvider = createAuthorizationContextCredentialProvider({ apiKey, authorizationContext });
+    const resolvedSession = readSessionForContext({ baseUrl, authorizationContext });
+    if (resolvedSession.status === "context_mismatch") {
+      throw new CliError(
+        "SESSION_EXPIRED",
+        "Stored discovery belongs to another API endpoint or authorization context. Run 'qveris discover' again.",
+      );
+    }
+    session = resolvedSession.session;
+  }
 
   const toolIds = [];
   let discoveryId = flags.discoveryId || null;
 
   for (const raw of idsOrIndexes) {
-    const resolved = resolveToolId(raw);
+    const resolved = resolveToolId(raw, { session });
+    if (/^\d+$/.test(raw) && !resolved.fromSession) {
+      throw new CliError("SESSION_EXPIRED", "No matching discovery index. Run 'qveris discover' first.");
+    }
     toolIds.push(resolved.toolId);
     if (resolved.fromSession && resolved.discoveryId && !discoveryId) {
       discoveryId = resolved.discoveryId;
     }
   }
 
-  if (!discoveryId) discoveryId = getSessionDiscoveryId();
+  if (!discoveryId) discoveryId = getSessionDiscoveryId({ session });
 
   const spinner = flags.json ? { stop() {} } : createSpinner("Inspecting tools...");
 
   try {
     const result = await inspectToolsByIds({
       apiKey,
-      baseUrl: flags.baseUrl,
+      credentialProvider,
+      baseUrl,
       toolIds,
       discoveryId,
       timeoutMs,

--- a/packages/cli/src/commands/interactive.mjs
+++ b/packages/cli/src/commands/interactive.mjs
@@ -1,5 +1,9 @@
 import { createInterface } from "node:readline";
-import { resolveApiKey } from "../client/auth.mjs";
+import {
+  createAuthorizationContextCredentialProvider,
+  resolveApiKey,
+  resolveAuthorizationContextId,
+} from "../client/auth.mjs";
 import { discoverTools, inspectToolsByIds, callTool, resolveApiBaseUrl } from "../client/api.mjs";
 import { resolveParams } from "../utils/params.mjs";
 import { formatDiscoverResult, formatInspectResult, formatCallResult } from "../output/formatter.mjs";
@@ -17,6 +21,8 @@ export async function runInteractive(flags) {
     baseUrlFlag: flags.baseUrl,
     preferOAuth: apiKey === undefined,
   });
+  const authorizationContext = await resolveAuthorizationContextId({ apiKey });
+  const credentialProvider = createAuthorizationContextCredentialProvider({ apiKey, authorizationContext });
   const limit = parseInt(flags.limit, 10) || 5;
   const discoverTimeout = (parseInt(flags.timeout, 10) || 30) * 1000;
   const callTimeout = (parseInt(flags.timeout, 10) || 60) * 1000;
@@ -67,6 +73,7 @@ export async function runInteractive(flags) {
           const sp = createSpinner("Discovering...");
           const result = await discoverTools({
             apiKey,
+            credentialProvider,
             baseUrl: resolvedBaseUrl,
             query,
             limit,
@@ -85,6 +92,7 @@ export async function runInteractive(flags) {
             discoveryId: result.search_id,
             query,
             baseUrl: resolvedBaseUrl,
+            authorizationContext,
             results: state.results,
           });
           console.log(formatDiscoverResult(result));
@@ -99,6 +107,7 @@ export async function runInteractive(flags) {
           const sp2 = createSpinner("Inspecting...");
           const result = await inspectToolsByIds({
             apiKey,
+            credentialProvider,
             baseUrl: resolvedBaseUrl,
             toolIds: [toolId],
             discoveryId: state.discoveryId,
@@ -123,6 +132,7 @@ export async function runInteractive(flags) {
           const sp3 = createSpinner("Calling...");
           const result = await callTool({
             apiKey,
+            credentialProvider,
             baseUrl: resolvedBaseUrl,
             toolId,
             discoveryId: state.discoveryId,

--- a/packages/cli/src/commands/probe.mjs
+++ b/packages/cli/src/commands/probe.mjs
@@ -1,6 +1,10 @@
-import { resolveApiKey } from "../client/auth.mjs";
-import { probeTool } from "../client/api.mjs";
-import { resolveToolId } from "../session/session.mjs";
+import {
+  createAuthorizationContextCredentialProvider,
+  resolveApiKey,
+  resolveAuthorizationContextId,
+} from "../client/auth.mjs";
+import { probeTool, resolveApiBaseUrl } from "../client/api.mjs";
+import { readSessionForContext, resolveToolId } from "../session/session.mjs";
 import { resolveParams } from "../utils/params.mjs";
 import { outputJson } from "../output/json.mjs";
 import { createSpinner } from "../output/spinner.mjs";
@@ -26,7 +30,27 @@ export function resolveProbeChecks(value) {
 export async function runProbe(idOrIndex, flags) {
   const apiKey = resolveApiKey(flags.apiKey);
   const timeoutMs = (parseInt(flags.timeout, 10) || 30) * 1000;
-  const toolId = resolveToolId(idOrIndex).toolId;
+  const { baseUrl } = resolveApiBaseUrl({ baseUrlFlag: flags.baseUrl, preferOAuth: apiKey === undefined });
+  const numericIndex = /^\d+$/.test(idOrIndex);
+  let session = null;
+  let credentialProvider;
+  if (numericIndex) {
+    const authorizationContext = await resolveAuthorizationContextId({ apiKey });
+    credentialProvider = createAuthorizationContextCredentialProvider({ apiKey, authorizationContext });
+    const resolvedSession = readSessionForContext({ baseUrl, authorizationContext });
+    if (resolvedSession.status === "context_mismatch") {
+      throw new CliError(
+        "SESSION_EXPIRED",
+        "Stored discovery belongs to another API endpoint or authorization context. Run 'qveris discover' again.",
+      );
+    }
+    session = resolvedSession.session;
+  }
+  const resolved = resolveToolId(idOrIndex, { session });
+  if (numericIndex && !resolved.fromSession) {
+    throw new CliError("SESSION_EXPIRED", "No matching discovery index. Run 'qveris discover' first.");
+  }
+  const toolId = resolved.toolId;
   const parameters = resolveParams(flags.params || "{}");
   const checks = resolveProbeChecks(flags.checks);
   const liveBudget = flags.liveBudget ?? "none";
@@ -38,7 +62,8 @@ export async function runProbe(idOrIndex, flags) {
   try {
     const result = await probeTool({
       apiKey,
-      baseUrl: flags.baseUrl,
+      credentialProvider,
+      baseUrl,
       toolId,
       parameters,
       checks,

--- a/packages/cli/src/session/session.mjs
+++ b/packages/cli/src/session/session.mjs
@@ -28,10 +28,19 @@ export function writeSession(data) {
   writeFileSync(sessionPath(), JSON.stringify({ ...data, timestamp: Date.now() }, null, 2) + "\n", { mode: 0o600 });
 }
 
-export function resolveToolId(idOrIndex) {
+export function readSessionForContext({ baseUrl, authorizationContext }) {
+  const session = readSession();
+  if (!session) return { session: null, status: "missing" };
+  if (!session.discoveryId && !Array.isArray(session.results)) return { session: null, status: "missing" };
+  if (session.baseUrl !== baseUrl || session.authorizationContext !== authorizationContext) {
+    return { session: null, status: "context_mismatch" };
+  }
+  return { session, status: "match" };
+}
+
+export function resolveToolId(idOrIndex, { session = readSession() } = {}) {
   if (!/^\d+$/.test(idOrIndex)) return { toolId: idOrIndex, fromSession: false };
 
-  const session = readSession();
   if (!session || !session.results) return { toolId: idOrIndex, fromSession: false };
 
   const index = parseInt(idOrIndex, 10) - 1;
@@ -47,7 +56,6 @@ export function resolveToolId(idOrIndex) {
   };
 }
 
-export function getSessionDiscoveryId() {
-  const session = readSession();
+export function getSessionDiscoveryId({ session = readSession() } = {}) {
   return session?.discoveryId || null;
 }

--- a/packages/cli/test/commands.test.mjs
+++ b/packages/cli/test/commands.test.mjs
@@ -14,6 +14,7 @@ import { runHistory } from "../src/commands/history.mjs";
 import { runInspect } from "../src/commands/inspect.mjs";
 import { runLedger } from "../src/commands/ledger.mjs";
 import { runLogin, runLogout, runWhoami } from "../src/commands/login.mjs";
+import { runProbe } from "../src/commands/probe.mjs";
 import { runUsage } from "../src/commands/usage.mjs";
 import { getConfigPath, setConfigValue } from "../src/config/store.mjs";
 import { main } from "../src/main.mjs";
@@ -146,8 +147,11 @@ test("discover, inspect, call, and history commands cover session-based workflow
 
         const discover = await captureOutput(() => runDiscover("weather forecast", { ...flags, limit: "2" }));
         assert.equal(jsonFromStdout(discover.stdout).search_id, "search-1");
-        const session = JSON.parse(readFileSync(join(configDir, "qveris", ".session.json"), "utf-8"));
+        const serializedSession = readFileSync(join(configDir, "qveris", ".session.json"), "utf-8");
+        const session = JSON.parse(serializedSession);
         assert.equal(session.results[0].tool_id, "weather.tool.v1");
+        assert.match(session.authorizationContext, /^v1:api-key:[a-f0-9]{64}$/);
+        assert.equal(serializedSession.includes("sk-test"), false);
 
         const inspect = await captureOutput(() => runInspect(["1"], flags));
         assert.equal(jsonFromStdout(inspect.stdout).results[0].tool_id, "weather.tool.v1");
@@ -164,6 +168,7 @@ test("discover, inspect, call, and history commands cover session-based workflow
 
         const history = await captureOutput(() => runHistory({ json: true }));
         assert.equal(jsonFromStdout(history.stdout).discoveryId, "search-1");
+        assert.equal(jsonFromStdout(history.stdout).authorizationContext, undefined);
       },
     );
   });
@@ -195,6 +200,88 @@ test("call dry-run validates resolved tool, params, and max size without network
           parameters: { symbol: "AAPL" },
           max_response_size: 2048,
         });
+      },
+    );
+  });
+});
+
+test("session shortcuts fail closed across endpoints and authorization contexts", async () => {
+  await withTempConfig(async () => {
+    let networkCalls = 0;
+    await withMockFetch(
+      (request) => {
+        networkCalls += 1;
+        if (request.url.pathname.endsWith("/search")) {
+          return response({
+            search_id: "search-a",
+            results: [{ tool_id: "weather.tool.v1", name: "Weather" }],
+          });
+        }
+        throw new Error(`unexpected network call ${request.url}`);
+      },
+      async () => {
+        await captureOutput(() =>
+          runDiscover("weather", {
+            apiKey: "sk-account-a",
+            baseUrl: "https://a.test/api/v1",
+            json: true,
+          }),
+        );
+        assert.equal(networkCalls, 1);
+
+        const mismatchedCommands = [
+          () =>
+            runCall("1", {
+              apiKey: "sk-account-a",
+              baseUrl: "https://b.test/api/v1",
+              discoveryId: "explicit-search",
+              params: "{}",
+              dryRun: true,
+              json: true,
+            }),
+          () =>
+            runCall("weather.tool.v1", {
+              apiKey: "sk-account-b",
+              baseUrl: "https://a.test/api/v1",
+              params: "{}",
+              dryRun: true,
+              json: true,
+            }),
+          () =>
+            runInspect(["1"], {
+              apiKey: "sk-account-b",
+              baseUrl: "https://a.test/api/v1",
+              discoveryId: "explicit-search",
+              json: true,
+            }),
+          () =>
+            runProbe("1", {
+              apiKey: "sk-account-a",
+              baseUrl: "https://b.test/api/v1",
+              json: true,
+            }),
+        ];
+        for (const command of mismatchedCommands) {
+          await assert.rejects(
+            command,
+            (error) =>
+              error?.code === "SESSION_EXPIRED" && /another API endpoint or authorization context/.test(error.message),
+          );
+        }
+        assert.equal(networkCalls, 1);
+
+        const explicit = await captureOutput(() =>
+          runCall("weather.tool.v1", {
+            apiKey: "sk-account-b",
+            baseUrl: "https://b.test/api/v1",
+            discoveryId: "search-b",
+            params: "{}",
+            dryRun: true,
+            json: true,
+          }),
+        );
+        assert.equal(jsonFromStdout(explicit.stdout).discovery_id, "search-b");
+        assert.equal(networkCalls, 1);
       },
     );
   });

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -11,7 +11,9 @@ import {
   runInit,
   shellSingleQuote,
 } from "../src/commands/init.mjs";
+import { authorizationContextForApiKey } from "../src/auth/context.mjs";
 import { CliError } from "../src/errors/handler.mjs";
+import { writeSession } from "../src/session/session.mjs";
 
 function withTempConfig(fn) {
   const dir = mkdtempSync(join(tmpdir(), "qveris-cli-init-"));
@@ -111,6 +113,29 @@ test("init helpers respect max size and escape single quotes in shell hints", ()
     ).tool_id,
     "weather",
   );
+});
+
+test("init resume rejects a session from another endpoint or authorization context", async () => {
+  await withTempConfig(async () => {
+    writeSession({
+      discoveryId: "search-a",
+      query: "weather",
+      baseUrl: "https://a.test/api/v1",
+      authorizationContext: authorizationContextForApiKey("sk-account-a"),
+      results: [{ tool_id: "weather.tool.v1", name: "Weather" }],
+    });
+
+    for (const flags of [
+      { apiKey: "sk-account-a", baseUrl: "https://b.test/api/v1" },
+      { apiKey: "sk-account-b", baseUrl: "https://a.test/api/v1" },
+    ]) {
+      await assert.rejects(
+        () => runInit(null, { ...flags, resume: true, json: true, dryRun: true }),
+        (error) =>
+          error?.code === "SESSION_EXPIRED" && /another API endpoint or authorization context/.test(error.message),
+      );
+    }
+  });
 });
 
 test("init dry run records the provided max response size", async () => {

--- a/packages/cli/test/oauth.test.mjs
+++ b/packages/cli/test/oauth.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdirSync, statSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { authorizationContextForOAuth } from "../src/auth/context.mjs";
 import {
   DEVICE_CODE_GRANT,
   createStoredOAuthCredentialProvider,
@@ -23,6 +24,7 @@ import {
 } from "../src/auth/storage.mjs";
 import { runAuth } from "../src/commands/auth.mjs";
 import { runConfig } from "../src/commands/config.mjs";
+import { createAuthorizationContextCredentialProvider } from "../src/client/auth.mjs";
 import { deleteConfigValue, getConfigPath, getConfigValue, setConfigValue } from "../src/config/store.mjs";
 
 function response(payload, status = 200, headers = {}) {
@@ -490,26 +492,74 @@ test("Refresh uses the public client and rotates the refresh token", async () =>
   process.env.QVERIS_DISABLE_KEYRING = "1";
   try {
     let form;
-    const result = await refreshOAuthSession(
-      { ...discovery, api_base_url: "https://unit.test/api/v1", resource: "https://unit.test/tools" },
-      { access_token: "old-access", refresh_token: "old-refresh" },
-      async (_url, options) => {
-        form = Object.fromEntries(options.body.entries());
-        return response({
-          access_token: "new-access",
-          refresh_token: "new-refresh",
-          token_type: "Bearer",
-          expires_in: 3600,
-        });
-      },
-    );
+    const initialMetadata = {
+      ...discovery,
+      api_base_url: "https://unit.test/api/v1",
+      resource: "https://unit.test/tools",
+    };
+    const initialSecret = { access_token: "old-access", refresh_token: "old-refresh" };
+    const contextBeforeRefresh = authorizationContextForOAuth(initialMetadata, initialSecret);
+    const result = await refreshOAuthSession(initialMetadata, initialSecret, async (_url, options) => {
+      form = Object.fromEntries(options.body.entries());
+      return response({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    });
     assert.deepEqual(form, {
       grant_type: "refresh_token",
       client_id: "qveris-cli",
       refresh_token: "old-refresh",
     });
     assert.equal(result.secret.refresh_token, "new-refresh");
+    assert.equal(authorizationContextForOAuth(result.metadata, result.secret), contextBeforeRefresh);
+    assert.ok(result.metadata.authorization_context_id);
     assert.equal(getOAuthSessionMetadata().storage, "session");
+  } finally {
+    await deleteOAuthSession();
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    if (previousKeyring === undefined) delete process.env.QVERIS_DISABLE_KEYRING;
+    else process.env.QVERIS_DISABLE_KEYRING = previousKeyring;
+  }
+});
+
+test("A context-bound provider rejects an OAuth account replaced before request dispatch", async () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const previousKeyring = process.env.QVERIS_DISABLE_KEYRING;
+  process.env.XDG_CONFIG_HOME = `/tmp/qveris-oauth-context-${process.pid}-${Date.now()}`;
+  process.env.QVERIS_DISABLE_KEYRING = "1";
+  try {
+    const baseMetadata = {
+      ...discovery,
+      storage: "config",
+      api_base_url: "https://unit.test/api/v1",
+      resource: "https://unit.test/tools",
+      expires_at: Date.now() + 3600000,
+    };
+    const firstSecret = { access_token: "first-access", refresh_token: "first-refresh" };
+    await saveOAuthSession({ ...baseMetadata, authorization_context_id: "login-a" }, firstSecret, {
+      allowUnencryptedStorage: true,
+    });
+    const provider = createAuthorizationContextCredentialProvider({
+      apiKey: undefined,
+      authorizationContext: authorizationContextForOAuth(
+        { ...baseMetadata, authorization_context_id: "login-a" },
+        firstSecret,
+      ),
+    });
+
+    await saveOAuthSession(
+      { ...baseMetadata, authorization_context_id: "login-b" },
+      { access_token: "second-access", refresh_token: "second-refresh" },
+      { allowUnencryptedStorage: true },
+    );
+    await assert.rejects(
+      provider.getCredential({ resource: "https://unit.test/api/v1", scopes: [] }),
+      (error) => error?.code === "AUTH_OAUTH_FAILED" && /context changed/.test(error.message),
+    );
   } finally {
     await deleteOAuthSession();
     if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
@@ -1218,6 +1268,7 @@ test("A successful login revokes the previous OAuth session before replacing it"
       access_token: "new-access",
       refresh_token: "new-refresh",
     });
+    assert.ok(getOAuthSessionMetadata().authorization_context_id);
   } finally {
     console.log = previousLog;
     console.error = previousError;

--- a/packages/cli/test/session-context.test.mjs
+++ b/packages/cli/test/session-context.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  authorizationContextForApiKey,
+  authorizationContextForOAuth,
+  deriveLegacyOAuthAuthorizationContextId,
+} from "../src/auth/context.mjs";
+import { readSessionForContext, writeSession } from "../src/session/session.mjs";
+
+test("authorization context fingerprints are stable without exposing credentials", () => {
+  const first = authorizationContextForApiKey("sk-account-a-secret");
+  assert.equal(first, authorizationContextForApiKey("sk-account-a-secret"));
+  assert.notEqual(first, authorizationContextForApiKey("sk-account-b-secret"));
+  assert.equal(first.includes("sk-account-a-secret"), false);
+
+  const metadata = { issuer: "https://unit.test", authorization_context_id: "login-a" };
+  assert.equal(
+    authorizationContextForOAuth(metadata, { refresh_token: "old-refresh" }),
+    authorizationContextForOAuth(metadata, { refresh_token: "rotated-refresh" }),
+  );
+  assert.notEqual(
+    authorizationContextForOAuth(metadata, { refresh_token: "old-refresh" }),
+    authorizationContextForOAuth(
+      { ...metadata, authorization_context_id: "login-b" },
+      { refresh_token: "old-refresh" },
+    ),
+  );
+});
+
+test("legacy OAuth context can be pinned before refresh-token rotation", () => {
+  const metadata = { issuer: "https://unit.test" };
+  const secret = { refresh_token: "old-refresh" };
+  const legacyId = deriveLegacyOAuthAuthorizationContextId(metadata, secret);
+  const before = authorizationContextForOAuth(metadata, secret);
+  const after = authorizationContextForOAuth(
+    { ...metadata, authorization_context_id: legacyId },
+    { refresh_token: "new-refresh" },
+  );
+  assert.equal(after, before);
+  assert.equal(before.includes("old-refresh"), false);
+
+  const invalidStored = authorizationContextForOAuth(
+    { ...metadata, authorization_context_id: "invalid context with spaces" },
+    secret,
+  );
+  assert.equal(invalidStored, before);
+});
+
+test("stored discovery sessions require exact endpoint and authorization context", () => {
+  const previous = process.env.XDG_CONFIG_HOME;
+  const configHome = mkdtempSync(join(tmpdir(), "qveris-cli-session-context-"));
+  process.env.XDG_CONFIG_HOME = configHome;
+  try {
+    writeSession({
+      discoveryId: "search-a",
+      baseUrl: "https://a.test/api/v1",
+      authorizationContext: "v1:api-key:account-a",
+      results: [{ tool_id: "weather.a" }],
+    });
+
+    assert.equal(
+      readSessionForContext({
+        baseUrl: "https://a.test/api/v1",
+        authorizationContext: "v1:api-key:account-a",
+      }).status,
+      "match",
+    );
+    assert.equal(
+      readSessionForContext({
+        baseUrl: "https://b.test/api/v1",
+        authorizationContext: "v1:api-key:account-a",
+      }).status,
+      "context_mismatch",
+    );
+    assert.equal(
+      readSessionForContext({
+        baseUrl: "https://a.test/api/v1",
+        authorizationContext: "v1:api-key:account-b",
+      }).status,
+      "context_mismatch",
+    );
+
+    writeSession({});
+    assert.equal(
+      readSessionForContext({
+        baseUrl: "https://a.test/api/v1",
+        authorizationContext: "v1:api-key:account-a",
+      }).status,
+      "missing",
+    );
+  } finally {
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    rmSync(configHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- bind persisted Discover indexes and implicit discovery IDs to the exact normalized API endpoint and authorization context that created them
- fail closed before `call`, `inspect`, `probe`, or `init --resume` can consume session provenance from another endpoint/account
- keep explicit tool ID plus explicit discovery ID independent from persisted shortcuts
- add a stable OAuth login-context identifier that survives token rotation, with a compatibility migration for existing OAuth sessions
- bind OAuth credential acquisition to the validated context so a concurrent account replacement cannot race request dispatch
- keep authorization fingerprints out of `history --json` and never persist raw API keys or OAuth tokens in the discovery session
- document the boundary in global and deployment-specific CLI guides and the package changelog

## Fault matrix

- API key A → API key B
- endpoint A → endpoint B
- numeric index with an explicit but cross-context discovery ID
- explicit tool ID with an implicit cross-context discovery ID
- `inspect`, `probe`, and `init --resume` session consumers
- OAuth account replacement before request dispatch
- OAuth refresh-token rotation within one login context
- existing OAuth metadata without a context identifier
- cleared, missing, and expired sessions

## Verification

- CLI: 162 tests
- CLI lint and formatting
- package dry-run contents
- locale consistency
- public-copy checks and tests
- release/client contract tests
- public region-boundary scans and diff checks

Implements the CLI session-isolation change set defined by #360.
