### PR TITLE
Prepare MCP 0.14.5 release

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qveris",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Discover, inspect, validate, and call real-world API capabilities from Cursor through the hosted QVeris MCP, with usage and credit auditing.",
   "author": {
     "name": "QVeris AI",

--- a/agent/GUIDELINES.md
+++ b/agent/GUIDELINES.md
@@ -352,6 +352,6 @@ Run `qveris doctor` to check setup: Node.js version, API key validity, endpoint 
 | Probe | `{"parameters": {...}, "checks": ["schema", "quote"], "live_budget": "none"}` |
 | Call | `{"search_id": "...", "parameters": {...}, "model": "router-model-v1", "max_response_size": 20480}` |
 
-> **MCP backward compatibility:** Old tool names `search_tools`, `get_tools_by_ids`, `execute_tool` are still supported as deprecated aliases in MCP server v0.14.4. Use the canonical names (`discover`, `inspect`, `probe`, `call`, `usage_history`, `credits_ledger`) going forward.
+> **MCP backward compatibility:** Old tool names `search_tools`, `get_tools_by_ids`, `execute_tool` are still supported as deprecated aliases in MCP server v0.14.5. Use the canonical names (`discover`, `inspect`, `probe`, `call`, `usage_history`, `credits_ledger`) going forward.
 
 Full API documentation: https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/docs/en-US/rest-api.md

--- a/agent/SETUP.md
+++ b/agent/SETUP.md
@@ -99,7 +99,7 @@ Reconnect the client and confirm `discover`, `inspect`, `probe`, and `call` are 
 Detect which MCP-capable desktop client you are currently running in. QVeris supports Claude Code, ChatGPT (Codex), OpenCode, Cursor, Cherry Studio, TRAE, GitHub Copilot, Cline, Roo Code, Continue, Kiro, Junie, Augment, Zed, Google Antigravity, Qoder, CodeBuddy, and WorkBuddy.
 
 **Configuration involves two steps for all environments:**
-1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.4) to your environment.
+1. **MCP Server Setup:** Connects the QVeris tool server (`@qverisai/mcp` v0.14.5) to your environment.
 2. **Skill Configuration:** Teaches the agent how to use the tools using the MCP/client skill definition file.
    - **Skill URL:** `https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/skills/qveris/SKILL.md`
 

--- a/agent/llms-full.txt
+++ b/agent/llms-full.txt
@@ -226,7 +226,7 @@ Full CLI docs: https://github.com/QVerisAI/qveris-agent-toolkit/blob/main/packag
 
 ### MCP Server Quick Start
 
-The MCP server (`@qverisai/mcp` v0.14.4) exposes six canonical agent-facing tools via the Model Context Protocol:
+The MCP server (`@qverisai/mcp` v0.14.5) exposes six canonical agent-facing tools via the Model Context Protocol:
 
 | MCP Tool | Description | Cost |
 |----------|-------------|------|
@@ -584,7 +584,7 @@ Model improvement is a tailwind for QVeris, not a headwind.
 ### SDK & Tools
 
 - **CLI (npm):** https://www.npmjs.com/package/@qverisai/cli — `npm install -g @qverisai/cli` (v0.11.3)
-- **MCP Server (npm):** https://www.npmjs.com/package/@qverisai/mcp — `npx @qverisai/mcp` (v0.14.4)
+- **MCP Server (npm):** https://www.npmjs.com/package/@qverisai/mcp — `npx @qverisai/mcp` (v0.14.5)
 - **JavaScript SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/js-sdk (v0.8.4)
 - **Python SDK:** https://github.com/QVerisAI/qveris-agent-toolkit/tree/main/packages/python-sdk (v0.7.3)
 - **Online Docs:** https://qveris.ai/docs
@@ -680,7 +680,7 @@ Generate a new UUID for each user session, and reuse it throughout that session.
 
 - **llms-full.txt Version:** 1.2.0
 - **CLI Version:** 0.11.3
-- **MCP Server Version:** 0.14.4
+- **MCP Server Version:** 0.14.5
 - **JavaScript SDK Version:** 0.8.4
 - **Python SDK Version:** 0.7.3
 - **Last Updated:** 2026-09-09

