### PR TITLE
Prepare OpenClaw plugin 2026.9.10

### DIFF
--- a/.github/workflows/qveris-plugin-clawhub-publish.yml
+++ b/.github/workflows/qveris-plugin-clawhub-publish.yml
@@ -7,7 +7,7 @@ on:
         description: Existing qveris-plugin-v* tag to publish
         required: true
         type: string
-        default: qveris-plugin-v2026.9.9
+        default: qveris-plugin-v2026.9.10
       dry_run:
         description: Validate and preview without publishing
         required: true

--- a/.github/workflows/qveris-plugin-publish.yml
+++ b/.github/workflows/qveris-plugin-publish.yml
@@ -115,9 +115,9 @@ jobs:
 
             ## Highlights
 
-            - Aligns ClawHub Trusted Publishing source attribution with the authorized candidate commit SHA.
-            - Keeps the immutable release tag for artifact checkout while binding both trusted source fields to the verified commit.
-            - Adds regression coverage that prevents tag refs from being submitted as the authorized source ref.
+            - Preserves Provider-comparison prerequisites and requires fresh Calls for current, latest, or date-sensitive requests.
+            - Hardens exact-query capability reuse with endpoint and credential-context isolation, explicit live-discovery provenance, and bounded refresh and expiry behavior.
+            - Prevents stale or ambiguous paid Call outcomes from being replayed while retaining the shortest safe direct route from a sufficient Discover contract.
             - Preserves exact Registry metadata, source-commit, integrity, runtime-manifest, and concrete-tool verification before creating this release.
 
             See [README](packages/openclaw-qveris-plugin/README.md) for usage.

--- a/packages/openclaw-qveris-plugin/CHANGELOG.md
+++ b/packages/openclaw-qveris-plugin/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## [Unreleased]
 
+## [2026.9.10] - 2026-09-09
+
+### Changed
+
+- Preserve Provider-comparison prerequisites and require a fresh Call for current, latest, or date-sensitive requests while retaining the shortest safe direct path when Discover returns a sufficient contract. ([#362])
+
+### Fixed
+
+- Harden exact-query capability reuse so cache hits preserve live discovery provenance separately from reusable contracts, isolate endpoint and credential-context variants, honor refresh and expiry semantics, and never replay stale or ambiguous paid Calls. ([#363])
+
 ## [2026.9.9] - 2026-09-08
 
 ### Fixed
@@ -76,7 +86,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 - First published build with compiled `dist/` output. ([#90])
 
-[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.9...HEAD
+[Unreleased]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.10...HEAD
+[2026.9.10]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.9...qveris-plugin-v2026.9.10
 [2026.9.9]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.8...qveris-plugin-v2026.9.9
 [2026.9.8]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.9.7...qveris-plugin-v2026.9.8
 [2026.9.7]: https://github.com/QVerisAI/qveris-agent-toolkit/compare/qveris-plugin-v2026.7.30...qveris-plugin-v2026.9.7
@@ -97,3 +108,5 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 [#352]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/352
 [#354]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/354
 [#356]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/356
+[#362]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/362
+[#363]: https://github.com/QVerisAI/qveris-agent-toolkit/pull/363

--- a/packages/openclaw-qveris-plugin/openclaw.plugin.json
+++ b/packages/openclaw-qveris-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "qveris",
   "name": "QVeris Plugin",
   "description": "QVeris capability discovery, tool inspection, and tool calling",
-  "version": "2026.9.9",
+  "version": "2026.9.10",
   "setup": {
     "providers": [
       {

--- a/packages/openclaw-qveris-plugin/package-lock.json
+++ b/packages/openclaw-qveris-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.9.9",
+  "version": "2026.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/qveris",
-      "version": "2026.9.9",
+      "version": "2026.9.10",
       "dependencies": {
         "@sinclair/typebox": "0.34.52"
       },

--- a/packages/openclaw-qveris-plugin/package.json
+++ b/packages/openclaw-qveris-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qverisai/qveris",
-  "version": "2026.9.9",
+  "version": "2026.9.10",
   "description": "OpenClaw QVeris plugin — capability discovery, tool inspection, and tool calling",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Prepare `@qverisai/qveris@2026.9.10` for release.

This release carries the Provider-comparison and fresh-call routing guidance from #362 and the exact-query capability-reuse hardening from #363. It aligns the package, lockfile, plugin manifest, changelog, and ClawHub workflow default with the new date-based version.

This PR only prepares release metadata. It does not create a tag or publish to npm or ClawHub.

## Validation

- Confirmed npm version `2026.9.10` is unoccupied
- Confirmed tag `qveris-plugin-v2026.9.10` is unoccupied
- 130 plugin tests passed
- 31 Registry release-contract tests passed
- Typecheck and lint passed
- Packed contents check passed (19 files)
- Packed-tarball install and OpenClaw runtime contract passed against host `2026.9.2`
- Production dependency audit found 0 vulnerabilities
- Diff check passed

## Follow-up

After merge, create the annotated release tag and let the npm workflow verify the exact Registry artifact and installed runtime before publishing the corresponding ClawHub release.