--- a/agent/llms.txt
+++ b/agent/llms.txt
@@ -39,7 +39,7 @@
 ## Access methods (recommended order)
 - Hosted MCP (recommended for remote-capable MCP clients): open /hosted-mcp on the QVeris site that issued the API key for the correct Streamable HTTP endpoint and Bearer authentication setup — no local process, Node.js, or package install
 - CLI v0.11.3 (recommended for shell-capable agents): npm install -g @qverisai/cli — no upfront catalog schemas, deterministic output, API discovery without preloading the catalog
-- MCP Server v0.14.4 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
+- MCP Server v0.14.5 (local stdio fallback): npx @qverisai/mcp — for stdio-only IDE integrations
 - JavaScript SDK v0.8.4: npm install @qverisai/sdk
 - Python SDK v0.7.3: pip install qveris
 - REST API: https://qveris.ai/api/v1

--- a/docs/cn/zh-CN/mcp-server.md
+++ b/docs/cn/zh-CN/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` 是面向 Cursor、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程 Agent 等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
-`@qverisai/mcp` v0.14.4 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
+`@qverisai/mcp` v0.14.5 是最新测试版本，通过六个规范 MCP 工具为 Agent 提供 QVeris 访问能力：
 
 - `discover` — 用自然语言发现能力
 - `inspect` — 获取工具详情（参数、成功率、示例）

--- a/docs/en-US/mcp-server.md
+++ b/docs/en-US/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` is the official QVeris MCP server for MCP-compatible clients such as ChatGPT (Codex), Cursor, Claude Desktop, Cherry Studio, GitHub Copilot, Cline, Roo Code, Kiro, Qoder, CodeBuddy, WorkBuddy, and other coding agents.
 
-`@qverisai/mcp` v0.14.4 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
+`@qverisai/mcp` v0.14.5 is the latest tested release. It gives agents access to QVeris through six canonical MCP tools:
 
 - `discover` — Find capabilities by natural language
 - `inspect` — Get detailed tool info (params, success rate, examples)

--- a/docs/zh-CN/mcp-server.md
+++ b/docs/zh-CN/mcp-server.md
@@ -4,7 +4,7 @@
 
 `@qverisai/mcp` 是面向 ChatGPT（Codex）、Cursor、Claude Desktop、Cherry Studio、GitHub Copilot、Cline、Roo Code、Kiro、Qoder、CodeBuddy、WorkBuddy 及其他编程智能体等 MCP 兼容客户端的官方 QVeris MCP 服务器。
 
-`@qverisai/mcp` v0.14.4 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
+`@qverisai/mcp` v0.14.5 是最新测试版本，通过六个规范 MCP 工具为智能体提供 QVeris 访问能力：
 
 - `discover` — 用自然语言发现能力
 - `inspect` — 获取工具详情（参数、成功率、示例）

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "qveris",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Discover, inspect, and call real-world API capabilities from Gemini CLI with QVeris.",
   "mcpServers": {
     "qveris": {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.14.5] - 2026-09-10
+
 ### Changed
 
 - Added an embedding option for hosted deployments to omit deprecated aliases from `tools/list` while retaining local compatibility and server-side resolution for stale callers. This keeps the canonical six-tool surface focused for new remote clients.

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qverisai/mcp",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qverisai/mcp",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.30.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qverisai/mcp",
   "mcpName": "io.github.QVerisAI/mcp",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "QVeris MCP server for agent tool discovery, inspection, and calling",
   "keywords": [
     "qveris",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.14.4",
+  "version": "0.14.5",
   "remotes": [
     {
       "type": "streamable-http",
@@ -30,7 +30,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@qverisai/mcp",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- prepare `@qverisai/mcp` 0.14.5 for the hosted deprecated-alias discovery control
- synchronize MCP registry, extension, package-lock, and public version references

## Validation
- `npm test` (219 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `node scripts/release-client-packages.mjs check`
- `node scripts/check-public-copy.mjs`